### PR TITLE
Feature/bk update id classes

### DIFF
--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -14,7 +14,6 @@ PulseCandidateFinder::PulseCandidateFinder(std::string detname, modules::options
   }
 
   if (fDefaultParameterValues[fChannel] == 0) {
-      std::cout << "Error: PulseCandidateFinder currently does not have a parameter value for " << fChannel << std::endl;
   }
 
   fParameterValue = opts->GetInt(detname, fDefaultParameterValues[fChannel]); // set the parameter value for this channel
@@ -34,10 +33,10 @@ void PulseCandidateFinder::FindPulseCandidates(TPulseIsland* pulse) {
   fPulseIsland = pulse;
 
   // We have a different algorithm for fast and slow pulses
-  if (fChannel == IDs::Fast) {
+  if (fChannel.isFast()) {
     FindCandidatePulses_Fast(fParameterValue);
   }
-  else if (fChannel == IDs::Slow) {
+  else if (fChannel.isSlow()) {
     FindCandidatePulses_Slow(fParameterValue);
   }
 }
@@ -158,11 +157,11 @@ void PulseCandidateFinder::FillParameterHistogram(TH1D* histogram) {
   std::string parameter_name = "Unknown";
 
   // We have a different algorithm for fast and slow pulses
-  if (theChannel == IDs::Fast) {
+  if (theChannel.isFast()) {
     parameter_name = "SampleDifference";
     FillSampleDifferencesHistogram(histogram);
   }
-  else if (theChannel == IDs::Slow) {
+  else if (theChannel.isSlow()) {
     parameter_name = "SampleHeight";
     FillSampleHeightsHistogram(histogram);
   }

--- a/analyzer/rootana/src/TDP_generators/MaxTimeDiffDPGenerator.cpp
+++ b/analyzer/rootana/src/TDP_generators/MaxTimeDiffDPGenerator.cpp
@@ -46,10 +46,10 @@ void MaxTimeDiffDPGenerator::ProcessPulses(const TSetupData* setup,const std::st
 	      double pulse_time = pulse->GetTime() * 1e-6; // convert to ms
 
 	      if (std::fabs(pulse_time - min_time) < time_difference) {
-		if ( pulse->GetSource()==IDs::Fast) {
+		if ( pulse->GetSource().isFast()) {
 		  if(Debug()) cout<<"Fast? " << pulse->GetSource().str() << std::endl;
 		  fast_pulse = pulse;
-		} else if ( pulse->GetSource()==IDs::Slow) {
+		} else if ( pulse->GetSource().isSlow()) {
 		  if(Debug()) cout<<"Slow? " << pulse->GetSource().str() << std::endl;
 		  slow_pulse = pulse;
 		}

--- a/analyzer/rootana/src/debug_tools.cpp
+++ b/analyzer/rootana/src/debug_tools.cpp
@@ -1,0 +1,23 @@
+#include "debug_tools.h"
+
+char DEBUG::time_log::str[]={0};
+char DEBUG::mem_log::str[] = {0};
+
+
+DEBUG::time_log::time_log(int c, int u) : cpu(c), user(u) {
+      snprintf(str, 64, "CPU/User(ms) = %4d / %4d",cpu, user);
+  }
+  
+DEBUG:: mem_log:: mem_log(int r, int v) : res(r), virt(v) {
+     snprintf(str, 64, "Res/Virt(MiB) = %4d / %4d",res, virt);
+    }
+
+const DEBUG::mem_log DEBUG::check_mem(){
+    static ProcInfo_t proc;
+    gSystem->GetProcInfo(&proc);
+    return mem_log(proc.fMemResident /1024., proc.fMemVirtual /1024.);
+  }
+
+DEBUG::time_log DEBUG::check_clock(){
+    return check_clock<0xBADBEEF>();
+  }

--- a/analyzer/rootana/src/debug_tools.h
+++ b/analyzer/rootana/src/debug_tools.h
@@ -8,22 +8,20 @@
 //This file contains a bunch of handy snippets for debugging, mostly
 //runtime checks like memory usage and stopwatches.
 
-#define DEBUG_PRINT std::cout << "@ " << __FILE__ << ":" << __LINE__ << std::endl;
+#define DEBUG_PREFIX std::cout << "@ " << __FILE__ << ":" << __LINE__
+#define DEBUG_PRINT DEBUG_PREFIX << std::endl;
+#define DEBUG_VALUE(value) DEBUG_PREFIX <<std::boolalpha<<" " #value "= |"<<value<<"|"<<std::endl;
 
 namespace DEBUG {
   //--------------------------------------------------------------------
   struct time_log {
-    time_log(int c, int u) : cpu(c), user(u) {
-      snprintf(str, 64, "CPU/User(ms) = %4d / %4d",cpu, user);
-    };
+    time_log(int c, int u) ;
     
     static char str[64];
     int cpu; 
     int user;
   };
 
-  char time_log::str[] = {0};
-  
   template<int I> 
     const time_log check_clock(){
     static TStopwatch watch;
@@ -33,29 +31,18 @@ namespace DEBUG {
     return log;
   }
 
-  time_log check_clock() {
-    return check_clock<0xBADBEEF>();
-  }
+  time_log check_clock();
 
   //--------------------------------------------------------------------
   struct mem_log {
-    mem_log(int r, int v) : res(r), virt(v) 
-    {
-     snprintf(str, 64, "Res/Virt(MiB) = %4d / %4d",res, virt);
-    };
+    mem_log(int r, int v) ;
 
     static char str[64];
     int res;
     int virt;
   };
 
-  char mem_log::str[] = {0};
-
-  const mem_log check_mem(){
-    static ProcInfo_t proc;
-    gSystem->GetProcInfo(&proc);
-    return mem_log(proc.fMemResident /1024., proc.fMemVirtual /1024.);
-  }
+  const mem_log check_mem();
 };
 
 #endif

--- a/analyzer/rootana/src/framework/IdChannel.cpp
+++ b/analyzer/rootana/src/framework/IdChannel.cpp
@@ -1,6 +1,8 @@
 #include "ModulesParser.h"
 #include "IdChannel.h"
+#include <iostream>
 #include <ostream>
+#include <algorithm>
 
 ClassImp(IDs::channel);
 
@@ -54,17 +56,29 @@ IDs::Detector_t IDs::channel::GetDetectorEnum(const std::string& det){
 
 IDs::channel& IDs::channel::operator=(const std::string& rhs){
    // Search for a fast slow string at the end of the end of the string
-   const char* fast_slow_strs[3]={"-*","-S","-F"};
-   size_t match=std::string::npos;
-   for(int i=0;i<3 && match==std::string::npos; i++){
-   	match=rhs.rfind(fast_slow_strs[i]);
+   static const int num_strs=3;
+   static const std::string fast_slow_strs[num_strs]={"-*","-S","-F"};
+   int i=0;
+   std::string::const_iterator match;
+   // Create a functino pointer to the iequals method
+   bool (*compare) (const char a, const char b);
+   compare = modules::parser::iequals;
+   for(i=0;i<num_strs ; i++){
+   	match=std::find_end(rhs.begin(),rhs.end(),
+            fast_slow_strs[i].begin(),fast_slow_strs[i].end(),
+            compare);
+    if (match!=rhs.end()) break;
    }
    // Have we found a map
-   if(match!=std::string::npos){
-	   fSlowFast=GetSlowFastEnum(rhs.substr(match));
-   }
+   size_t boundary=std::string::npos;
+   if(i<= num_strs){
+       boundary=match - rhs.begin();
+   std::string fs=rhs.substr(boundary);
+	   fSlowFast=GetSlowFastEnum(fs);
+   }else fSlowFast=kNotApplicable;
+
    // Use what's left to make the channel part
-   fDetector=GetDetectorEnum(rhs.substr(0,match));
+   fDetector=GetDetectorEnum(rhs.substr(0,boundary));
 
    return *this;
 }
@@ -82,13 +96,13 @@ std::string IDs::channel::GetSlowFastString(SlowFast_t sf){
 }
 
 IDs::SlowFast_t IDs::channel::GetSlowFastEnum(const std::string& type){
-	if(type=="-S"|| type=="slow") return kSlow;
-	else if(type=="-F"|| type=="fast") return kFast;
+	if(modules::parser::iequals(type,"-S") || type=="slow") return kSlow;
+	else if(modules::parser::iequals(type,"-F")|| type=="fast") return kFast;
 	else if(type=="*"|| type=="any") return kAnySlowFast;
 	return kNotApplicable;
 }
 
-ostream& operator<< (ostream& os , IDs::channel& id){
+std::ostream& operator<< (ostream& os ,const IDs::channel& id){
   os<<id.str();
   return os;
 }

--- a/analyzer/rootana/src/framework/IdChannel.cpp
+++ b/analyzer/rootana/src/framework/IdChannel.cpp
@@ -1,3 +1,4 @@
+#include "ModulesParser.h"
 #include "IdChannel.h"
 #include <ostream>
 
@@ -46,7 +47,7 @@ IDs::Detector_t IDs::channel::GetDetectorEnum(const std::string& det){
 		"SiR1_1", "SiR1_2", "SiR1_3", "SiR1_4", "SiR1_sum", "SiR2", 
 		"MuSc", "MuScA" };
      for (int i=0;i<IDs::num_detector_enums;i++){
-        if(det==names[i]) return (Detector_t)i;
+        if(modules::parser::iequals(det,names[i])) return (Detector_t)i;
      } 
      return kErrorDetector;
 }
@@ -74,7 +75,8 @@ std::string IDs::channel::GetSlowFastString(SlowFast_t sf){
    case kAnySlowFast   : output+="-*" ; break ; 
    case kSlow          : output+="-S" ; break ; 
    case kFast          : output+="-F" ; break ; 
-   case kNotApplicable : case kErrorSlowFast: break ; 
+   case kNotApplicable : break;
+   case kErrorSlowFast: output+="-Unknown" ;break ; 
  }
  return output;
 }

--- a/analyzer/rootana/src/framework/IdChannel.h
+++ b/analyzer/rootana/src/framework/IdChannel.h
@@ -81,10 +81,15 @@ public:
 	/// Sets kErrorDetector or kErrorSlowFast if there is a problem decoding the string
 	channel& operator=(const char* rhs){ return (*this=std::string(rhs));};
 
-	/// Returns true if this channel is the same as another or has it's fields set to 'any'.
+	/// Returns true if this channel is the same as another 
 	bool operator==(const channel& rhs)const;
-	/// Returns true if this channel is not the same as another and it's fields are not set to 'any'.
+	/// Returns true if this channel is not the same as another 
 	bool operator!=(const channel& rhs)const{return !(this->operator==(rhs));};
+    /// @brief Check if this channel is the same as another or has it's fields set to 'any'.
+    /// @details Return true if for both the Detector and SlowFast parts, either
+    /// the rhs is the same as this one, or if either this or rhs has a
+    /// corresponding Any flag set
+    bool matches(const channel& rhs)const;
 	
 	/// not intuitively meaningful but maybe useful for sorting
 	bool operator<(const channel& rhs)const;
@@ -133,6 +138,10 @@ public:
 };
 
 inline bool IDs::channel::operator==(const IDs::channel& rhs)const{
+    return (fDetector == rhs.fDetector) && (fSlowFast== rhs.fSlowFast);
+}
+
+inline bool IDs::channel::matches(const channel& rhs)const{
 	return (fDetector==kAnyDetector || rhs.fDetector==kAnyDetector || fDetector==rhs.fDetector) 
 	&& (fSlowFast==kAnySlowFast || rhs.fSlowFast==kAnySlowFast || fSlowFast==rhs.fSlowFast) ;
 }

--- a/analyzer/rootana/src/framework/IdChannel.h
+++ b/analyzer/rootana/src/framework/IdChannel.h
@@ -141,8 +141,8 @@ inline bool IDs::channel::operator==(const IDs::channel& rhs)const{
 }
 
 inline bool IDs::channel::matches(const channel& rhs)const{
-	return (fDetector==kAnyDetector || rhs.fDetector==kAnyDetector || fDetector==rhs.fDetector) 
-	&& (fSlowFast==kAnySlowFast || rhs.fSlowFast==kAnySlowFast || fSlowFast==rhs.fSlowFast) ;
+	return (isWildCardDetector() || rhs.isWildCardDetector() || fDetector==rhs.fDetector) 
+	&& (isWildCardSlowFast() || rhs.isWildCardSlowFast() || fSlowFast==rhs.fSlowFast) ;
 }
 
 inline bool IDs::channel::operator>(const IDs::channel& rhs)const{

--- a/analyzer/rootana/src/framework/IdChannel.h
+++ b/analyzer/rootana/src/framework/IdChannel.h
@@ -102,17 +102,16 @@ public:
 	/// Check there there have been no errors creating this channel ID
 	bool isValid(){return (fDetector!=kErrorDetector) && (fSlowFast != kErrorSlowFast);};
 
-        /// Check if the Detector_t is a wildcard
-        bool isWildCardDetector() const {return fDetector == kAnyDetector;}
+    /// Check if the Detector_t is a wildcard
+    bool isWildCardDetector() const {return fDetector == kAnyDetector;}
 
-        /// Check if the SlowFast_t is a wildcard
-        bool isWildCardSlowFast() const {return fSlowFast == kAnySlowFast;}
+    /// Check if the SlowFast_t is a wildcard
+    bool isWildCardSlowFast() const {return fSlowFast == kAnySlowFast;}
 
-        /// Check if this channel ID is a wildcard (either Detector_t
-        /// or SlowFast_t is kAny...). User must interrogate further
-        /// to find out which.
-        bool isWildCard() const 
-        {return isWildCardDetector() || isWildCardSlowFast();}
+    /// Check if this channel ID is a wildcard (either Detector_t
+    /// or SlowFast_t is kAny...). User must interrogate further
+    /// to find out which.
+    bool isWildCard() const {return isWildCardDetector() || isWildCardSlowFast();}
 
 	/// Convert a Detector_t enum into the corresponding string
 	static std::string GetDetectorString(Detector_t det);

--- a/analyzer/rootana/src/framework/IdChannel.h
+++ b/analyzer/rootana/src/framework/IdChannel.h
@@ -80,10 +80,15 @@ public:
 	/// Sets kErrorDetector or kErrorSlowFast if there is a problem decoding the string
 	channel& operator=(const char* rhs){ return (*this=std::string(rhs));};
 
-	/// Returns true if this channel is the same as another or has it's fields set to 'any'.
+	/// Returns true if this channel is the same as another 
 	bool operator==(const channel& rhs)const;
-	/// Returns true if this channel is not the same as another and it's fields are not set to 'any'.
+	/// Returns true if this channel is not the same as another 
 	bool operator!=(const channel& rhs)const{return !(this->operator==(rhs));};
+    /// @brief Check if this channel is the same as another or has it's fields set to 'any'.
+    /// @details Return true if for both the Detector and SlowFast parts, either
+    /// the rhs is the same as this one, or if either this or rhs has a
+    /// corresponding Any flag set
+    bool matches(const channel& rhs)const;
 	
 	/// not intuitively meaningful but maybe useful for sorting
 	bool operator<(const channel& rhs)const;
@@ -120,6 +125,10 @@ public:
 };
 
 inline bool IDs::channel::operator==(const IDs::channel& rhs)const{
+    return (fDetector == rhs.fDetector) && (fSlowFast== rhs.fSlowFast);
+}
+
+inline bool IDs::channel::matches(const channel& rhs)const{
 	return (fDetector==kAnyDetector || rhs.fDetector==kAnyDetector || fDetector==rhs.fDetector) 
 	&& (fSlowFast==kAnySlowFast || rhs.fSlowFast==kAnySlowFast || fSlowFast==rhs.fSlowFast) ;
 }

--- a/analyzer/rootana/src/framework/IdChannel.h
+++ b/analyzer/rootana/src/framework/IdChannel.h
@@ -113,6 +113,11 @@ public:
     /// to find out which.
     bool isWildCard() const {return isWildCardDetector() || isWildCardSlowFast();}
 
+    /// Check if this channel ID is for a fast channel
+    bool isFast() const {return fSlowFast==kFast;};
+    /// Check if this channel ID is for a slow channel
+    bool isSlow() const {return fSlowFast==kSlow;};
+
 	/// Convert a Detector_t enum into the corresponding string
 	static std::string GetDetectorString(Detector_t det);
 
@@ -165,6 +170,6 @@ inline IDs::channel::channel(const std::string& channel ):fDetector(),fSlowFast(
   *this=channel;
 }
 
-ostream& operator<< (ostream& os , IDs::channel& id);
+std::ostream& operator<< (ostream& os ,const IDs::channel& id);
 
 #endif //IDCHANNEL_H_

--- a/analyzer/rootana/src/framework/IdGenerator.cpp
+++ b/analyzer/rootana/src/framework/IdGenerator.cpp
@@ -5,7 +5,7 @@
 ClassImp(IDs::generator);
 
 std::string IDs::generator::str()const{
-  return fType+"::"+fConfig;
+  return fType+IDs::field_separator+fConfig;
 }
 
 ostream& operator<< (ostream& os , IDs::generator& id) {

--- a/analyzer/rootana/src/framework/IdGenerator.cpp
+++ b/analyzer/rootana/src/framework/IdGenerator.cpp
@@ -5,7 +5,6 @@
 ClassImp(IDs::generator);
 
 std::string IDs::generator::str()const{
-  if( fConfig==kAnyConfig) return fType;
   return fType+"::"+fConfig;
 }
 

--- a/analyzer/rootana/src/framework/IdGenerator.h
+++ b/analyzer/rootana/src/framework/IdGenerator.h
@@ -42,6 +42,7 @@ class IDs::generator:public TObject{
 	/// Is this generator the same as another, or is this or the other id
 	/// have fields set to kAny
 	bool operator==(const generator& rhs)const;
+	bool matches(const generator& rhs)const;
 
 	/// Is this generator the different to another, and do both this and
 	/// the other id have fields not set to kAny
@@ -77,6 +78,10 @@ class IDs::generator:public TObject{
 };
 
 inline bool IDs::generator::operator==(const IDs::generator& rhs)const{
+	return (fType==rhs.fType) && (fConfig==rhs.fConfig) ;
+}
+
+bool IDs::generator::matches(const generator& rhs)const{
 	return (fType==kAnyGenerator || rhs.fType==kAnyGenerator || fType==rhs.fType) 
 		&& (fConfig==kAnyConfig || rhs.fConfig==kAnyConfig || fConfig==rhs.fConfig) ;
 }

--- a/analyzer/rootana/src/framework/IdGenerator.h
+++ b/analyzer/rootana/src/framework/IdGenerator.h
@@ -81,7 +81,7 @@ inline bool IDs::generator::operator==(const IDs::generator& rhs)const{
 	return (fType==rhs.fType) && (fConfig==rhs.fConfig) ;
 }
 
-bool IDs::generator::matches(const generator& rhs)const{
+inline bool IDs::generator::matches(const generator& rhs)const{
 	return (fType==kAnyGenerator || rhs.fType==kAnyGenerator || fType==rhs.fType) 
 		&& (fConfig==kAnyConfig || rhs.fConfig==kAnyConfig || fConfig==rhs.fConfig) ;
 }

--- a/analyzer/rootana/src/framework/IdGenerator.h
+++ b/analyzer/rootana/src/framework/IdGenerator.h
@@ -42,6 +42,7 @@ class IDs::generator:public TObject{
 	/// Is this generator the same as another, or is this or the other id
 	/// have fields set to kAny
 	bool operator==(const generator& rhs)const;
+	bool matches(const generator& rhs)const;
 
 	/// Is this generator the different to another, and do both this and
 	/// the other id have fields not set to kAny
@@ -65,6 +66,10 @@ class IDs::generator:public TObject{
 };
 
 inline bool IDs::generator::operator==(const IDs::generator& rhs)const{
+	return (fType==rhs.fType) && (fConfig==rhs.fConfig) ;
+}
+
+bool IDs::generator::matches(const generator& rhs)const{
 	return (fType==kAnyGenerator || rhs.fType==kAnyGenerator || fType==rhs.fType) 
 		&& (fConfig==kAnyConfig || rhs.fConfig==kAnyConfig || fConfig==rhs.fConfig) ;
 }

--- a/analyzer/rootana/src/framework/IdGenerator.h
+++ b/analyzer/rootana/src/framework/IdGenerator.h
@@ -18,20 +18,22 @@ namespace IDs{
     /// module
 	const Config_t kDefaultConfig="default";
 
+    const std::string field_separator="#";
 }
 
-/// Streamable identifier for a generator
+/// Streamable identifier for an instance of a generator
 class IDs::generator:public TObject{
 	public:
-	/// @brief Constructor taking two strings for the Generator type and its configuration.
+    /// @brief Constructor taking two strings for the Generator type and its
+    /// configuration.
 	/// 
 	/// @param g The type of the generator
 	/// @param c The configuration of the generator
+	generator(Generator_t g , Config_t c=kAnyConfig);
 
-	generator(Generator_t g , Config_t c=kDefaultConfig);
 	/// @brief Default constructor for a generator ID.
 	/// Will match true against all generator IDs
-	generator():fType(kAnyGenerator),fConfig(kDefaultConfig){};
+	generator():fType(kAnyGenerator),fConfig(kAnyConfig){};
 
 	virtual ~generator(){};
 
@@ -59,17 +61,14 @@ class IDs::generator:public TObject{
 	/// Get this ID as a string
 	std::string str()const;
 
-        /// Check if the Generator_t part of the ID is a wildcard
-        bool isWildCardType() const
-        { return fType == kAnyGenerator; }
+    /// Check if the Generator_t part of the ID is a wildcard
+    bool isWildCardType() const { return fType == kAnyGenerator; }
 
-        /// Check if the Config_t part of the ID is a wildcard
-        bool isWildCardConfig() const
-        { return fConfig == kAnyConfig; }
+    /// Check if the Config_t part of the ID is a wildcard
+    bool isWildCardConfig() const { return fConfig == kAnyConfig; }
 
-        /// Check if any part of the ID is a wildcard
-        bool isWildCard() const
-        { return isWildCardConfig() || isWildCardType(); }
+    /// Check if any part of the ID is a wildcard
+    bool isWildCard() const { return isWildCardConfig() || isWildCardType(); }
 
 	private:
 	/// Stores the type of this generator
@@ -77,7 +76,7 @@ class IDs::generator:public TObject{
 	/// Stores the configuration of this generator
 	Config_t fConfig;
 
-	ClassDef(IDs::generator,1);
+	ClassDef(generator,1);
 };
 
 inline bool IDs::generator::operator==(const IDs::generator& rhs)const{
@@ -85,8 +84,8 @@ inline bool IDs::generator::operator==(const IDs::generator& rhs)const{
 }
 
 inline bool IDs::generator::matches(const generator& rhs)const{
-	return (fType==kAnyGenerator || rhs.fType==kAnyGenerator || fType==rhs.fType) 
-		&& (fConfig==kAnyConfig || rhs.fConfig==kAnyConfig || fConfig==rhs.fConfig) ;
+	return (isWildCardType() || rhs.isWildCardType() || fType==rhs.fType) 
+		&& (isWildCardConfig() || rhs.isWildCardConfig() || fConfig==rhs.fConfig) ;
 }
 
 inline bool IDs::generator::operator>(const IDs::generator& rhs)const{

--- a/analyzer/rootana/src/framework/IdGenerator.h
+++ b/analyzer/rootana/src/framework/IdGenerator.h
@@ -14,6 +14,9 @@ namespace IDs{
 	const Generator_t kAnyGenerator="*";
 	/// Standardize the value to use to represent any configuration
 	const Config_t kAnyConfig="*";
+	/// Standardize the value to use to represent the default configuration of a
+    /// module
+	const Config_t kDefaultConfig="default";
 
 }
 
@@ -25,10 +28,10 @@ class IDs::generator:public TObject{
 	/// @param g The type of the generator
 	/// @param c The configuration of the generator
 
-	generator(Generator_t g , Config_t c=kAnyConfig);
+	generator(Generator_t g , Config_t c=kDefaultConfig);
 	/// @brief Default constructor for a generator ID.
 	/// Will match true against all generator IDs
-	generator():fType(kAnyGenerator),fConfig(kAnyConfig){};
+	generator():fType(kAnyGenerator),fConfig(kDefaultConfig){};
 
 	virtual ~generator(){};
 

--- a/analyzer/rootana/src/framework/IdSource.cpp
+++ b/analyzer/rootana/src/framework/IdSource.cpp
@@ -4,7 +4,7 @@
 ClassImp(IDs::source);
 
 std::string IDs::source::str()const{
-	return fChannel.str() + "::" +fGenerator.str();
+	return fChannel.str() + IDs::field_separator +fGenerator.str();
 }
 
 ostream& operator<< (ostream& os , IDs::source& id) {

--- a/analyzer/rootana/src/framework/IdSource.h
+++ b/analyzer/rootana/src/framework/IdSource.h
@@ -100,6 +100,11 @@ class IDs::source:public TObject{
   bool isWildCard() const 
   {return isWildCardChannel() || isWildCardGenerator();}
 
+  /// Check if the Channel is fast
+  bool isFast() const {return Channel().isFast();};
+
+  /// Check if the Channel is slow
+  bool isSlow() const {return Channel().isSlow();};
 
  private:
   channel fChannel;

--- a/analyzer/rootana/src/framework/IdSource.h
+++ b/analyzer/rootana/src/framework/IdSource.h
@@ -61,11 +61,17 @@ class IDs::source:public TObject{
   /// Returns true if the channel part of this source matches another channel
   bool operator==(const channel& rhs)const{return fChannel==rhs;};
 
-  /// Not intuitively meaningful but maybe useful for sorting
-  bool operator>(const source& rhs)const;
-  
-  /// Not intuitively meaningful but maybe useful for sorting
-  bool operator<(const source& rhs)const;
+  /// Returns true if this source matches another
+	bool matches(const source& rhs)const;
+  /// Returns true if the generator part of this source matches another generator
+	bool matches(const generator& rhs)const{return fGenerator.matches(rhs);};
+  /// Returns true if the channel part of this source matches another channel
+	bool matches(const channel& rhs)const{return fChannel.matches(rhs);};
+
+	/// Not intuitively meaningful but maybe useful for sorting
+	bool operator>(const source& rhs)const;
+	/// Not intuitively meaningful but maybe useful for sorting
+	bool operator<(const source& rhs)const;
 
   /// Get a reference to the generator ID in this source
   generator& Generator(){return fGenerator;};
@@ -105,6 +111,9 @@ class IDs::source:public TObject{
 inline bool IDs::source::operator==(const source& rhs)const
 {
   return rhs.Generator()==fGenerator && rhs.Channel()==fChannel;
+}
+inline bool IDs::source::matches(const source& rhs)const{
+	return fGenerator.matches(rhs.fGenerator) && fChannel.matches(rhs.fChannel);
 }
 
 inline bool IDs::source::operator>(const source& rhs)const

--- a/analyzer/rootana/src/framework/IdSource.h
+++ b/analyzer/rootana/src/framework/IdSource.h
@@ -55,6 +55,13 @@ class IDs::source:public TObject{
   /// Returns true if the channel part of this source matches another channel
 	bool operator==(const channel& rhs)const{return fChannel==rhs;};
 
+  /// Returns true if this source matches another
+	bool matches(const source& rhs)const;
+  /// Returns true if the generator part of this source matches another generator
+	bool matches(const generator& rhs)const{return fGenerator.matches(rhs);};
+  /// Returns true if the channel part of this source matches another channel
+	bool matches(const channel& rhs)const{return fChannel.matches(rhs);};
+
 	/// Not intuitively meaningful but maybe useful for sorting
 	bool operator>(const source& rhs)const;
 	/// Not intuitively meaningful but maybe useful for sorting
@@ -81,6 +88,9 @@ class IDs::source:public TObject{
 
 inline bool IDs::source::operator==(const source& rhs)const{
 	return rhs.Generator()==fGenerator && rhs.Channel()==fChannel;
+}
+inline bool IDs::source::matches(const source& rhs)const{
+	return fGenerator.matches(rhs.fGenerator) && fChannel.matches(rhs.fChannel);
 }
 
 inline bool IDs::source::operator>(const source& rhs)const{

--- a/analyzer/rootana/src/framework/IdSource.h
+++ b/analyzer/rootana/src/framework/IdSource.h
@@ -68,13 +68,6 @@ class IDs::source:public TObject{
   /// Returns true if the channel part of this source matches another channel
 	bool matches(const channel& rhs)const{return fChannel.matches(rhs);};
 
-  /// Returns true if this source matches another
-	bool matches(const source& rhs)const;
-  /// Returns true if the generator part of this source matches another generator
-	bool matches(const generator& rhs)const{return fGenerator.matches(rhs);};
-  /// Returns true if the channel part of this source matches another channel
-	bool matches(const channel& rhs)const{return fChannel.matches(rhs);};
-
 	/// Not intuitively meaningful but maybe useful for sorting
 	bool operator>(const source& rhs)const;
 	/// Not intuitively meaningful but maybe useful for sorting
@@ -118,9 +111,6 @@ class IDs::source:public TObject{
 inline bool IDs::source::operator==(const source& rhs)const
 {
   return rhs.Generator()==fGenerator && rhs.Channel()==fChannel;
-}
-inline bool IDs::source::matches(const source& rhs)const{
-	return fGenerator.matches(rhs.fGenerator) && fChannel.matches(rhs.fChannel);
 }
 inline bool IDs::source::matches(const source& rhs)const{
 	return fGenerator.matches(rhs.fGenerator) && fChannel.matches(rhs.fChannel);

--- a/analyzer/rootana/src/framework/IdSource.h
+++ b/analyzer/rootana/src/framework/IdSource.h
@@ -105,7 +105,7 @@ class IDs::source:public TObject{
   channel fChannel;
   generator fGenerator;
 
-  ClassDef(IDs::source,1);
+  ClassDef(source,1);
 };
 
 inline bool IDs::source::operator==(const source& rhs)const

--- a/analyzer/rootana/src/framework/ModulesParser.cpp
+++ b/analyzer/rootana/src/framework/ModulesParser.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <TString.h>
+#include <ctype.h>
 using std::cout;
 using std::endl;
 
@@ -127,4 +128,14 @@ double modules::parser::GetDouble(const std::string& input, size_t start, size_t
 	TString tstr=input.substr(start,stop-start);
 	double value=tstr.Atof();
 	return value;
+}
+
+bool modules::parser::iequals(const std::string& a, const std::string& b){
+  unsigned int sz = a.size();
+  if (b.size() != sz) return false;
+  for (unsigned int i = 0; i < sz; ++i){
+    if ( (a[i]=='_' && b[i]=='-' )|| ( a[i]=='-' && b[i]=='_') ) continue;
+    if (tolower(a[i]) != tolower(b[i])) return false;
+  }
+  return true;
 }

--- a/analyzer/rootana/src/framework/ModulesParser.cpp
+++ b/analyzer/rootana/src/framework/ModulesParser.cpp
@@ -130,12 +130,17 @@ double modules::parser::GetDouble(const std::string& input, size_t start, size_t
 	return value;
 }
 
+bool modules::parser::iequals(const char a, const char b){
+    return ( a=='_' && b=='-' ) ||
+           ( a=='-' && b=='_' ) ||
+           ( tolower(a) == tolower(b));
+}
+
 bool modules::parser::iequals(const std::string& a, const std::string& b){
   unsigned int sz = a.size();
   if (b.size() != sz) return false;
   for (unsigned int i = 0; i < sz; ++i){
-    if ( (a[i]=='_' && b[i]=='-' )|| ( a[i]=='-' && b[i]=='_') ) continue;
-    if (tolower(a[i]) != tolower(b[i])) return false;
+      if (! iequals(a[i],b[i])) return false;
   }
   return true;
 }

--- a/analyzer/rootana/src/framework/ModulesParser.h
+++ b/analyzer/rootana/src/framework/ModulesParser.h
@@ -66,7 +66,9 @@ namespace modules{
         bool IsNumber(const std::string& input);
         int GetNumber(const std::string& input);
 	double GetDouble(const std::string& input, size_t start=0, size_t stop=std::string::npos);
+  bool iequals(const std::string& a, const std::string& b);
     }
+    
 }
 
 #endif //MODULESPARSER_H_

--- a/analyzer/rootana/src/framework/ModulesParser.h
+++ b/analyzer/rootana/src/framework/ModulesParser.h
@@ -67,6 +67,7 @@ namespace modules{
         int GetNumber(const std::string& input);
 	double GetDouble(const std::string& input, size_t start=0, size_t stop=std::string::npos);
   bool iequals(const std::string& a, const std::string& b);
+  bool iequals(const char a, const char b);
     }
     
 }

--- a/analyzer/rootana/src/framework/ModulesReader.cpp
+++ b/analyzer/rootana/src/framework/ModulesReader.cpp
@@ -269,6 +269,8 @@ void modules::reader::ProcessGlobalOption(Option_t opt){
      } else{
         SetDebug();
      }
+  }else if(opt.key=="list_modules"){
+    modules::factory::Instance()->PrintPossibleModules();
   }else {
      if(fShouldPrint) std::cout<<"Warning: Unknown global option given, '"<<opt.key<<"'"<<std::endl;
      return;

--- a/analyzer/rootana/src/framework/TemplateFactory.h
+++ b/analyzer/rootana/src/framework/TemplateFactory.h
@@ -38,6 +38,8 @@ class TemplateFactory{
 	// Set the factory to output debugging commands
 	void SetDebug(bool debug=true){fDebug=debug;};
 
+  void PrintPossibleModules()const;
+
     private:
 	// the list of makers for all modules
 	typedef std::map<std::string, maker> MakersList; 

--- a/analyzer/rootana/src/framework/TemplateFactory.tpl
+++ b/analyzer/rootana/src/framework/TemplateFactory.tpl
@@ -76,3 +76,12 @@ void TemplateFactory<BaseModule,OptionsType>::addArguments(const std::string& al
         arg = strtok(NULL,", ");
     }
 }
+
+template <typename BaseModule, typename OptionsType>
+void TemplateFactory<BaseModule,OptionsType>::PrintPossibleModules()const{
+  std::cout<<"Available modules are:"<<std::endl;
+  for(typename MakersList::const_iterator it=fModuleMakers.begin();
+				 it!=fModuleMakers.end(); it++){
+				 std::cout<<"  "<<it->first<<std::endl;
+ }
+}

--- a/analyzer/rootana/src/framework/definitions.h
+++ b/analyzer/rootana/src/framework/definitions.h
@@ -6,11 +6,6 @@
 #include "IdSource.h"
 #include <string>
 
-namespace IDs{
-  const channel Fast(kAnyDetector,kFast);
-  const channel Slow(kAnyDetector,kSlow);
-}
-
 class ChannelID;
 
 typedef int TPulseIslandID;

--- a/analyzer/rootana/src/unit_test/IdChannel_test.cpp
+++ b/analyzer/rootana/src/unit_test/IdChannel_test.cpp
@@ -38,6 +38,20 @@ namespace tut
     ensure("Doublely wild is wild", all_wild.isWildCard());    
     ensure("Doublely wild is wild det", all_wild.isWildCardDetector());    
     ensure("Doublely wild is wild S/F", all_wild.isWildCardSlowFast());    
+
+    std::string string_ch0("Ge-F");
+    std::string string_ch1("ge-f");
+    std::string string_ch2("ge_f");
+    IDs::channel ch0(string_ch0);
+    IDs::channel ch1(string_ch1);
+    IDs::channel ch2(string_ch2);
+    ensure_equals("Ge-F == ge-f", ch0,ch1);    
+    ensure_equals("Ge-F == ge_f", ch0,ch2);    
+    ensure_equals("ge_f == ge-f", ch2,ch1);    
+
+    ensure_equals("IDs::channel(\"Ge-F\").str() should give Ge-F", ch0.str(),string_ch0);    
+    ensure_equals("IDs::channel(\"ge-f\").str() should give Ge-F", ch1.str(),string_ch0);    
+    ensure_equals("IDs::channel(\"ge_f\").str() should give Ge-F", ch2.str(),string_ch0);    
   }
 }
 


### PR DESCRIPTION
I've finished putting through the various requests / changes for the ID classes:
- Case independent and hyphens -> underscores #101 
- Rewrite operator== and matches method #82
- default value for generator config #80  
- Change field separator to # #89 

I have also added `isFast()` and `isSlow()` methods to the Channel and source IDs.  This should be used to check if a channel is fast or slow instead of the previous `IDs::channel ch1("....."); ch1==IDs::Fast;`.  This old approach has been broken by the fact that operator== now returns true only if the enums contained in the channel ID are identical.  The new `matches` method takes over the role of the wildcarded matching that operator== had previously done.

Because of this change, I'm doing this as a pull request, although I have already put the correct changes into the parts of the code that needed updating.
