### PR TITLE
Feature/finalise template creator

### DIFF
--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -98,7 +98,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  AddPulseToTemplate(hTemplate, pulse);
 	  ++n_pulses_in_template;
 
-	  const std::vector<int>& theSamples = (pulse)->GetSamples();
+/*	  const std::vector<int>& theSamples = (pulse)->GetSamples();
 	  std::stringstream histname;
 	  histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
 	  TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
@@ -111,7 +111,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	    hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
 	    hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
 	  }
-
+*/
 	  if (Debug()) {
 	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
 	  }
@@ -174,7 +174,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	}
 
 	// Now add the fitted pulse to the template
-
+/*
 	if (n_pulses_in_template <= 10 || 
 	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ||
 	    (n_pulses_in_template%100 == 0) ) {
@@ -182,7 +182,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
 	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
 	}
-
+*/
 	// Add the pulse to the template (we'll do the correcting there)
 	AddPulseToTemplate(hTemplate, pulse);
 	++n_pulses_in_template;
@@ -198,7 +198,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	if (prob != 0) {
 	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
 	}
-	
+/*	
 	// Create the corrected pulse
 	const std::vector<int>& theSamples = (pulse)->GetSamples();
 	std::stringstream histname;
@@ -218,6 +218,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
 	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
 	}
+*/
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -93,13 +93,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	double pedestal_estimate = 0;
 	double amplitude_estimate = 0;
 	double time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
-	std::cout << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {
-	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
+	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
+		    << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl
 	            << "Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
 	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
 	}
@@ -115,16 +115,11 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
 	  double uncorrected_value = (*sampleIter);
-	  std::cout << "Uncorrected value = " << uncorrected_value << std::endl;
 	  double corrected_value = uncorrected_value - template_fitter->GetPedestalOffset();
 	  corrected_value /= template_fitter->GetAmplitudeScaleFactor();
-	  std::cout << " / " << template_fitter->GetAmplitudeScaleFactor() << " = " << corrected_value << std::endl;
-	  //	  corrected_value += template_fitter->GetPedestalOffset();
-	  std::cout << " - " << template_fitter->GetPedestalOffset() << " = " << corrected_value << std::endl;
 
 	  hUncorrectedPulse->Fill(sampleIter - theSamples.begin(), uncorrected_value);
 	  hCorrectedPulse->Fill(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset(), corrected_value);
-	  //	  std::cout << "Uncorrected Value = " << (*sampleIter) << ", Corrected Value = " << (*sampleIter)*template_fitter->GetAmplitudeScaleFactor() + template_fitter->GetPedestalOffset() << std::endl;
 	}
 	// we keep on adding pulses until adding pulses has no effect on the template
       }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -98,7 +98,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  AddPulseToTemplate(hTemplate, pulse);
 	  ++n_pulses_in_template;
 
-	  const std::vector<int>& theSamples = (pulse)->GetSamples();
+/*	  const std::vector<int>& theSamples = (pulse)->GetSamples();
 	  std::stringstream histname;
 	  histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
 	  TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
@@ -111,7 +111,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	    hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
 	    hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
 	  }
-
+*/
 	  if (Debug()) {
 	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
 	  }
@@ -174,7 +174,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	}
 
 	// Now add the fitted pulse to the template
-
+/*
 	if (n_pulses_in_template <= 10 || 
 	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ||
 	    (n_pulses_in_template%100 == 0) ) {
@@ -182,7 +182,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
 	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
 	}
-
+*/
 	// Add the pulse to the template (we'll do the correcting there)
 	AddPulseToTemplate(hTemplate, pulse);
 	++n_pulses_in_template;
@@ -198,7 +198,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	if (prob != 0) {
 	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
 	}
-	
+/*	
 	// Create the corrected pulse
 	const std::vector<int>& theSamples = (pulse)->GetSamples();
 	std::stringstream histname;
@@ -218,6 +218,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
 	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
 	}
+*/
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -93,13 +93,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	double pedestal_estimate = 0;
 	double amplitude_estimate = 0;
 	double time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
-	std::cout << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {
-	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
+	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
+		    << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl
 	            << "Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
 	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
 	}
@@ -115,16 +115,11 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
 	  double uncorrected_value = (*sampleIter);
-	  std::cout << "Uncorrected value = " << uncorrected_value << std::endl;
 	  double corrected_value = uncorrected_value - template_fitter->GetPedestalOffset();
 	  corrected_value /= template_fitter->GetAmplitudeScaleFactor();
-	  std::cout << " / " << template_fitter->GetAmplitudeScaleFactor() << " = " << corrected_value << std::endl;
-	  //	  corrected_value += template_fitter->GetPedestalOffset();
-	  std::cout << " - " << template_fitter->GetPedestalOffset() << " = " << corrected_value << std::endl;
 
 	  hUncorrectedPulse->Fill(sampleIter - theSamples.begin(), uncorrected_value);
 	  hCorrectedPulse->Fill(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset(), corrected_value);
-	  //	  std::cout << "Uncorrected Value = " << (*sampleIter) << ", Corrected Value = " << (*sampleIter)*template_fitter->GetAmplitudeScaleFactor() + template_fitter->GetPedestalOffset() << std::endl;
 	}
 	// we keep on adding pulses until adding pulses has no effect on the template
       }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -116,13 +116,14 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	  double uncorrected_value = (*sampleIter);
 	  std::cout << "Uncorrected value = " << uncorrected_value << std::endl;
-	  double corrected_value = uncorrected_value * template_fitter->GetAmplitudeScaleFactor();
-	  std::cout << " x " << template_fitter->GetAmplitudeScaleFactor() << " = " << corrected_value << std::endl;
-	  corrected_value += template_fitter->GetPedestalOffset();
-	  std::cout << " + " << template_fitter->GetPedestalOffset() << " = " << corrected_value << std::endl;
+	  double corrected_value = uncorrected_value - template_fitter->GetPedestalOffset();
+	  corrected_value /= template_fitter->GetAmplitudeScaleFactor();
+	  std::cout << " / " << template_fitter->GetAmplitudeScaleFactor() << " = " << corrected_value << std::endl;
+	  //	  corrected_value += template_fitter->GetPedestalOffset();
+	  std::cout << " - " << template_fitter->GetPedestalOffset() << " = " << corrected_value << std::endl;
 
 	  hUncorrectedPulse->Fill(sampleIter - theSamples.begin(), uncorrected_value);
-	  hCorrectedPulse->Fill(sampleIter - theSamples.begin() + template_fitter->GetTimeOffset(), corrected_value);
+	  hCorrectedPulse->Fill(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset(), corrected_value);
 	  //	  std::cout << "Uncorrected Value = " << (*sampleIter) << ", Corrected Value = " << (*sampleIter)*template_fitter->GetAmplitudeScaleFactor() + template_fitter->GetPedestalOffset() << std::endl;
 	}
 	// we keep on adding pulses until adding pulses has no effect on the template

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -220,22 +220,21 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	// Create the corrected pulse
 	std::stringstream histname;
 	histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
-	TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
+	TH1D* hUncorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
 	histname << "_Corrected";
-	TH1D* hCorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
+	TH1D* hCorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
 
 	double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+	for (int iPulseBin = 1; iPulseBin <= hPulseToFit->GetNbinsX(); ++iPulseBin) {
+	  //std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
-	  double uncorrected_value = (*sampleIter);
+	  double uncorrected_value = hPulseToFit->GetBinContent(iPulseBin);
 	  double corrected_value = CorrectSampleValue(uncorrected_value, template_pedestal);
 
-	  hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
-	  hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
-	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
-	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
+	  hCorrectedPulse->SetBinContent(iPulseBin +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
+	  hCorrectedPulse->SetBinError(iPulseBin +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
 	}
-
+	delete hPulseToFit;
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -89,6 +89,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
+	// Get some initial estimates for the fitter
+	double pedestal_estimate = TSetupData::Instance()->GetPedestal(bankname);
+	double amplitude_estimate = (*pulseIter)->GetAmplitude();
+	double time_estimate = (*pulseIter)->GetPeakSample();
+	std::cout << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
+	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
+
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -96,6 +96,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  std::string histname = "hTemplate_" + detname;
 	  std::string histtitle = "Template Histogram for the " + detname + " channel";
 
+	  int pulse_length = pulse->GetSamples().size();
+	  if (pulse->GetPeakSample() >= pulse_length - pulse_length/5.0) {
+	    if (Debug()) {
+	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " is too close to one end of the island and so won't be used as the first pulse in the template." << std::endl;
+	    }
+	    continue;
+	  }
 	  hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), true);
 	  ++n_pulses_in_template;
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -22,10 +22,8 @@ extern Long64_t* gEntryNumber;
 TemplateCreator::TemplateCreator(modules::options* opts):
   BaseModule("TemplateCreator",opts), fOpts(opts){
 
-  // Do something with opts here.  Has the user specified any
-  // particular configuration that you want to know?
-  // For example, perhaps this module wants an axis range:
   fRefineFactor = opts->GetInt("refine_factor", 5);
+  fPulseDebug = opts->GetBool("pulse_debug", false);
 }
 
 TemplateCreator::~TemplateCreator(){
@@ -183,7 +181,6 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  continue;
 	}
 	++n_successful_fits;
-	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 
 	if (Debug()) {
 	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << fTemplateFitter->GetPedestalOffset() << ", AmpScaleFactor = " << fTemplateFitter->GetAmplitudeScaleFactor()
@@ -191,51 +188,48 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 		    << ", Prob = " << TMath::Prob(fTemplateFitter->GetChi2(), fTemplateFitter->GetNDoF()) << std::endl << std::endl;
 	}
 
-	// Now add the fitted pulse to the template
-	if (n_pulses_in_template <= 10 || 
-	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ||
-	    (n_pulses_in_template%100 == 0) ) {
-	  std::stringstream newhistname;
-	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
-	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
+	if (fPulseDebug) {
+	  // Print out some templates as we go along
+	  if (n_pulses_in_template <= 10 || 
+	      (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ||
+	      (n_pulses_in_template%100 == 0) ) {
+	    std::stringstream newhistname;
+	    newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
+	    TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
+	  }
 	}
 
-	// Add the pulse to the template (we'll do the correcting there)
+	// Add the pulse to the template (we'll do correct the sample values there)
 	AddPulseToTemplate(hTemplate, hPulseToFit, bankname);
 	++n_pulses_in_template;
-	/*	double error_of_max_bin;
-	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) {
-	  error_of_max_bin = hTemplate->GetBinError(hTemplate->GetMaximumBin());
-	}
-	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
-	  error_of_max_bin = hTemplate->GetBinError(hTemplate->GetMinimumBin());
-	}
-	fErrorVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, error_of_max_bin);
-	double prob = TMath::Prob(fTemplateFitter->GetChi2(), fTemplateFitter->GetNDoF());
-	if (prob != 0) {
-	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
-	}
-	*/
 	
-	// Create the corrected pulse
-	std::stringstream histname;
-	histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
-	TH1D* hUncorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
-	histname << "_Corrected";
-	TH1D* hCorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
-	hCorrectedPulse->SetEntries(0); // set entries back to 0
 
-	double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-	for (int iPulseBin = 1; iPulseBin <= hPulseToFit->GetNbinsX(); ++iPulseBin) {
-	  //std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+	if (fPulseDebug) {
+	  // Print out the uncorrected and corrected pulse that has been added to the template
 
-	  double uncorrected_value = hPulseToFit->GetBinContent(iPulseBin);
-	  double corrected_value = CorrectSampleValue(uncorrected_value, template_pedestal);
+	  // Create the histograms that we will use to plot the corrected and uncorrected pulses
+	  std::stringstream histname;
+	  histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
+	  TH1D* hUncorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
+	  histname << "_Corrected";
+	  TH1D* hCorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
+	  hCorrectedPulse->SetEntries(0); // set entries back to 0
+	  
+	  double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
 
-	  hCorrectedPulse->SetBinContent(iPulseBin +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
-	  hCorrectedPulse->SetBinError(iPulseBin +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
+	  // Loop through the bins of the uncorrected pulse and set the values in the corrected pulse histogram
+	  for (int iPulseBin = 1; iPulseBin <= hPulseToFit->GetNbinsX(); ++iPulseBin) {
+	    
+	    double uncorrected_value = hPulseToFit->GetBinContent(iPulseBin);
+	    double corrected_value = CorrectSampleValue(uncorrected_value, template_pedestal);
+	    
+	    hCorrectedPulse->SetBinContent(iPulseBin +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
+	    hCorrectedPulse->SetBinError(iPulseBin +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
+	  }
 	}
+
 	delete hPulseToFit;
+
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
@@ -259,14 +253,17 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData,TSetupData *setup){
 
   StringPulseIslandMap::const_iterator it;
 
-  // Loop over each detector
-  for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
-    std::string bankname = it->first;
-    std::string detname = setup->GetDetectorName(bankname);
+  if (Debug()) {
 
-    int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
-    int& n_successful_fits = fNSuccessfulFits[detname];
-    std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
+    // Print to stdout the percentage of successful fit for each channel
+    for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
+      std::string bankname = it->first;
+      std::string detname = setup->GetDetectorName(bankname);
+
+      int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
+      int& n_successful_fits = fNSuccessfulFits[detname];
+      std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
+    }
   }
 
   // Clean up the template archive
@@ -303,26 +300,32 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, TH1D* & hPulse, std:
     std::cout << "AddPulseToTemplate(): n_pulses = " << n_pulses << std::endl;
   }
 
-  // Loop through the pulse histogram
   double template_pedestal = hTemplate->GetBinContent(1);
-  for (int iPulseBin = 1; iPulseBin < hPulse->GetNbinsX(); ++iPulseBin) {
-    //    for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
+  // Loop through the pulse histogram
+  for (int iPulseBin = 1; iPulseBin < hPulse->GetNbinsX(); ++iPulseBin) {
+
+    // First, get the corrected sample value based on the fitted parameters
     double uncorrected_value = hPulse->GetBinContent(iPulseBin);
     double corrected_value = CorrectSampleValue(uncorrected_value, template_pedestal);
 
+    // Get the corrected bin number based on the fitted time offset
     int bin_number = iPulseBin + 0.5 - fTemplateFitter->GetTimeOffset(); // +0.5 so that we round to the nearest integer and subtract time offset because this value might not want to go direct into the template
 
     // Only change the bin contents of bins within the range of the template histogram
     if (bin_number < 1 || bin_number > hTemplate->GetNbinsX()) {
       continue;
     }
+
+    // Store the old bin content and error for later
     double old_bin_content = hTemplate->GetBinContent(bin_number);
     double old_bin_error = hTemplate->GetBinError(bin_number);
 
+    // Calculate the new bin content...
     double new_bin_content = n_pulses * old_bin_content + corrected_value;
     new_bin_content /= (n_pulses + 1);
 
+    /// ...and new bin error
     double new_bin_error = ((n_pulses - 1)*old_bin_error*old_bin_error) + (corrected_value - old_bin_content)*(corrected_value - new_bin_content);
     new_bin_error = std::sqrt(new_bin_error / n_pulses);
 
@@ -332,6 +335,7 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, TH1D* & hPulse, std:
 		<< "\t\t\tNew Value (Error) = " << new_bin_content << "(" << new_bin_error << ")" << std::endl;
     }
 
+    // Set the new bin content and error of the template
     hTemplate->SetBinContent(bin_number, new_bin_content);
     hTemplate->SetBinError(bin_number, new_bin_error);
   }
@@ -349,20 +353,26 @@ double TemplateCreator::CorrectSampleValue(double old_value, double template_ped
 // Creates a histogram with sub-bin resolution
 TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, bool interpolate) {
 
+  // Get a few things first
   std::string bankname = pulse->GetBankName();
   const std::vector<int>& theSamples = pulse->GetSamples();
   int n_samples = theSamples.size();
   int n_bins = fRefineFactor*n_samples; // number of bins in the template
 
+  // Create the higher resolution histogram
   TH1D* hist = new TH1D(histname.c_str(), histtitle.c_str(), n_bins, 0, n_samples);
 
   double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
+
+  // Go through the bins in the high-resolution histogram
+  // NB sample numbers go grom 0 to n-1 and bins go from 1 to n
   for (int i = 0; i < n_bins; ++i) {
     int bin = i+1; // bins go from 1 to n rather than 0 to n-1
     int sample_number = i / fRefineFactor;
     double remainder = i % fRefineFactor;
     double sample_value;
 
+    // We may want to interpolate between the samples in the samples vector
     if (interpolate) {
       try {
 	sample_value = theSamples.at(sample_number) + (remainder / fRefineFactor)*(theSamples.at(sample_number+1) - theSamples.at(sample_number));
@@ -374,6 +384,8 @@ TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, st
     else {
       sample_value = theSamples.at(sample_number);
     }
+
+    // Set the bin contents and bin error
     hist->SetBinContent( bin, sample_value);
     hist->SetBinError( bin, pedestal_error);
   }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -89,8 +89,8 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
       // only continue if there is one pulse candidate on the TPI
       if (n_pulse_candidates == 1) {
 
-	std::vector<TPulseIsland*> pulse_candidates = pulse_candidate_finder->GetPulseCandidates();
-	TPulseIsland* pulse = pulse_candidates.at(0);
+	TPulseIsland* pulse = *pulseIter;
+
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) {
 	  AddPulseToTemplate(hTemplate, pulse);

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -94,13 +94,15 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	double pedestal_estimate = 0;//(*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
-	double amplitude_estimate = 0;//(*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
+	double pedestal_estimate = (*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
+	double amplitude_estimate;
 	double time_estimate;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
+	  amplitude_estimate = (*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
 	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
 	}
 	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
+	  amplitude_estimate = (*pulseIter)->GetAmplitude() / hTemplate->GetMinimum(); // estimated scale factor
 	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMinimumBin();
 	}
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -442,8 +442,8 @@ bool TemplateCreator::CheckConvergence(TH1D* hTemplate, std::string bankname) {
   error_histogram->Fill(n_pulses_in_template, error);
 
   // Check the difference between this iteration and previous ones and, if it's small, the template has converged
-  int n_bins_to_check = 5;
-  double convergence_limit = 0.001;
+  int n_bins_to_check = 10;
+  double convergence_limit = 0.1;
   bool converged = false;
   for (int iPrevBin = 0; iPrevBin < n_bins_to_check; ++iPrevBin) {
     double previous_error = error_histogram->GetBinContent(n_pulses_in_template-iPrevBin); // we have just added error to bin number n_pulses_in_template+1

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -76,6 +76,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
     // Store a couple of numbers to get an idea of how many successful fits there are
     int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
     int& n_successful_fits = fNSuccessfulFits[detname];
+    int& n_pulses_in_template = fNPulsesInTemplate[detname];
 
     // Loop through all the pulses
     for (PulseIslandList::iterator pulseIter = thePulseIslands.begin(); pulseIter != thePulseIslands.end(); ++pulseIter) {
@@ -90,8 +91,9 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
       if (n_pulse_candidates == 1) {
 
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
-	if (hTemplate == NULL) { // for debugging, just print add one pulse to the template
+	if (hTemplate == NULL) {
 	  AddPulseToTemplate(hTemplate, *pulseIter);
+	  ++n_pulses_in_template;
 
 	  if (Debug()) {
 	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
@@ -151,7 +153,23 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 		    << ", Prob = " << TMath::Prob(template_fitter->GetChi2(), template_fitter->GetNDoF()) << std::endl << std::endl;
 	}
 
-	/*	// Create the corrected pulse
+	// Now add the fitted pulse to the template
+	AddPulseToTemplate(hTemplate, *pulseIter);
+	++n_pulses_in_template;
+	double error_of_max_bin;
+	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) {
+	  error_of_max_bin = hTemplate->GetBinError(hTemplate->GetMaximumBin());
+	}
+	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
+	  error_of_max_bin = hTemplate->GetBinError(hTemplate->GetMinimumBin());
+	}
+	fErrorVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, error_of_max_bin);
+	double prob = TMath::Prob(template_fitter->GetChi2(), template_fitter->GetNDoF());
+	if (prob != 0) {
+	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
+	}
+
+	// Create the corrected pulse
 	const std::vector<int>& theSamples = (*pulseIter)->GetSamples();
 	std::stringstream histname;
 	histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
@@ -171,7 +189,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 - template_fitter->GetTimeOffset(), corrected_value); 
 	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset()+1, pedestal_error);
 	}
-	*/
+
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
@@ -219,6 +237,9 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
   const std::vector<int>& theSamples = pulse->GetSamples();
   int n_samples = theSamples.size();
 
+  std::string bankname = pulse->GetBankName();
+  std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
+
   // Wnat to increase the bin resolution (this may become a module option at some point)
   int refine_factor = 5;
 
@@ -226,8 +247,6 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
   if (hTemplate == NULL) {
 
     // Names for the histograms
-    std::string bankname = pulse->GetBankName();
-    std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
     std::string histname = "hTemplate_" + detname;
     std::string histtitle = "Template Histogram for the " + detname + " channel";
 
@@ -237,7 +256,59 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
     for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
       hTemplate->SetBinContent( sampleIter - theSamples.begin()+1, *sampleIter); // +1 because ROOT numbers bins from 1
-      hTemplate->SetBinError( sampleIter - theSamples.begin()+1, pedestal_error);
+      hTemplate->SetBinError( sampleIter - theSamples.begin()+1, 5*pedestal_error);
+    }
+
+    std::string error_histname = "hErrorVsPulseAdded_" + detname;
+    std::string error_histtitle = "Plot of the Error as each new Pulse is added to the template for the " + detname + " channel";
+    int n_bins = 1000000;
+    TH1D* error_hist = new TH1D(error_histname.c_str(), error_histtitle.c_str(), n_bins,0,n_bins);
+    error_hist->Fill(1, pedestal_error);
+    fErrorVsPulseAddedHistograms[detname] = error_hist;
+
+    std::string prob_histname = "hProbVsPulseAdded_" + detname;
+    std::string prob_histtitle = "Plot of the Prob as each new Pulse is added to the template for the " + detname + " channel";
+    TH1D* prob_hist = new TH1D(prob_histname.c_str(), prob_histtitle.c_str(), n_bins,0,n_bins);
+    fProbVsPulseAddedHistograms[detname] = prob_hist;
+  }
+
+  else { // add subsequent pulses
+    /*    double x, x_old;
+    double e, e_old;
+    for (int i = 0; i < fNBins; ++i) {
+      x_old = fTemplate->GetBinContent(i+1);
+      e_old = fTemplate->GetBinError(i+1);
+      x = (double)fNPulses * x_old + reshaped_pulse[i];
+      x /= (double)(fNPulses + 1);
+      e = (double)(fNPulses - 1) * std::pow(e_old, 2.) + ((double)reshaped_pulse[i] - x_old) * ((double)reshaped_pulse[i] - x);
+      e = std::sqrt(e / fNPulses);
+      fTemplate->SetBinContent(i+1, x);
+      fTemplate->SetBinError(i+1, e);
+    }
+    */
+    int n_pulses = fNPulsesInTemplate.at(detname);
+    if (Debug()) {
+      std::cout << "AddPulseToTemplate(): n_pulses = " << n_pulses << std::endl;
+    }
+    for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+
+      int bin_number = sampleIter - theSamples.begin() + 1; // +1 because ROOT numbers bins from 1
+      double old_bin_content = hTemplate->GetBinContent(bin_number);
+      double old_bin_error = hTemplate->GetBinError(bin_number);
+
+      double new_bin_content = n_pulses * old_bin_content + *sampleIter;
+      new_bin_content /= (n_pulses + 1);
+
+      double new_bin_error = ((n_pulses - 1)*old_bin_error*old_bin_error) + (*sampleIter - old_bin_content)*(*sampleIter - new_bin_content);
+      new_bin_error = std::sqrt(new_bin_error / n_pulses);
+
+      if (Debug()) {
+	std::cout << "TemplateCreator::AddPulseToTemplate(): Bin #" << bin_number << ": Old Value (Error) = " << old_bin_content << "(" << old_bin_error << ")" << std::endl
+		  << "\t\t\tNew Value (Error) = " << new_bin_content << "(" << new_bin_error << ")" << std::endl;
+      }
+
+      hTemplate->SetBinContent(bin_number, new_bin_content);
+      hTemplate->SetBinError(bin_number, new_bin_error);
     }
   }
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -96,7 +96,14 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	// Get some initial estimates for the fitter
 	double pedestal_estimate = 0;//(*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
 	double amplitude_estimate = 0;//(*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
-	double time_estimate = 0;
+	double time_estimate;
+	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
+	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
+	}
+	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
+	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMinimumBin();
+	}
+
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	
 	if (Debug()) {

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -83,24 +83,32 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
       if (n_pulse_candidates == 1) {
 
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
-	if (Debug() && hTemplate == NULL) { // for debugging, just print add one pulse to the template
+	if (hTemplate == NULL) { // for debugging, just print add one pulse to the template
 	  AddPulseToTemplate(hTemplate, *pulseIter);
+
+	  if (Debug()) {
+	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
+	  }
 	  continue;
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	double pedestal_estimate = 0;
-	double amplitude_estimate = 0;
-	double time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
+	double pedestal_estimate = 0;//(*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
+	double amplitude_estimate = 0;//(*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
+	double time_estimate = 0;
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	
+	if (Debug()) {
+	  std::cout << "TemplateCreator: " << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
+		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
+	}
+
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+
 	if (Debug()) {
-	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
-		    << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl
-	            << "Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
+	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
 	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
 	}
 
@@ -124,6 +132,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
+    // We will want to normalise to template to have pedestal=0 and amplitude=1
     // Save the template to the file
     fTemplateArchive->SaveTemplate(hTemplate);
   }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -89,10 +89,26 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
       // only continue if there is one pulse candidate on the TPI
       if (n_pulse_candidates == 1) {
 
+	std::vector<TPulseIsland*> pulse_candidates = pulse_candidate_finder->GetPulseCandidates();
+	TPulseIsland* pulse = pulse_candidates.at(0);
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) {
-	  AddPulseToTemplate(hTemplate, *pulseIter);
+	  AddPulseToTemplate(hTemplate, pulse);
 	  ++n_pulses_in_template;
+
+	  const std::vector<int>& theSamples = (pulse)->GetSamples();
+	  std::stringstream histname;
+	  histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
+	  TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
+
+	  double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
+	  for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+
+	    double uncorrected_value = (*sampleIter);
+	    
+	    hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
+	    hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
+	  }
 
 	  if (Debug()) {
 	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
@@ -106,9 +122,9 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	double template_amplitude;
 	double template_time;
 
-	double pulse_pedestal = (*pulseIter)->GetSamples().at(0);
-	double pulse_amplitude = (*pulseIter)->GetAmplitude();
-	double pulse_time = (*pulseIter)->GetPeakSample(); // between 0 and n_samples-1
+	double pulse_pedestal = (pulse)->GetSamples().at(0);
+	double pulse_amplitude = (pulse)->GetAmplitude();
+	double pulse_time = (pulse)->GetPeakSample(); // between 0 and n_samples-1
 
 	double pedestal_offset_estimate = template_pedestal - pulse_pedestal;
 	double amplitude_scale_factor_estimate;
@@ -138,7 +154,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 		    << ", time = " << time_offset_estimate << std::endl;
 	}
 
-	int fit_status = fTemplateFitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	int fit_status = fTemplateFitter->FitPulseToTemplate(hTemplate, pulse);
 	++n_fit_attempts;
 	if (fit_status != 0) {
 	  if (Debug()) {
@@ -156,7 +172,8 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	}
 
 	// Now add the fitted pulse to the template
-	if (n_pulses_in_template <= 40 || 
+
+	if (n_pulses_in_template <= 10 || 
 	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ) {
 	  std::stringstream newhistname;
 	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
@@ -164,7 +181,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	}
 
 	// Add the pulse to the template (we'll do the correcting there)
-	AddPulseToTemplate(hTemplate, *pulseIter);
+	AddPulseToTemplate(hTemplate, pulse);
 	++n_pulses_in_template;
 	double error_of_max_bin;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) {
@@ -178,9 +195,9 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	if (prob != 0) {
 	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
 	}
-
+	
 	// Create the corrected pulse
-	const std::vector<int>& theSamples = (*pulseIter)->GetSamples();
+	const std::vector<int>& theSamples = (pulse)->GetSamples();
 	std::stringstream histname;
 	histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
 	TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
@@ -191,15 +208,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
 	  double uncorrected_value = (*sampleIter);
-	  double corrected_value = uncorrected_value - fTemplateFitter->GetPedestalOffset();
-	  corrected_value /= fTemplateFitter->GetAmplitudeScaleFactor();
+	  double corrected_value = CorrectSampleValue(uncorrected_value);
 
 	  hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
 	  hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
 	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
 	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
 	}
-
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
@@ -359,8 +374,8 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
 
 double TemplateCreator::CorrectSampleValue(double old_value) {
 
-  double new_value = old_value - fTemplateFitter->GetPedestalOffset();
-  new_value /= fTemplateFitter->GetAmplitudeScaleFactor();
+  double new_value = old_value / fTemplateFitter->GetAmplitudeScaleFactor();
+  new_value -= fTemplateFitter->GetPedestalOffset();
 
   return new_value;
 }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -123,9 +123,17 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	// Loop through the samples and check for digitizer overflow
 	bool overflowed = false;
 	for (int i = 0; i < n_samples; ++i) {
-	  if (theSamples.at(i) >= max_adc_value-1 && theSamples.at(i) <= max_adc_value+1) {
+	  int sample_value = theSamples.at(i);
+	  if (sample_value >= max_adc_value-1 && sample_value <= max_adc_value+1) {
 	    if (Debug()) {
 	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " has overflowed the digitizer and won't be added to the template" << std::endl;
+	    }
+	    overflowed = true;
+	    break;
+	  }
+	  else if (sample_value == 0) {
+	    if (Debug()) {
+	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " has underflowed the digitizer and won't be added to the template" << std::endl;
 	    }
 	    overflowed = true;
 	    break;
@@ -157,7 +165,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	double pulse_amplitude;
 	double pulse_time;
 
-	double pedestal_offset_estimate = template_pedestal - pulse_pedestal;
+	double pedestal_offset_estimate = pulse_pedestal; // now we're dealing with actual pulses since we subtract the template_pedestal in the transformation
 	double amplitude_scale_factor_estimate;
 	double time_offset_estimate;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
@@ -408,7 +416,7 @@ bool TemplateCreator::CheckConvergence(TH1D* hTemplate, std::string bankname) {
     error = hTemplate->GetBinError(hTemplate->GetMaximumBin());
   }
   fErrorVsPulseAddedHistograms[detname]->Fill(n_pulses_in_template, error);
-  std::cout << detname << ": #" << n_pulses_in_template << ", Error = " << error << std::endl;
+  //  std::cout << detname << ": #" << n_pulses_in_template << ", Error = " << error << std::endl;
 
 }
 // The following macro registers this module to be useable in the config file.

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -10,6 +10,8 @@
 #include "utils/TemplateFitter.h"
 #include "ExportPulse.h"
 
+#include "TMath.h"
+
 #include <iostream>
 #include <sstream>
 using std::cout;
@@ -101,21 +103,21 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 
 	double pulse_pedestal = (*pulseIter)->GetSamples().at(0);
 	double pulse_amplitude = (*pulseIter)->GetAmplitude();
-	double pulse_time = (*pulseIter)->GetPeakSample();
+	double pulse_time = (*pulseIter)->GetPeakSample(); // between 0 and n_samples-1
 
-	double pedestal_offset_estimate = pulse_pedestal - template_pedestal;
+	double pedestal_offset_estimate = template_pedestal - pulse_pedestal;
 	double amplitude_scale_factor_estimate;
 	double time_offset_estimate;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
 	  template_amplitude = (hTemplate->GetMaximum() - template_pedestal);
-	  template_time = hTemplate->GetMaximumBin();
+	  template_time = hTemplate->GetMaximumBin() - 1; // go from bin numbering (1, n_samples) to clock ticks (0, n_samples-1)
 
 	  amplitude_scale_factor_estimate = pulse_amplitude / template_amplitude;  // estimated scale factor
 	  time_offset_estimate = pulse_time - template_time;
 	}
 	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
 	  template_amplitude = (template_pedestal - hTemplate->GetMinimum());
-	  template_time = hTemplate->GetMinimumBin();
+	  template_time = hTemplate->GetMinimumBin() - 1; // go from bin numbering (1, n_samples) to clock ticks (0, n_samples-1)
 
 	  amplitude_scale_factor_estimate = pulse_amplitude / template_amplitude;  // estimated scale factor
 	  time_offset_estimate = pulse_time - template_time;
@@ -139,7 +141,8 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 
 	if (Debug()) {
 	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
-	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
+	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << ", NDoF = " << template_fitter->GetNDoF() 
+		    << ", Prob = " << TMath::Prob(template_fitter->GetChi2(), template_fitter->GetNDoF()) << std::endl << std::endl;
 	}
 
 	// Create the corrected pulse

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -7,7 +7,6 @@
 #include "definitions.h"
 
 #include "SetupNavigator.h"
-#include "utils/TemplateFitter.h"
 #include "ExportPulse.h"
 
 #include "TMath.h"
@@ -63,7 +62,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
     PulseCandidateFinder* pulse_candidate_finder = new PulseCandidateFinder(detname, fOpts);
 
     // Create the TemplateFitter that we will use for this channel
-    TemplateFitter* template_fitter = new TemplateFitter(detname);
+    fTemplateFitter = new TemplateFitter(detname);
 
     // Get the TPIs
     thePulseIslands = it->second;
@@ -129,7 +128,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  time_offset_estimate = pulse_time - template_time;
 	}
 
-	template_fitter->SetInitialParameterEstimates(pedestal_offset_estimate, amplitude_scale_factor_estimate, time_offset_estimate);
+	fTemplateFitter->SetInitialParameterEstimates(pedestal_offset_estimate, amplitude_scale_factor_estimate, time_offset_estimate);
 	
 	if (Debug()) {
 	  std::cout << "TemplateCreator: " << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
@@ -139,21 +138,32 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 		    << ", time = " << time_offset_estimate << std::endl;
 	}
 
-	int fit_status = template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	int fit_status = fTemplateFitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	++n_fit_attempts;
 	if (fit_status != 0) {
+	  if (Debug()) {
+	    std::cout << "TemplateCreator: Problem with fit (status = " << fit_status << ")" << std::endl;
+	  }
 	  continue;
 	}
 	++n_successful_fits;
 	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 
 	if (Debug()) {
-	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
-	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << ", NDoF = " << template_fitter->GetNDoF() 
-		    << ", Prob = " << TMath::Prob(template_fitter->GetChi2(), template_fitter->GetNDoF()) << std::endl << std::endl;
+	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << fTemplateFitter->GetPedestalOffset() << ", AmpScaleFactor = " << fTemplateFitter->GetAmplitudeScaleFactor()
+	            << ", TimeOffset = " << fTemplateFitter->GetTimeOffset() << ", Chi2 = " << fTemplateFitter->GetChi2() << ", NDoF = " << fTemplateFitter->GetNDoF() 
+		    << ", Prob = " << TMath::Prob(fTemplateFitter->GetChi2(), fTemplateFitter->GetNDoF()) << std::endl << std::endl;
 	}
 
 	// Now add the fitted pulse to the template
+	if (n_pulses_in_template <= 40 || 
+	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ) {
+	  std::stringstream newhistname;
+	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
+	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
+	}
+
+	// Add the pulse to the template (we'll do the correcting there)
 	AddPulseToTemplate(hTemplate, *pulseIter);
 	++n_pulses_in_template;
 	double error_of_max_bin;
@@ -164,7 +174,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  error_of_max_bin = hTemplate->GetBinError(hTemplate->GetMinimumBin());
 	}
 	fErrorVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, error_of_max_bin);
-	double prob = TMath::Prob(template_fitter->GetChi2(), template_fitter->GetNDoF());
+	double prob = TMath::Prob(fTemplateFitter->GetChi2(), fTemplateFitter->GetNDoF());
 	if (prob != 0) {
 	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
 	}
@@ -181,13 +191,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
 	  double uncorrected_value = (*sampleIter);
-	  double corrected_value = uncorrected_value - template_fitter->GetPedestalOffset();
-	  corrected_value /= template_fitter->GetAmplitudeScaleFactor();
+	  double corrected_value = uncorrected_value - fTemplateFitter->GetPedestalOffset();
+	  corrected_value /= fTemplateFitter->GetAmplitudeScaleFactor();
 
 	  hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
 	  hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
-	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 - template_fitter->GetTimeOffset(), corrected_value); 
-	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset()+1, pedestal_error);
+	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
+	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
 	}
 
 	// we keep on adding pulses until adding pulses has no effect on the template
@@ -256,7 +266,7 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
     for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
       hTemplate->SetBinContent( sampleIter - theSamples.begin()+1, *sampleIter); // +1 because ROOT numbers bins from 1
-      hTemplate->SetBinError( sampleIter - theSamples.begin()+1, 5*pedestal_error);
+      hTemplate->SetBinError( sampleIter - theSamples.begin()+1, pedestal_error);
     }
 
     std::string error_histname = "hErrorVsPulseAdded_" + detname;
@@ -290,20 +300,29 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     if (Debug()) {
       std::cout << "AddPulseToTemplate(): n_pulses = " << n_pulses << std::endl;
     }
+
+    // Loop through the pulse samples
     for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
-      int bin_number = sampleIter - theSamples.begin() + 1; // +1 because ROOT numbers bins from 1
+      double corrected_value = CorrectSampleValue(*sampleIter);
+
+      int bin_number = sampleIter - theSamples.begin() + 1 + 0.5 - fTemplateFitter->GetTimeOffset(); // +1 because ROOT numbers bins from 1, +0.5 to round to the nearest integer and subtract time offset because this value might not want to go direct into the template
+
+      if (bin_number < 1 || bin_number > hTemplate->GetNbinsX()) {
+	continue;
+      }
       double old_bin_content = hTemplate->GetBinContent(bin_number);
       double old_bin_error = hTemplate->GetBinError(bin_number);
 
-      double new_bin_content = n_pulses * old_bin_content + *sampleIter;
+      double new_bin_content = n_pulses * old_bin_content + corrected_value;
       new_bin_content /= (n_pulses + 1);
 
-      double new_bin_error = ((n_pulses - 1)*old_bin_error*old_bin_error) + (*sampleIter - old_bin_content)*(*sampleIter - new_bin_content);
+      double new_bin_error = ((n_pulses - 1)*old_bin_error*old_bin_error) + (corrected_value - old_bin_content)*(corrected_value - new_bin_content);
       new_bin_error = std::sqrt(new_bin_error / n_pulses);
 
       if (Debug()) {
-	std::cout << "TemplateCreator::AddPulseToTemplate(): Bin #" << bin_number << ": Old Value (Error) = " << old_bin_content << "(" << old_bin_error << ")" << std::endl
+	std::cout << "TemplateCreator::AddPulseToTemplate(): Bin #" << bin_number << ": Corrected Sample Value = " << corrected_value << std::endl
+		  << "\t\t\tOld Value (Error) = " << old_bin_content << "(" << old_bin_error << ")" << std::endl
 		  << "\t\t\tNew Value (Error) = " << new_bin_content << "(" << new_bin_error << ")" << std::endl;
       }
 
@@ -335,6 +354,14 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     hTemplate->SetBinContent( iBin, value_to_fill);
   }
   */
+}
+
+double TemplateCreator::CorrectSampleValue(double old_value) {
+
+  double new_value = old_value - fTemplateFitter->GetPedestalOffset();
+  new_value /= fTemplateFitter->GetAmplitudeScaleFactor();
+
+  return new_value;
 }
 
 // The following macro registers this module to be useable in the config file.

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -97,7 +97,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	*/
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
-	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {
 	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
 	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -253,17 +253,14 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData, const TSetupData* setup)
 
   StringPulseIslandMap::const_iterator it;
 
-  if (Debug()) {
-
-    // Print to stdout the percentage of successful fit for each channel
-    for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
-      std::string bankname = it->first;
-      std::string detname = setup->GetDetectorName(bankname);
-
-      int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
-      int& n_successful_fits = fNSuccessfulFits[detname];
-      std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
-    }
+  // Print to stdout the percentage of successful fit for each channel
+  for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
+    std::string bankname = it->first;
+    std::string detname = setup->GetDetectorName(bankname);
+    
+    int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
+    int& n_successful_fits = fNSuccessfulFits[detname];
+    std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
   }
 
   // Clean up the template archive
@@ -277,23 +274,6 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData, const TSetupData* setup)
 void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, TH1D* & hPulse, std::string bankname) {
 
   std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
-
-  /*
-    // Create some histograms that monitor the progression of the template
-    std::string error_histname = "hErrorVsPulseAdded_" + detname;
-    std::string error_histtitle = "Plot of the Error as each new Pulse is added to the template for the " + detname + " channel";
-    int n_bins = 1000000;
-    TH1D* error_hist = new TH1D(error_histname.c_str(), error_histtitle.c_str(), n_bins,0,n_bins);
-
-    double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-    error_hist->Fill(1, pedestal_error);
-    fErrorVsPulseAddedHistograms[detname] = error_hist;
-
-    std::string prob_histname = "hProbVsPulseAdded_" + detname;
-    std::string prob_histtitle = "Plot of the Prob as each new Pulse is added to the template for the " + detname + " channel";
-    TH1D* prob_hist = new TH1D(prob_histname.c_str(), prob_histtitle.c_str(), n_bins,0,n_bins);
-    fProbVsPulseAddedHistograms[detname] = prob_hist;
-  */
 
   int n_pulses = fNPulsesInTemplate.at(detname);
   if (Debug()) {

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -220,22 +220,21 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	// Create the corrected pulse
 	std::stringstream histname;
 	histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
-	TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
+	TH1D* hUncorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
 	histname << "_Corrected";
-	TH1D* hCorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
+	TH1D* hCorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
 
 	double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+	for (int iPulseBin = 1; iPulseBin <= hPulseToFit->GetNbinsX(); ++iPulseBin) {
+	  //std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
-	  double uncorrected_value = (*sampleIter);
+	  double uncorrected_value = hPulseToFit->GetBinContent(iPulseBin);
 	  double corrected_value = CorrectSampleValue(uncorrected_value, template_pedestal);
 
-	  hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
-	  hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
-	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
-	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
+	  hCorrectedPulse->SetBinContent(iPulseBin +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
+	  hCorrectedPulse->SetBinError(iPulseBin +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
 	}
-
+	delete hPulseToFit;
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -84,17 +84,17 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (Debug() && hTemplate == NULL) { // for debugging, just print add one pulse to the template
 	  AddPulseToTemplate(hTemplate, *pulseIter);
-	  //	  continue;
+	  continue;
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
-	//	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
-	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
-	//	if (Debug()) {
-	//	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
-	//	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()
-	//	            << ", Time = " << template_fitter->GetTime() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
-	//	}
+	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+	if (Debug()) {
+	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
+	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()
+	            << ", Time = " << template_fitter->GetTime() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
+	}
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
@@ -141,11 +141,11 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string histname = "hTemplate_" + detname;
     std::string histtitle = "Template Histogram for the " + detname + " channel";
 
-    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), refine_factor*n_samples, 0, n_samples);
+    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_samples, 0, n_samples);
   }
 
   // Now loop through the samples and add to the template
-  for (int iBin = 0; iBin < refine_factor*n_samples; ++iBin) {
+  /*  for (int iBin = 0; iBin < refine_factor*n_samples; ++iBin) {
 
     int sample_element = iBin / refine_factor;
     double value_to_fill = 0;
@@ -165,6 +165,11 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     }
     //    std::cout << "Bin#" << iBin << ": " << value_to_fill << std::endl;
     hTemplate->SetBinContent( iBin, value_to_fill);
+  }
+  */
+
+  for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+    hTemplate->Fill( sampleIter - theSamples.begin(), *sampleIter);
   }
 }
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -89,12 +89,12 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	double pedestal_estimate = TSetupData::Instance()->GetPedestal(bankname);
+	/*	double pedestal_estimate = TSetupData::Instance()->GetPedestal(bankname);
 	double amplitude_estimate = (*pulseIter)->GetAmplitude();
 	double time_estimate = (*pulseIter)->GetPeakSample();
 	std::cout << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
-
+	*/
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -96,22 +96,37 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
 	double template_pedestal = hTemplate->GetBinContent(1);
-	double pedestal_offset_estimate = (*pulseIter)->GetSamples().at(0) - template_pedestal;
+	double template_amplitude;
+	double template_time;
+
+	double pulse_pedestal = (*pulseIter)->GetSamples().at(0);
+	double pulse_amplitude = (*pulseIter)->GetAmplitude();
+	double pulse_time = (*pulseIter)->GetPeakSample();
+
+	double pedestal_offset_estimate = pulse_pedestal - template_pedestal;
 	double amplitude_scale_factor_estimate;
 	double time_offset_estimate;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
-	  amplitude_scale_factor_estimate = (*pulseIter)->GetAmplitude() / (hTemplate->GetMaximum() - template_pedestal); // estimated scale factor
-	  time_offset_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
+	  template_amplitude = (hTemplate->GetMaximum() - template_pedestal);
+	  template_time = hTemplate->GetMaximumBin();
+
+	  amplitude_scale_factor_estimate = pulse_amplitude / template_amplitude;  // estimated scale factor
+	  time_offset_estimate = pulse_time - template_time;
 	}
 	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
-	  amplitude_scale_factor_estimate = (*pulseIter)->GetAmplitude() / (template_pedestal - hTemplate->GetMinimum()); // estimated scale factor
-	  time_offset_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMinimumBin();
+	  template_amplitude = (template_pedestal - hTemplate->GetMinimum());
+	  template_time = hTemplate->GetMinimumBin();
+
+	  amplitude_scale_factor_estimate = pulse_amplitude / template_amplitude;  // estimated scale factor
+	  time_offset_estimate = pulse_time - template_time;
 	}
 
 	template_fitter->SetInitialParameterEstimates(pedestal_offset_estimate, amplitude_scale_factor_estimate, time_offset_estimate);
 	
 	if (Debug()) {
 	  std::cout << "TemplateCreator: " << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
+		    << "TemplateCreator: Template: pedestal = " << template_pedestal << ", amplitude = " << template_amplitude << ", time = " << template_time << std::endl
+		    << "TemplateCreator: Pulse: pedestal = " << pulse_pedestal << ", amplitude = " << pulse_amplitude << ", time = " << pulse_time << std::endl
 		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_offset_estimate << ", amplitude = " << amplitude_scale_factor_estimate 
 		    << ", time = " << time_offset_estimate << std::endl;
 	}
@@ -142,10 +157,10 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  double corrected_value = uncorrected_value - template_fitter->GetPedestalOffset();
 	  corrected_value /= template_fitter->GetAmplitudeScaleFactor();
 
-	  hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin(), uncorrected_value);
-	  hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin(), pedestal_error);
-	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset(), corrected_value);
-	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin(), pedestal_error);
+	  hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
+	  hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
+	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 - template_fitter->GetTimeOffset(), corrected_value); 
+	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset()+1, pedestal_error);
 	}
 	// we keep on adding pulses until adding pulses has no effect on the template
       }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -114,7 +114,10 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
 	}
 
-	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	int fit_status = template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	if (fit_status != 0) {
+	  continue;
+	}
 	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 
 	if (Debug()) {
@@ -194,8 +197,8 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     // Add the first pulse and the correct initial errors
     double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
     for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-      hTemplate->SetBinContent( sampleIter - theSamples.begin(), *sampleIter);
-      hTemplate->SetBinError( sampleIter - theSamples.begin(), pedestal_error);
+      hTemplate->SetBinContent( sampleIter - theSamples.begin()+1, *sampleIter); // +1 because ROOT numbers bins from 1
+      hTemplate->SetBinError( sampleIter - theSamples.begin()+1, pedestal_error);
     }
   }
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -86,8 +86,6 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
       pulse_candidate_finder->FindPulseCandidates(*pulseIter);
       int n_pulse_candidates = pulse_candidate_finder->GetNPulseCandidates();
 
-      std::vector<TPulseIsland*> pulse_candidates = pulse_candidate_finder->GetPulseCandidates();
-
       // only continue if there is one pulse candidate on the TPI
       if (n_pulse_candidates == 1) {
 
@@ -116,13 +114,18 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	double max_adc_value = std::pow(2, n_bits);
 
 	// Loop through the samples and check for digitizer overflow
+	bool overflowed = false;
 	for (int i = 0; i < n_samples; ++i) {
 	  if (theSamples.at(i) >= max_adc_value-1 && theSamples.at(i) <= max_adc_value+1) {
 	    if (Debug()) {
 	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " has overflowed the digitizer and won't be added to the template" << std::endl;
 	    }
-	    continue;
+	    overflowed = true;
+	    break;
 	  }
+	}
+	if (overflowed) {
+	  continue; // skip this pulse
 	}
 
 	// Create the refined pulse waveform

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -72,7 +72,10 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
     // Try and get the template (it may have been created in a previous event)
     std::string template_name = "hTemplate_" + detname;
-    TH1D* hTemplate = fTemplateArchive->GetTemplate(template_name.c_str());
+    TH1D* hTemplate = NULL;
+    if (fTemplates.find(detname) != fTemplates.end()) {
+      hTemplate = fTemplates[detname];
+    }
 
     // Store a couple of numbers to get an idea of how many successful fits there are
     int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
@@ -109,6 +112,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  if (Debug()) {
 	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
 	  }
+	  fTemplates[detname] = hTemplate;
 	  continue;
 	}
 
@@ -263,8 +267,6 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
       }
     }
     // We will want to normalise to template to have pedestal=0 and amplitude=1
-    // Save the template to the file
-    fTemplateArchive->SaveTemplate(hTemplate);
   }
 
   return 0;
@@ -290,6 +292,9 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData, const TSetupData* setup)
     int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
     int& n_successful_fits = fNSuccessfulFits[detname];
     std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
+
+    // Save the template to the file
+    fTemplateArchive->SaveTemplate(fTemplates[detname]);
   }
 
   // Clean up the template archive

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -90,12 +90,12 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	double pedestal_estimate = TSetupData::Instance()->GetPedestal(bankname);
+	/*	double pedestal_estimate = TSetupData::Instance()->GetPedestal(bankname);
 	double amplitude_estimate = (*pulseIter)->GetAmplitude();
 	double time_estimate = (*pulseIter)->GetPeakSample();
 	std::cout << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
-
+	*/
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -85,22 +85,30 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) { // for debugging, just print add one pulse to the template
 	  AddPulseToTemplate(hTemplate, *pulseIter);
+
+	  if (Debug()) {
+	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
+	  }
 	  continue;
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	double pedestal_estimate = 0;
-	double amplitude_estimate = 0;
-	double time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
+	double pedestal_estimate = 0;//(*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
+	double amplitude_estimate = 0;//(*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
+	double time_estimate = 0;
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	
+	if (Debug()) {
+	  std::cout << "TemplateCreator: " << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
+		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
+	}
+
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+
 	if (Debug()) {
-	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
-		    << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl
-	            << "Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
+	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
 	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
 	}
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -85,22 +85,30 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) { // for debugging, just print add one pulse to the template
 	  AddPulseToTemplate(hTemplate, *pulseIter);
+
+	  if (Debug()) {
+	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
+	  }
 	  continue;
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	double pedestal_estimate = 0;
-	double amplitude_estimate = 0;
-	double time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
+	double pedestal_estimate = 0;//(*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
+	double amplitude_estimate = 0;//(*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
+	double time_estimate = 0;
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	
+	if (Debug()) {
+	  std::cout << "TemplateCreator: " << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
+		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
+	}
+
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+
 	if (Debug()) {
-	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
-		    << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl
-	            << "Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
+	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
 	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
 	}
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -54,7 +54,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
   // Loop over each detector
   for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
-    
+
     // Get the bank and detector names for this detector
     bankname = it->first;
     detname = setup->GetDetectorName(bankname);
@@ -72,6 +72,10 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
     // Try and get the template (it may have been created in a previous event)
     std::string template_name = "hTemplate_" + detname;
     TH1D* hTemplate = fTemplateArchive->GetTemplate(template_name.c_str());
+
+    // Store a couple of numbers to get an idea of how many successful fits there are
+    int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
+    int& n_successful_fits = fNSuccessfulFits[detname];
 
     // Loop through all the pulses
     for (PulseIslandList::iterator pulseIter = thePulseIslands.begin(); pulseIter != thePulseIslands.end(); ++pulseIter) {
@@ -134,9 +138,11 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	}
 
 	int fit_status = template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	++n_fit_attempts;
 	if (fit_status != 0) {
 	  continue;
 	}
+	++n_successful_fits;
 	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 
 	if (Debug()) {
@@ -145,7 +151,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 		    << ", Prob = " << TMath::Prob(template_fitter->GetChi2(), template_fitter->GetNDoF()) << std::endl << std::endl;
 	}
 
-	// Create the corrected pulse
+	/*	// Create the corrected pulse
 	const std::vector<int>& theSamples = (*pulseIter)->GetSamples();
 	std::stringstream histname;
 	histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
@@ -165,6 +171,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 - template_fitter->GetTimeOffset(), corrected_value); 
 	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset()+1, pedestal_error);
 	}
+	*/
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
@@ -184,6 +191,18 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData, const TSetupData* setup)
   // Print extra info if we're debugging this module:
   if(Debug()){
      cout<<"-----I'm debugging TemplateCreator::AfterLastEntry()"<<endl;
+  }
+
+  StringPulseIslandMap::const_iterator it;
+
+  // Loop over each detector
+  for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
+    std::string bankname = it->first;
+    std::string detname = setup->GetDetectorName(bankname);
+
+    int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
+    int& n_successful_fits = fNSuccessfulFits[detname];
+    std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
   }
 
   // Clean up the template archive

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -184,8 +184,8 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
 	}
 */
-	// Add the pulse to the template (we'll do the correcting there)
-	/*	AddPulseToTemplate(hTemplate, pulse);
+/*	// Add the pulse to the template (we'll do the correcting there)
+	AddPulseToTemplate(hTemplate, pulse);
 	++n_pulses_in_template;
 	double error_of_max_bin;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) {
@@ -198,7 +198,8 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	double prob = TMath::Prob(fTemplateFitter->GetChi2(), fTemplateFitter->GetNDoF());
 	if (prob != 0) {
 	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
-	  }*/
+	}
+*/
 /*	
 	// Create the corrected pulse
 	const std::vector<int>& theSamples = (pulse)->GetSamples();
@@ -272,7 +273,6 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
 
   // Wnat to increase the bin resolution (this may become a module option at some point)
   int refine_factor = 5;
-  int n_bins = refine_factor*n_samples; // number of bins in the template
 
   // If the template histogram is NULL, then create it
   if (hTemplate == NULL) {
@@ -281,31 +281,16 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string histname = "hTemplate_" + detname;
     std::string histtitle = "Template Histogram for the " + detname + " channel";
 
-    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_bins, 0, n_samples);
+    // Create a refined pulse histogram from the first pulse we are given
+    hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), refine_factor);
 
-    // Add the first pulse and the correct initial errors
-    double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-    for (int i = 0; i < n_bins; ++i) {
-      int bin = i+1; // bins go from 1 to n rather than 0 to n-1
-      int sample_number = i / refine_factor;
-      double remainder = i % refine_factor;
-      double sample_value;
-      try {
-	sample_value = theSamples.at(sample_number) + (remainder / refine_factor)*(theSamples.at(sample_number+1) - theSamples.at(sample_number));
-      }
-      catch (const std::out_of_range& oor) { // if we'll be going out of range of the samples vector
-	sample_value = theSamples.at(sample_number);
-      }
-
-      std::cout << "i: " << i << ", Bin: " << bin << ", Sample Number: " << sample_number << ", Sample Value: " << sample_value << std::endl;
-      hTemplate->SetBinContent( bin, sample_value);
-      hTemplate->SetBinError( bin, pedestal_error);
-    }
-
+    // Create some histograms that monitor the progression of the template
     std::string error_histname = "hErrorVsPulseAdded_" + detname;
     std::string error_histtitle = "Plot of the Error as each new Pulse is added to the template for the " + detname + " channel";
     int n_bins = 1000000;
     TH1D* error_hist = new TH1D(error_histname.c_str(), error_histtitle.c_str(), n_bins,0,n_bins);
+
+    double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
     error_hist->Fill(1, pedestal_error);
     fErrorVsPulseAddedHistograms[detname] = error_hist;
 
@@ -316,19 +301,6 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
   }
 
   else { // add subsequent pulses
-    /*    double x, x_old;
-    double e, e_old;
-    for (int i = 0; i < fNBins; ++i) {
-      x_old = fTemplate->GetBinContent(i+1);
-      e_old = fTemplate->GetBinError(i+1);
-      x = (double)fNPulses * x_old + reshaped_pulse[i];
-      x /= (double)(fNPulses + 1);
-      e = (double)(fNPulses - 1) * std::pow(e_old, 2.) + ((double)reshaped_pulse[i] - x_old) * ((double)reshaped_pulse[i] - x);
-      e = std::sqrt(e / fNPulses);
-      fTemplate->SetBinContent(i+1, x);
-      fTemplate->SetBinError(i+1, e);
-    }
-    */
     int n_pulses = fNPulsesInTemplate.at(detname);
     if (Debug()) {
       std::cout << "AddPulseToTemplate(): n_pulses = " << n_pulses << std::endl;
@@ -365,30 +337,6 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
       hTemplate->SetBinError(bin_number, new_bin_error);
     }
   }
-
-  // Now loop through the samples and add to the template
-  /*  for (int iBin = 0; iBin < refine_factor*n_samples; ++iBin) {
-
-    int sample_element = iBin / refine_factor;
-    double value_to_fill = 0;
-
-    if (sample_element != theSamples.size()-1) { // if this element is not going to be outside of the samples vector
-      int iSubBin = iBin % refine_factor;
-      
-      int this_sample = theSamples.at(sample_element);
-      int next_sample = theSamples.at(sample_element+1);
-      double sample_difference = next_sample - this_sample;
-      
-      double interpolated_value = this_sample + iSubBin*(sample_difference / refine_factor);
-      value_to_fill = interpolated_value;
-    }
-    else {
-      value_to_fill = theSamples.at(sample_element);
-    }
-    //    std::cout << "Bin#" << iBin << ": " << value_to_fill << std::endl;
-    hTemplate->SetBinContent( iBin, value_to_fill);
-  }
-  */
 }
 
 double TemplateCreator::CorrectSampleValue(double old_value, double template_pedestal) {
@@ -404,6 +352,36 @@ double TemplateCreator::CorrectSampleValue(double old_value, double template_ped
   return new_value;
 }
 
+// Creates a histogram with sub-bin resolution
+TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, int refine_factor) {
+
+  std::string bankname = pulse->GetBankName();
+  const std::vector<int>& theSamples = pulse->GetSamples();
+  int n_samples = theSamples.size();
+  int n_bins = refine_factor*n_samples; // number of bins in the template
+
+  TH1D* hist = new TH1D(histname.c_str(), histtitle.c_str(), n_bins, 0, n_samples);
+
+  double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
+  for (int i = 0; i < n_bins; ++i) {
+    int bin = i+1; // bins go from 1 to n rather than 0 to n-1
+    int sample_number = i / refine_factor;
+    double remainder = i % refine_factor;
+    double sample_value;
+    try {
+      sample_value = theSamples.at(sample_number) + (remainder / refine_factor)*(theSamples.at(sample_number+1) - theSamples.at(sample_number));
+    }
+    catch (const std::out_of_range& oor) { // if we'll be going out of range of the samples vector
+      sample_value = theSamples.at(sample_number);
+    }
+    
+    std::cout << "i: " << i << ", Bin: " << bin << ", Sample Number: " << sample_number << ", Sample Value: " << sample_value << std::endl;
+    hist->SetBinContent( bin, sample_value);
+    hist->SetBinError( bin, pedestal_error);
+  }
+
+  return hist;
+}
 // The following macro registers this module to be useable in the config file.
 // The first argument is compulsory and gives the name of this module
 // All subsequent arguments will be used as names for arguments given directly 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -95,23 +95,25 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	double pedestal_estimate = (*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
-	double amplitude_estimate;
-	double time_estimate;
+	double template_pedestal = hTemplate->GetBinContent(1);
+	double pedestal_offset_estimate = (*pulseIter)->GetSamples().at(0) - template_pedestal;
+	double amplitude_scale_factor_estimate;
+	double time_offset_estimate;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
-	  amplitude_estimate = (*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
-	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
+	  amplitude_scale_factor_estimate = (*pulseIter)->GetAmplitude() / (hTemplate->GetMaximum() - template_pedestal); // estimated scale factor
+	  time_offset_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
 	}
 	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
-	  amplitude_estimate = (*pulseIter)->GetAmplitude() / hTemplate->GetMinimum(); // estimated scale factor
-	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMinimumBin();
+	  amplitude_scale_factor_estimate = (*pulseIter)->GetAmplitude() / (template_pedestal - hTemplate->GetMinimum()); // estimated scale factor
+	  time_offset_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMinimumBin();
 	}
 
-	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
+	template_fitter->SetInitialParameterEstimates(pedestal_offset_estimate, amplitude_scale_factor_estimate, time_offset_estimate);
 	
 	if (Debug()) {
 	  std::cout << "TemplateCreator: " << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
-		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
+		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_offset_estimate << ", amplitude = " << amplitude_scale_factor_estimate 
+		    << ", time = " << time_offset_estimate << std::endl;
 	}
 
 	int fit_status = template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -16,6 +16,8 @@
 using std::cout;
 using std::endl;
 
+extern Long64_t* gEntryNumber;
+
 TemplateCreator::TemplateCreator(modules::options* opts):
   BaseModule("TemplateCreator",opts), fOpts(opts){
 
@@ -98,7 +100,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	  const std::vector<int>& theSamples = (pulse)->GetSamples();
 	  std::stringstream histname;
-	  histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
+	  histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
 	  TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
 
 	  double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
@@ -175,7 +177,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	if (n_pulses_in_template <= 10 || 
 	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ||
-	    (n_pulses_in_template <= 1000 && n_pulses_in_template%100 == 0) ) {
+	    (n_pulses_in_template%100 == 0) ) {
 	  std::stringstream newhistname;
 	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
 	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
@@ -200,7 +202,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	// Create the corrected pulse
 	const std::vector<int>& theSamples = (pulse)->GetSamples();
 	std::stringstream histname;
-	histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
+	histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
 	TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
 	histname << "_Corrected";
 	TH1D* hCorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
@@ -376,9 +378,13 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
 
 double TemplateCreator::CorrectSampleValue(double old_value, double template_pedestal) {
 
+  //  std::cout << "TemplateCreator::CorrectSampleValue():\nold value = " << old_value << std::endl;
   double new_value = old_value / fTemplateFitter->GetAmplitudeScaleFactor();
+  //  std::cout << "/ AmpSF:  / " << fTemplateFitter->GetAmplitudeScaleFactor() << " = " << new_value << std::endl;
   new_value -= fTemplateFitter->GetPedestalOffset();
+  //  std::cout << "- PedOffset: - " << fTemplateFitter->GetPedestalOffset() << " = " << new_value << std::endl;
   new_value += template_pedestal;
+  //  std::cout << "+ TemplatePed: + " << template_pedestal << " = " << new_value << std::endl;
 
   return new_value;
 }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 using std::cout;
 using std::endl;
 
@@ -287,7 +288,15 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     for (int i = 0; i < n_bins; ++i) {
       int bin = i+1; // bins go from 1 to n rather than 0 to n-1
       int sample_number = i / refine_factor;
-      double sample_value = theSamples.at(sample_number);
+      double remainder = i % refine_factor;
+      double sample_value;
+      try {
+	sample_value = theSamples.at(sample_number) + (remainder / refine_factor)*(theSamples.at(sample_number+1) - theSamples.at(sample_number));
+      }
+      catch (const std::out_of_range& oor) { // if we'll be going out of range of the samples vector
+	sample_value = theSamples.at(sample_number);
+      }
+
       std::cout << "i: " << i << ", Bin: " << bin << ", Sample Number: " << sample_number << ", Sample Value: " << sample_value << std::endl;
       hTemplate->SetBinContent( bin, sample_value);
       hTemplate->SetBinError( bin, pedestal_error);

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -96,6 +96,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  std::string histname = "hTemplate_" + detname;
 	  std::string histtitle = "Template Histogram for the " + detname + " channel";
 
+	  int pulse_length = pulse->GetSamples().size();
+	  if (pulse->GetPeakSample() >= pulse_length - pulse_length/5.0) {
+	    if (Debug()) {
+	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " is too close to one end of the island and so won't be used as the first pulse in the template." << std::endl;
+	    }
+	    continue;
+	  }
 	  hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), true);
 	  ++n_pulses_in_template;
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -253,17 +253,14 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData,TSetupData *setup){
 
   StringPulseIslandMap::const_iterator it;
 
-  if (Debug()) {
-
-    // Print to stdout the percentage of successful fit for each channel
-    for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
-      std::string bankname = it->first;
-      std::string detname = setup->GetDetectorName(bankname);
-
-      int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
-      int& n_successful_fits = fNSuccessfulFits[detname];
-      std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
-    }
+  // Print to stdout the percentage of successful fit for each channel
+  for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
+    std::string bankname = it->first;
+    std::string detname = setup->GetDetectorName(bankname);
+    
+    int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
+    int& n_successful_fits = fNSuccessfulFits[detname];
+    std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
   }
 
   // Clean up the template archive
@@ -277,23 +274,6 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData,TSetupData *setup){
 void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, TH1D* & hPulse, std::string bankname) {
 
   std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
-
-  /*
-    // Create some histograms that monitor the progression of the template
-    std::string error_histname = "hErrorVsPulseAdded_" + detname;
-    std::string error_histtitle = "Plot of the Error as each new Pulse is added to the template for the " + detname + " channel";
-    int n_bins = 1000000;
-    TH1D* error_hist = new TH1D(error_histname.c_str(), error_histtitle.c_str(), n_bins,0,n_bins);
-
-    double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-    error_hist->Fill(1, pedestal_error);
-    fErrorVsPulseAddedHistograms[detname] = error_hist;
-
-    std::string prob_histname = "hProbVsPulseAdded_" + detname;
-    std::string prob_histtitle = "Plot of the Prob as each new Pulse is added to the template for the " + detname + " channel";
-    TH1D* prob_hist = new TH1D(prob_histname.c_str(), prob_histtitle.c_str(), n_bins,0,n_bins);
-    fProbVsPulseAddedHistograms[detname] = prob_hist;
-  */
 
   int n_pulses = fNPulsesInTemplate.at(detname);
   if (Debug()) {

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -114,7 +114,10 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
 	}
 
-	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	int fit_status = template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	if (fit_status != 0) {
+	  continue;
+	}
 	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 
 	if (Debug()) {
@@ -194,8 +197,8 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     // Add the first pulse and the correct initial errors
     double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
     for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-      hTemplate->SetBinContent( sampleIter - theSamples.begin(), *sampleIter);
-      hTemplate->SetBinError( sampleIter - theSamples.begin(), pedestal_error);
+      hTemplate->SetBinContent( sampleIter - theSamples.begin()+1, *sampleIter); // +1 because ROOT numbers bins from 1
+      hTemplate->SetBinError( sampleIter - theSamples.begin()+1, pedestal_error);
     }
   }
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -184,7 +184,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	}
 */
 	// Add the pulse to the template (we'll do the correcting there)
-	AddPulseToTemplate(hTemplate, pulse);
+	/*	AddPulseToTemplate(hTemplate, pulse);
 	++n_pulses_in_template;
 	double error_of_max_bin;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) {
@@ -197,7 +197,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	double prob = TMath::Prob(fTemplateFitter->GetChi2(), fTemplateFitter->GetNDoF());
 	if (prob != 0) {
 	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
-	}
+	  }*/
 /*	
 	// Create the corrected pulse
 	const std::vector<int>& theSamples = (pulse)->GetSamples();
@@ -271,6 +271,7 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
 
   // Wnat to increase the bin resolution (this may become a module option at some point)
   int refine_factor = 5;
+  int n_bins = refine_factor*n_samples; // number of bins in the template
 
   // If the template histogram is NULL, then create it
   if (hTemplate == NULL) {
@@ -279,13 +280,17 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string histname = "hTemplate_" + detname;
     std::string histtitle = "Template Histogram for the " + detname + " channel";
 
-    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_samples, 0, n_samples);
+    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_bins, 0, n_samples);
 
     // Add the first pulse and the correct initial errors
     double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-    for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-      hTemplate->SetBinContent( sampleIter - theSamples.begin()+1, *sampleIter); // +1 because ROOT numbers bins from 1
-      hTemplate->SetBinError( sampleIter - theSamples.begin()+1, pedestal_error);
+    for (int i = 0; i < n_bins; ++i) {
+      int bin = i+1; // bins go from 1 to n rather than 0 to n-1
+      int sample_number = i / refine_factor;
+      double sample_value = theSamples.at(sample_number);
+      std::cout << "i: " << i << ", Bin: " << bin << ", Sample Number: " << sample_number << ", Sample Value: " << sample_value << std::endl;
+      hTemplate->SetBinContent( bin, sample_value);
+      hTemplate->SetBinError( bin, pedestal_error);
     }
 
     std::string error_histname = "hErrorVsPulseAdded_" + detname;

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -341,13 +341,9 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, TH1D* & hPulse, std:
 
 double TemplateCreator::CorrectSampleValue(double old_value, double template_pedestal) {
 
-  //  std::cout << "TemplateCreator::CorrectSampleValue():\nold value = " << old_value << std::endl;
-  double new_value = old_value / fTemplateFitter->GetAmplitudeScaleFactor();
-  //  std::cout << "/ AmpSF:  / " << fTemplateFitter->GetAmplitudeScaleFactor() << " = " << new_value << std::endl;
-  new_value -= fTemplateFitter->GetPedestalOffset();
-  //  std::cout << "- PedOffset: - " << fTemplateFitter->GetPedestalOffset() << " = " << new_value << std::endl;
+  double new_value = old_value - fTemplateFitter->GetPedestalOffset();
+  new_value /= fTemplateFitter->GetAmplitudeScaleFactor();
   new_value += template_pedestal;
-  //  std::cout << "+ TemplatePed: + " << template_pedestal << " = " << new_value << std::endl;
 
   return new_value;
 }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -89,8 +89,8 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
       // only continue if there is one pulse candidate on the TPI
       if (n_pulse_candidates == 1) {
 
-	std::vector<TPulseIsland*> pulse_candidates = pulse_candidate_finder->GetPulseCandidates();
-	TPulseIsland* pulse = pulse_candidates.at(0);
+	TPulseIsland* pulse = *pulseIter;
+
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) {
 	  AddPulseToTemplate(hTemplate, pulse);

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -128,6 +128,15 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	// Create the refined pulse waveform
 	TH1D* hPulseToFit = CreateRefinedPulseHistogram(pulse, "hPulseToFit", "hPulseToFit", false);
 
+	// Create some histograms that monitor the progression of the template
+	if (fErrorVsPulseAddedHistograms.find(detname) == fErrorVsPulseAddedHistograms.end()) {
+	  std::string error_histname = "hErrorVsPulseAdded_" + detname;
+	  std::string error_histtitle = "Plot of the Error as each new Pulse is added to the template for the " + detname + " channel";
+	  int n_bins = 10000;
+	  TH1D* error_hist = new TH1D(error_histname.c_str(), error_histtitle.c_str(), n_bins,0,n_bins);
+	  fErrorVsPulseAddedHistograms[detname] = error_hist;
+	}
+
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
 	double template_pedestal = hTemplate->GetBinContent(1);
@@ -178,6 +187,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	  if (Debug()) {
 	    std::cout << "TemplateCreator: Problem with fit (status = " << fit_status << ")" << std::endl;
 	  }
+	  delete hPulseToFit; // delete this here since it is no longer needed
 	  continue;
 	}
 	++n_successful_fits;
@@ -209,7 +219,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	  // Create the histograms that we will use to plot the corrected and uncorrected pulses
 	  std::stringstream histname;
-	  histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
+	  histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin() << "_" << n_pulses_in_template << "Added";
 	  TH1D* hUncorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
 	  histname << "_Corrected";
 	  TH1D* hCorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
@@ -231,6 +241,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	delete hPulseToFit;
 
 	// we keep on adding pulses until adding pulses has no effect on the template
+	bool converged = CheckConvergence(hTemplate, bankname);
       }
     }
     // We will want to normalise to template to have pedestal=0 and amplitude=1
@@ -371,6 +382,24 @@ TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, st
   }
 
   return hist;
+}
+
+
+bool TemplateCreator::CheckConvergence(TH1D* hTemplate, std::string bankname) {
+
+  std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
+  int n_pulses_in_template = fNPulsesInTemplate[detname];
+  int trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+  double error = 0;
+  if (trigger_polarity == -1) {
+    error = hTemplate->GetBinError(hTemplate->GetMinimumBin());
+  }
+  else if (trigger_polarity == 1) {
+    error = hTemplate->GetBinError(hTemplate->GetMaximumBin());
+  }
+  fErrorVsPulseAddedHistograms[detname]->Fill(n_pulses_in_template, error);
+  std::cout << detname << ": #" << n_pulses_in_template << ", Error = " << error << std::endl;
+
 }
 // The following macro registers this module to be useable in the config file.
 // The first argument is compulsory and gives the name of this module

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -96,7 +96,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	*/
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
-	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {
 	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
 	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -86,8 +86,6 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
       pulse_candidate_finder->FindPulseCandidates(*pulseIter);
       int n_pulse_candidates = pulse_candidate_finder->GetNPulseCandidates();
 
-      std::vector<TPulseIsland*> pulse_candidates = pulse_candidate_finder->GetPulseCandidates();
-
       // only continue if there is one pulse candidate on the TPI
       if (n_pulse_candidates == 1) {
 
@@ -116,13 +114,18 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	double max_adc_value = std::pow(2, n_bits);
 
 	// Loop through the samples and check for digitizer overflow
+	bool overflowed = false;
 	for (int i = 0; i < n_samples; ++i) {
 	  if (theSamples.at(i) >= max_adc_value-1 && theSamples.at(i) <= max_adc_value+1) {
 	    if (Debug()) {
 	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " has overflowed the digitizer and won't be added to the template" << std::endl;
 	    }
-	    continue;
+	    overflowed = true;
+	    break;
 	  }
+	}
+	if (overflowed) {
+	  continue; // skip this pulse
 	}
 
 	// Create the refined pulse waveform

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -25,6 +25,7 @@ TemplateCreator::TemplateCreator(modules::options* opts):
   // Do something with opts here.  Has the user specified any
   // particular configuration that you want to know?
   // For example, perhaps this module wants an axis range:
+  fRefineFactor = opts->GetInt("refine_factor", 5);
 }
 
 TemplateCreator::~TemplateCreator(){
@@ -65,7 +66,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
     PulseCandidateFinder* pulse_candidate_finder = new PulseCandidateFinder(detname, fOpts);
 
     // Create the TemplateFitter that we will use for this channel
-    fTemplateFitter = new TemplateFitter(detname);
+    fTemplateFitter = new TemplateFitter(detname, fRefineFactor);
 
     // Get the TPIs
     thePulseIslands = it->second;
@@ -96,11 +97,10 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) {
-	  int refine_factor = 5;
 	  std::string histname = "hTemplate_" + detname;
 	  std::string histtitle = "Template Histogram for the " + detname + " channel";
 
-	  hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), refine_factor, true);
+	  hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), true);
 	  ++n_pulses_in_template;
 
 	  if (Debug()) {
@@ -128,7 +128,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	}
 
 	// Create the refined pulse waveform
-	TH1D* hPulseToFit = CreateRefinedPulseHistogram(pulse, "hPulseToFit", "hPulseToFit", 5, false);
+	TH1D* hPulseToFit = CreateRefinedPulseHistogram(pulse, "hPulseToFit", "hPulseToFit", false);
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
@@ -281,9 +281,6 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, TH1D* & hPulse, std:
 
   std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
 
-  // Wnat to increase the bin resolution (this may become a module option at some point)
-  int refine_factor = 5;
-
   /*
     // Create some histograms that monitor the progression of the template
     std::string error_histname = "hErrorVsPulseAdded_" + detname;
@@ -350,25 +347,25 @@ double TemplateCreator::CorrectSampleValue(double old_value, double template_ped
 }
 
 // Creates a histogram with sub-bin resolution
-TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, int refine_factor, bool interpolate) {
+TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, bool interpolate) {
 
   std::string bankname = pulse->GetBankName();
   const std::vector<int>& theSamples = pulse->GetSamples();
   int n_samples = theSamples.size();
-  int n_bins = refine_factor*n_samples; // number of bins in the template
+  int n_bins = fRefineFactor*n_samples; // number of bins in the template
 
   TH1D* hist = new TH1D(histname.c_str(), histtitle.c_str(), n_bins, 0, n_samples);
 
   double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
   for (int i = 0; i < n_bins; ++i) {
     int bin = i+1; // bins go from 1 to n rather than 0 to n-1
-    int sample_number = i / refine_factor;
-    double remainder = i % refine_factor;
+    int sample_number = i / fRefineFactor;
+    double remainder = i % fRefineFactor;
     double sample_value;
 
     if (interpolate) {
       try {
-	sample_value = theSamples.at(sample_number) + (remainder / refine_factor)*(theSamples.at(sample_number+1) - theSamples.at(sample_number));
+	sample_value = theSamples.at(sample_number) + (remainder / fRefineFactor)*(theSamples.at(sample_number+1) - theSamples.at(sample_number));
       }
       catch (const std::out_of_range& oor) { // if we'll be going out of range of the samples vector
 	sample_value = theSamples.at(sample_number);

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -174,7 +174,8 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	// Now add the fitted pulse to the template
 
 	if (n_pulses_in_template <= 10 || 
-	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ) {
+	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ||
+	    (n_pulses_in_template <= 1000 && n_pulses_in_template%100 == 0) ) {
 	  std::stringstream newhistname;
 	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
 	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
@@ -208,7 +209,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
 	  double uncorrected_value = (*sampleIter);
-	  double corrected_value = CorrectSampleValue(uncorrected_value);
+	  double corrected_value = CorrectSampleValue(uncorrected_value, template_pedestal);
 
 	  hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
 	  hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
@@ -317,9 +318,10 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     }
 
     // Loop through the pulse samples
+    double template_pedestal = hTemplate->GetBinContent(1);
     for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
-      double corrected_value = CorrectSampleValue(*sampleIter);
+      double corrected_value = CorrectSampleValue(*sampleIter, template_pedestal);
 
       int bin_number = sampleIter - theSamples.begin() + 1 + 0.5 - fTemplateFitter->GetTimeOffset(); // +1 because ROOT numbers bins from 1, +0.5 to round to the nearest integer and subtract time offset because this value might not want to go direct into the template
 
@@ -372,10 +374,11 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
   */
 }
 
-double TemplateCreator::CorrectSampleValue(double old_value) {
+double TemplateCreator::CorrectSampleValue(double old_value, double template_pedestal) {
 
   double new_value = old_value / fTemplateFitter->GetAmplitudeScaleFactor();
   new_value -= fTemplateFitter->GetPedestalOffset();
+  new_value += template_pedestal;
 
   return new_value;
 }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -85,59 +85,17 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) { // for debugging, just print add one pulse to the template
 	  AddPulseToTemplate(hTemplate, *pulseIter);
-
-	  if (Debug()) {
-	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
-	  }
-	  continue;
+	  //	  continue;
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
-	// Get some initial estimates for the fitter
-	double pedestal_estimate = (*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
-	double amplitude_estimate;
-	double time_estimate;
-	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
-	  amplitude_estimate = (*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
-	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
-	}
-	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
-	  amplitude_estimate = (*pulseIter)->GetAmplitude() / hTemplate->GetMinimum(); // estimated scale factor
-	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMinimumBin();
-	}
-
-	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
-	
-	if (Debug()) {
-	  std::cout << "TemplateCreator: " << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": " << std::endl
-		    << "TemplateCreator: Initial Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
-	}
-
-	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
-	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
-
-	if (Debug()) {
-	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
-	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
-	}
-
-	// Create the corrected pulse
-	const std::vector<int>& theSamples = (*pulseIter)->GetSamples();
-	std::stringstream histname;
-	histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
-	TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
-	histname << "_Corrected";
-	TH1D* hCorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
-
-	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-
-	  double uncorrected_value = (*sampleIter);
-	  double corrected_value = uncorrected_value - template_fitter->GetPedestalOffset();
-	  corrected_value /= template_fitter->GetAmplitudeScaleFactor();
-
-	  hUncorrectedPulse->Fill(sampleIter - theSamples.begin(), uncorrected_value);
-	  hCorrectedPulse->Fill(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset(), corrected_value);
-	}
+	//	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+	//	if (Debug()) {
+	//	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
+	//	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()
+	//	            << ", Time = " << template_fitter->GetTime() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
+	//	}
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
@@ -185,11 +143,11 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string histname = "hTemplate_" + detname;
     std::string histtitle = "Template Histogram for the " + detname + " channel";
 
-    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_samples, 0, n_samples);
+    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), refine_factor*n_samples, 0, n_samples);
   }
 
   // Now loop through the samples and add to the template
-  /*  for (int iBin = 0; iBin < refine_factor*n_samples; ++iBin) {
+  for (int iBin = 0; iBin < refine_factor*n_samples; ++iBin) {
 
     int sample_element = iBin / refine_factor;
     double value_to_fill = 0;
@@ -209,11 +167,6 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     }
     //    std::cout << "Bin#" << iBin << ": " << value_to_fill << std::endl;
     hTemplate->SetBinContent( iBin, value_to_fill);
-  }
-  */
-
-  for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-    hTemplate->Fill( sampleIter - theSamples.begin(), *sampleIter);
   }
 }
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -184,7 +184,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	}
 */
 	// Add the pulse to the template (we'll do the correcting there)
-	AddPulseToTemplate(hTemplate, pulse);
+	/*	AddPulseToTemplate(hTemplate, pulse);
 	++n_pulses_in_template;
 	double error_of_max_bin;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) {
@@ -197,7 +197,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	double prob = TMath::Prob(fTemplateFitter->GetChi2(), fTemplateFitter->GetNDoF());
 	if (prob != 0) {
 	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
-	}
+	  }*/
 /*	
 	// Create the corrected pulse
 	const std::vector<int>& theSamples = (pulse)->GetSamples();
@@ -271,6 +271,7 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
 
   // Wnat to increase the bin resolution (this may become a module option at some point)
   int refine_factor = 5;
+  int n_bins = refine_factor*n_samples; // number of bins in the template
 
   // If the template histogram is NULL, then create it
   if (hTemplate == NULL) {
@@ -279,13 +280,17 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string histname = "hTemplate_" + detname;
     std::string histtitle = "Template Histogram for the " + detname + " channel";
 
-    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_samples, 0, n_samples);
+    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_bins, 0, n_samples);
 
     // Add the first pulse and the correct initial errors
     double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-    for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-      hTemplate->SetBinContent( sampleIter - theSamples.begin()+1, *sampleIter); // +1 because ROOT numbers bins from 1
-      hTemplate->SetBinError( sampleIter - theSamples.begin()+1, pedestal_error);
+    for (int i = 0; i < n_bins; ++i) {
+      int bin = i+1; // bins go from 1 to n rather than 0 to n-1
+      int sample_number = i / refine_factor;
+      double sample_value = theSamples.at(sample_number);
+      std::cout << "i: " << i << ", Bin: " << bin << ", Sample Number: " << sample_number << ", Sample Value: " << sample_value << std::endl;
+      hTemplate->SetBinContent( bin, sample_value);
+      hTemplate->SetBinError( bin, pedestal_error);
     }
 
     std::string error_histname = "hErrorVsPulseAdded_" + detname;

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -284,7 +284,6 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	}
       } // end if only one pulse candidate
     } //end for loop through channels
-    // We will want to normalise to template to have pedestal=0 and amplitude=1
   }
 
   return 0;
@@ -305,13 +304,42 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData,TSetupData *setup){
   for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
     std::string bankname = it->first;
     std::string detname = setup->GetDetectorName(bankname);
+
+    TH1D* hTemplate = fTemplates[detname];
+    
+    if (!hTemplate) { // if there's no template been created for this channel
+      continue;
+    }
     
     int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
     int& n_successful_fits = fNSuccessfulFits[detname];
     std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
 
+    // Normalise the template so that it has pedestal=0 and amplitude=1
+    // Work out the pedestal of the template from the first 5 bins
+    int n_bins_for_template_pedestal = 5;
+    double total = 0;
+    for (int iBin = 1; iBin <= n_bins_for_template_pedestal; ++iBin) {
+      total += hTemplate->GetBinContent(iBin);
+    }
+    double template_pedestal = total / n_bins_for_template_pedestal;
+    //    std::cout << detname << ": Template Pedestal = " << template_pedestal << std::endl;
+   
+    // Subtract off the pedesal
+    for (int iBin = 1; iBin <= hTemplate->GetNbinsX(); ++iBin) {
+      double old_value = hTemplate->GetBinContent(iBin);
+      double new_value = old_value - template_pedestal;
+
+      hTemplate->SetBinContent(iBin, new_value);
+    }
+
+    // Integrate over the histogram and scale to give an area of 1
+    double integral = std::fabs(hTemplate->Integral()); // want the absolute value for the integral because of the negative polarity pulses
+    hTemplate->Scale(1.0/integral);
+    integral = std::fabs(hTemplate->Integral());
+
     // Save the template to the file
-    fTemplateArchive->SaveTemplate(fTemplates[detname]);
+    fTemplateArchive->SaveTemplate(hTemplate);
   }
 
   // Clean up the template archive

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -94,13 +94,15 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	double pedestal_estimate = 0;//(*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
-	double amplitude_estimate = 0;//(*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
+	double pedestal_estimate = (*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
+	double amplitude_estimate;
 	double time_estimate;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
+	  amplitude_estimate = (*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
 	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
 	}
 	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
+	  amplitude_estimate = (*pulseIter)->GetAmplitude() / hTemplate->GetMinimum(); // estimated scale factor
 	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMinimumBin();
 	}
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -10,6 +10,7 @@
 #include "ExportPulse.h"
 
 #include <iostream>
+#include <sstream>
 using std::cout;
 using std::endl;
 
@@ -89,18 +90,40 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
-	/*	double pedestal_estimate = TSetupData::Instance()->GetPedestal(bankname);
-	double amplitude_estimate = (*pulseIter)->GetAmplitude();
-	double time_estimate = (*pulseIter)->GetPeakSample();
+	double pedestal_estimate = 0;
+	double amplitude_estimate = 0;
+	double time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
 	std::cout << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
-	*/
+	
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
-	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {
 	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
-	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()
-	            << ", Time = " << template_fitter->GetTime() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
+	            << "Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
+	            << ", TimeOffset = " << template_fitter->GetTimeOffset() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
+	}
+
+	// Create the corrected pulse
+	const std::vector<int>& theSamples = (*pulseIter)->GetSamples();
+	std::stringstream histname;
+	histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
+	TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
+	histname << "_Corrected";
+	TH1D* hCorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
+
+	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+
+	  double uncorrected_value = (*sampleIter);
+	  std::cout << "Uncorrected value = " << uncorrected_value << std::endl;
+	  double corrected_value = uncorrected_value * template_fitter->GetAmplitudeScaleFactor();
+	  std::cout << " x " << template_fitter->GetAmplitudeScaleFactor() << " = " << corrected_value << std::endl;
+	  corrected_value += template_fitter->GetPedestalOffset();
+	  std::cout << " + " << template_fitter->GetPedestalOffset() << " = " << corrected_value << std::endl;
+
+	  hUncorrectedPulse->Fill(sampleIter - theSamples.begin(), uncorrected_value);
+	  hCorrectedPulse->Fill(sampleIter - theSamples.begin() + template_fitter->GetTimeOffset(), corrected_value);
+	  //	  std::cout << "Uncorrected Value = " << (*sampleIter) << ", Corrected Value = " << (*sampleIter)*template_fitter->GetAmplitudeScaleFactor() + template_fitter->GetPedestalOffset() << std::endl;
 	}
 	// we keep on adding pulses until adding pulses has no effect on the template
       }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -6,6 +6,7 @@
 
 #include "definitions.h"
 
+#include "SetupNavigator.h"
 #include "utils/TemplateFitter.h"
 #include "ExportPulse.h"
 
@@ -114,7 +115,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	}
 
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
-	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 
 	if (Debug()) {
 	  std::cout << "Template Creator: Fitted Parameters: PedOffset = " << template_fitter->GetPedestalOffset() << ", AmpScaleFactor = " << template_fitter->GetAmplitudeScaleFactor()
@@ -129,14 +130,17 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	histname << "_Corrected";
 	TH1D* hCorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
 
+	double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
 	for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
 
 	  double uncorrected_value = (*sampleIter);
 	  double corrected_value = uncorrected_value - template_fitter->GetPedestalOffset();
 	  corrected_value /= template_fitter->GetAmplitudeScaleFactor();
 
-	  hUncorrectedPulse->Fill(sampleIter - theSamples.begin(), uncorrected_value);
-	  hCorrectedPulse->Fill(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset(), corrected_value);
+	  hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin(), uncorrected_value);
+	  hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin(), pedestal_error);
+	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin() - template_fitter->GetTimeOffset(), corrected_value);
+	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin(), pedestal_error);
 	}
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
@@ -186,6 +190,13 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string histtitle = "Template Histogram for the " + detname + " channel";
 
     hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_samples, 0, n_samples);
+
+    // Add the first pulse and the correct initial errors
+    double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
+    for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+      hTemplate->SetBinContent( sampleIter - theSamples.begin(), *sampleIter);
+      hTemplate->SetBinError( sampleIter - theSamples.begin(), pedestal_error);
+    }
   }
 
   // Now loop through the samples and add to the template
@@ -211,10 +222,6 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     hTemplate->SetBinContent( iBin, value_to_fill);
   }
   */
-
-  for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-    hTemplate->Fill( sampleIter - theSamples.begin(), *sampleIter);
-  }
 }
 
 // The following macro registers this module to be useable in the config file.

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -123,9 +123,17 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	// Loop through the samples and check for digitizer overflow
 	bool overflowed = false;
 	for (int i = 0; i < n_samples; ++i) {
-	  if (theSamples.at(i) >= max_adc_value-1 && theSamples.at(i) <= max_adc_value+1) {
+	  int sample_value = theSamples.at(i);
+	  if (sample_value >= max_adc_value-1 && sample_value <= max_adc_value+1) {
 	    if (Debug()) {
 	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " has overflowed the digitizer and won't be added to the template" << std::endl;
+	    }
+	    overflowed = true;
+	    break;
+	  }
+	  else if (sample_value == 0) {
+	    if (Debug()) {
+	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " has underflowed the digitizer and won't be added to the template" << std::endl;
 	    }
 	    overflowed = true;
 	    break;
@@ -157,7 +165,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	double pulse_amplitude;
 	double pulse_time;
 
-	double pedestal_offset_estimate = template_pedestal - pulse_pedestal;
+	double pedestal_offset_estimate = pulse_pedestal; // now we're dealing with actual pulses since we subtract the template_pedestal in the transformation
 	double amplitude_scale_factor_estimate;
 	double time_offset_estimate;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
@@ -408,7 +416,7 @@ bool TemplateCreator::CheckConvergence(TH1D* hTemplate, std::string bankname) {
     error = hTemplate->GetBinError(hTemplate->GetMaximumBin());
   }
   fErrorVsPulseAddedHistograms[detname]->Fill(n_pulses_in_template, error);
-  std::cout << detname << ": #" << n_pulses_in_template << ", Error = " << error << std::endl;
+  //  std::cout << detname << ": #" << n_pulses_in_template << ", Error = " << error << std::endl;
 
 }
 // The following macro registers this module to be useable in the config file.

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -78,23 +78,25 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
       std::vector<TPulseIsland*> pulse_candidates = pulse_candidate_finder->GetPulseCandidates();
 
-      // we only continue if there is more than one pulse candidate on the TPI
-      /*      if (n_pulse_candidates == 1) {
+      // only continue if there is one pulse candidate on the TPI
+      if (n_pulse_candidates == 1) {
 
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (Debug() && hTemplate == NULL) { // for debugging, just print add one pulse to the template
 	  AddPulseToTemplate(hTemplate, *pulseIter);
+	  //	  continue;
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
-	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
-	if (Debug()) {
-	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
-	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()
-	            << ", Time = " << template_fitter->GetTime() << ", Chi2 = " << template_fitter->GetChi2() << std::endl;
-	}
+	//	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+	//	if (Debug()) {
+	//	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
+	//	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()
+	//	            << ", Time = " << template_fitter->GetTime() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
+	//	}
 	// we keep on adding pulses until adding pulses has no effect on the template
-	}*/
+      }
     }
     // Save the template to the file
     fTemplateArchive->SaveTemplate(hTemplate);
@@ -127,6 +129,9 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
   const std::vector<int>& theSamples = pulse->GetSamples();
   int n_samples = theSamples.size();
 
+  // Wnat to increase the bin resolution (this may become a module option at some point)
+  int refine_factor = 5;
+
   // If the template histogram is NULL, then create it
   if (hTemplate == NULL) {
 
@@ -135,12 +140,31 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
     std::string histname = "hTemplate_" + detname;
     std::string histtitle = "Template Histogram for the " + detname + " channel";
-    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_samples, 0, n_samples);
+
+    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), refine_factor*n_samples, 0, n_samples);
   }
 
   // Now loop through the samples and add to the template
-  for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-    hTemplate->Fill(sampleIter - theSamples.begin(), *sampleIter);
+  for (int iBin = 0; iBin < refine_factor*n_samples; ++iBin) {
+
+    int sample_element = iBin / refine_factor;
+    double value_to_fill = 0;
+
+    if (sample_element != theSamples.size()-1) { // if this element is not going to be outside of the samples vector
+      int iSubBin = iBin % refine_factor;
+      
+      int this_sample = theSamples.at(sample_element);
+      int next_sample = theSamples.at(sample_element+1);
+      double sample_difference = next_sample - this_sample;
+      
+      double interpolated_value = this_sample + iSubBin*(sample_difference / refine_factor);
+      value_to_fill = interpolated_value;
+    }
+    else {
+      value_to_fill = theSamples.at(sample_element);
+    }
+    //    std::cout << "Bin#" << iBin << ": " << value_to_fill << std::endl;
+    hTemplate->SetBinContent( iBin, value_to_fill);
   }
 }
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -85,17 +85,17 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) { // for debugging, just print add one pulse to the template
 	  AddPulseToTemplate(hTemplate, *pulseIter);
-	  //	  continue;
+	  continue;
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
-	//	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
-	//	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
-	//	if (Debug()) {
-	//	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
-	//	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()
-	//	            << ", Time = " << template_fitter->GetTime() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
-	//	}
+	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
+	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
+	if (Debug()) {
+	  std::cout << detname << "(" << bankname << "): Pulse #" << pulseIter - thePulseIslands.begin() << ": "
+	            << "Fitted Parameters: Ped = " << template_fitter->GetPedestal() << ", Amp = " << template_fitter->GetAmplitude()
+	            << ", Time = " << template_fitter->GetTime() << ", Chi2 = " << template_fitter->GetChi2() << std::endl << std::endl;
+	}
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
@@ -143,11 +143,11 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string histname = "hTemplate_" + detname;
     std::string histtitle = "Template Histogram for the " + detname + " channel";
 
-    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), refine_factor*n_samples, 0, n_samples);
+    hTemplate = new TH1D(histname.c_str(), histtitle.c_str(), n_samples, 0, n_samples);
   }
 
   // Now loop through the samples and add to the template
-  for (int iBin = 0; iBin < refine_factor*n_samples; ++iBin) {
+  /*  for (int iBin = 0; iBin < refine_factor*n_samples; ++iBin) {
 
     int sample_element = iBin / refine_factor;
     double value_to_fill = 0;
@@ -167,6 +167,11 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     }
     //    std::cout << "Bin#" << iBin << ": " << value_to_fill << std::endl;
     hTemplate->SetBinContent( iBin, value_to_fill);
+  }
+  */
+
+  for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+    hTemplate->Fill( sampleIter - theSamples.begin(), *sampleIter);
   }
 }
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -16,6 +16,8 @@
 using std::cout;
 using std::endl;
 
+extern Long64_t* gEntryNumber;
+
 TemplateCreator::TemplateCreator(modules::options* opts):
   BaseModule("TemplateCreator",opts), fOpts(opts){
 
@@ -98,7 +100,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 
 	  const std::vector<int>& theSamples = (pulse)->GetSamples();
 	  std::stringstream histname;
-	  histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
+	  histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
 	  TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
 
 	  double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
@@ -175,7 +177,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 
 	if (n_pulses_in_template <= 10 || 
 	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ||
-	    (n_pulses_in_template <= 1000 && n_pulses_in_template%100 == 0) ) {
+	    (n_pulses_in_template%100 == 0) ) {
 	  std::stringstream newhistname;
 	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
 	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
@@ -200,7 +202,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	// Create the corrected pulse
 	const std::vector<int>& theSamples = (pulse)->GetSamples();
 	std::stringstream histname;
-	histname << template_name << "_Pulse" << pulseIter - thePulseIslands.begin();
+	histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
 	TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
 	histname << "_Corrected";
 	TH1D* hCorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
@@ -376,9 +378,13 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
 
 double TemplateCreator::CorrectSampleValue(double old_value, double template_pedestal) {
 
+  //  std::cout << "TemplateCreator::CorrectSampleValue():\nold value = " << old_value << std::endl;
   double new_value = old_value / fTemplateFitter->GetAmplitudeScaleFactor();
+  //  std::cout << "/ AmpSF:  / " << fTemplateFitter->GetAmplitudeScaleFactor() << " = " << new_value << std::endl;
   new_value -= fTemplateFitter->GetPedestalOffset();
+  //  std::cout << "- PedOffset: - " << fTemplateFitter->GetPedestalOffset() << " = " << new_value << std::endl;
   new_value += template_pedestal;
+  //  std::cout << "+ TemplatePed: + " << template_pedestal << " = " << new_value << std::endl;
 
   return new_value;
 }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -72,7 +72,10 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 
     // Try and get the template (it may have been created in a previous event)
     std::string template_name = "hTemplate_" + detname;
-    TH1D* hTemplate = fTemplateArchive->GetTemplate(template_name.c_str());
+    TH1D* hTemplate = NULL;
+    if (fTemplates.find(detname) != fTemplates.end()) {
+      hTemplate = fTemplates[detname];
+    }
 
     // Store a couple of numbers to get an idea of how many successful fits there are
     int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
@@ -109,6 +112,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  if (Debug()) {
 	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
 	  }
+	  fTemplates[detname] = hTemplate;
 	  continue;
 	}
 
@@ -263,8 +267,6 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
       }
     }
     // We will want to normalise to template to have pedestal=0 and amplitude=1
-    // Save the template to the file
-    fTemplateArchive->SaveTemplate(hTemplate);
   }
 
   return 0;
@@ -290,6 +292,9 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData,TSetupData *setup){
     int& n_fit_attempts = fNFitAttempts[detname]; // number of pulses we try to fit to
     int& n_successful_fits = fNSuccessfulFits[detname];
     std::cout << "TemplateCreator: " << detname << ": " << n_fit_attempts << " fits attempted with " << n_successful_fits << " successful (" << ((double)n_successful_fits/(double)n_fit_attempts)*100 << "%)" << std::endl;
+
+    // Save the template to the file
+    fTemplateArchive->SaveTemplate(fTemplates[detname]);
   }
 
   // Clean up the template archive

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -96,7 +96,14 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	// Get some initial estimates for the fitter
 	double pedestal_estimate = 0;//(*pulseIter)->GetSamples().at(0) - hTemplate->GetBinContent(1);
 	double amplitude_estimate = 0;//(*pulseIter)->GetAmplitude() / hTemplate->GetMaximum(); // estimated scale factor
-	double time_estimate = 0;
+	double time_estimate;
+	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) { 
+	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMaximumBin();
+	}
+	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
+	  time_estimate = (*pulseIter)->GetPeakSample() - hTemplate->GetMinimumBin();
+	}
+
 	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
 	
 	if (Debug()) {

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -48,9 +48,6 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
   PulseIslandList thePulseIslands;
   StringPulseIslandMap::const_iterator it;
 
-  // Create the TemplateFitter that we will use
-  TemplateFitter* template_fitter = new TemplateFitter();
-
   // Loop over each detector
   for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
     
@@ -60,6 +57,9 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
     // Create the pulse candidate finder for this detector
     PulseCandidateFinder* pulse_candidate_finder = new PulseCandidateFinder(detname, fOpts);
+
+    // Create the TemplateFitter that we will use for this channel
+    TemplateFitter* template_fitter = new TemplateFitter(detname);
 
     // Get the TPIs
     thePulseIslands = it->second;
@@ -88,6 +88,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 	}
 
 	// all the other pulses will be fitted to the template and then added to it
+	// Get some initial estimates for the fitter
+	double pedestal_estimate = TSetupData::Instance()->GetPedestal(bankname);
+	double amplitude_estimate = (*pulseIter)->GetAmplitude();
+	double time_estimate = (*pulseIter)->GetPeakSample();
+	std::cout << "Estimates: pedestal = " << pedestal_estimate << ", amplitude = " << amplitude_estimate << ", time = " << time_estimate << std::endl;
+	template_fitter->SetInitialParameterEstimates(pedestal_estimate, amplitude_estimate, time_estimate);
+
 	template_fitter->FitPulseToTemplate(hTemplate, *pulseIter);
 	ExportPulse::Instance()->AddToExportList(detname, pulseIter - thePulseIslands.begin());
 	if (Debug()) {

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -308,6 +308,7 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
 
       int bin_number = sampleIter - theSamples.begin() + 1 + 0.5 - fTemplateFitter->GetTimeOffset(); // +1 because ROOT numbers bins from 1, +0.5 to round to the nearest integer and subtract time offset because this value might not want to go direct into the template
 
+      // Only change the bin contents of bins within the range of the template histogram
       if (bin_number < 1 || bin_number > hTemplate->GetNbinsX()) {
 	continue;
       }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -41,6 +41,14 @@ int TemplateCreator::BeforeFirstEntry(TGlobalData* gData,TSetupData *setup){
   // Prepare the template archive
   fTemplateArchive = new TemplateArchive("templates.root", "RECREATE");
 
+  // Set all the converged statuses to false
+  StringPulseIslandMap::const_iterator it;
+  for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
+    std::string bankname = it->first;
+    std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
+
+    fConvergedStatuses[detname] = false;
+  }
   return 0;
 }
 
@@ -59,6 +67,11 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
     // Get the bank and detector names for this detector
     bankname = it->first;
     detname = setup->GetDetectorName(bankname);
+
+    // See if we already have a converged template for this detector
+    if (fConvergedStatuses[detname] == true) {
+      continue;
+    }
 
     // Create the pulse candidate finder for this detector
     PulseCandidateFinder* pulse_candidate_finder = new PulseCandidateFinder(detname, fOpts);
@@ -264,8 +277,13 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 
 	// we keep on adding pulses until adding pulses has no effect on the template
 	bool converged = CheckConvergence(hTemplate, bankname);
-      }
-    }
+	if (converged) {
+	  fConvergedStatuses[detname] = true;
+	  std::cout << "TemplateCreator: " << detname << " template terminated at iteration " << n_pulses_in_template << std::endl;
+	  break; // break from the for loop
+	}
+      } // end if only one pulse candidate
+    } //end for loop through channels
     // We will want to normalise to template to have pedestal=0 and amplitude=1
   }
 
@@ -282,9 +300,8 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData,TSetupData *setup){
      cout<<"-----I'm debugging TemplateCreator::AfterLastEntry()"<<endl;
   }
 
-  StringPulseIslandMap::const_iterator it;
-
   // Print to stdout the percentage of successful fit for each channel
+  StringPulseIslandMap::const_iterator it;
   for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
     std::string bankname = it->first;
     std::string detname = setup->GetDetectorName(bankname);
@@ -413,6 +430,8 @@ bool TemplateCreator::CheckConvergence(TH1D* hTemplate, std::string bankname) {
   std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
   int n_pulses_in_template = fNPulsesInTemplate[detname];
   int trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+
+  TH1D* error_histogram = fErrorVsPulseAddedHistograms[detname];
   double error = 0;
   if (trigger_polarity == -1) {
     error = hTemplate->GetBinError(hTemplate->GetMinimumBin());
@@ -420,8 +439,26 @@ bool TemplateCreator::CheckConvergence(TH1D* hTemplate, std::string bankname) {
   else if (trigger_polarity == 1) {
     error = hTemplate->GetBinError(hTemplate->GetMaximumBin());
   }
-  fErrorVsPulseAddedHistograms[detname]->Fill(n_pulses_in_template, error);
-  //  std::cout << detname << ": #" << n_pulses_in_template << ", Error = " << error << std::endl;
+  error_histogram->Fill(n_pulses_in_template, error);
+
+  // Check the difference between this iteration and previous ones and, if it's small, the template has converged
+  int n_bins_to_check = 5;
+  double convergence_limit = 0.001;
+  bool converged = false;
+  for (int iPrevBin = 0; iPrevBin < n_bins_to_check; ++iPrevBin) {
+    double previous_error = error_histogram->GetBinContent(n_pulses_in_template-iPrevBin); // we have just added error to bin number n_pulses_in_template+1
+
+    if ( std::fabs(previous_error - error) < convergence_limit) {
+      converged = true;
+    }
+    else {
+      converged = false;
+      break;
+    }
+  }
+
+  return converged;
+  //  std::cout << detname << ": #" << n_pulses_in_template << ", Error (Inserted) = " << error << ", Error (Retrieved) = " << error_histogram->GetBinContent(n_pulses_in_template+1) << std::endl;
 
 }
 // The following macro registers this module to be useable in the config file.

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -96,28 +96,39 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 
         // Add the first pulse directly to the template (although we may try and choose a random pulse to start with)
 	if (hTemplate == NULL) {
-	  AddPulseToTemplate(hTemplate, pulse);
+	  int refine_factor = 5;
+	  std::string histname = "hTemplate_" + detname;
+	  std::string histtitle = "Template Histogram for the " + detname + " channel";
+
+	  hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), refine_factor);
 	  ++n_pulses_in_template;
 
-/*	  const std::vector<int>& theSamples = (pulse)->GetSamples();
-	  std::stringstream histname;
-	  histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
-	  TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
-
-	  double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
-	  for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-
-	    double uncorrected_value = (*sampleIter);
-	    
-	    hUncorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1, uncorrected_value); // +1 because bins start at 1
-	    hUncorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1, pedestal_error);
-	  }
-*/
 	  if (Debug()) {
 	    std::cout << "TemplateCreator: Adding " << detname << " Pulse #" << pulseIter - thePulseIslands.begin() << " directly to the template" << std::endl;
 	  }
 	  continue;
 	}
+
+	// Get the samples so we can check for digitiser overflow
+	const std::vector<int>& theSamples = (pulse)->GetSamples();
+	int n_samples = theSamples.size();
+
+	// Calculate the maximum ADC value for this digitiser
+	int n_bits = TSetupData::Instance()->GetNBits(bankname);
+	double max_adc_value = std::pow(2, n_bits);
+
+	// Loop through the samples and check for digitizer overflow
+	for (int i = 0; i < n_samples; ++i) {
+	  if (theSamples.at(i) >= max_adc_value-1 && theSamples.at(i) <= max_adc_value+1) {
+	    if (Debug()) {
+	      std::cout << "TemplateCreator: Pulse #" << pulseIter - thePulseIslands.begin() << " has overflowed the digitizer and won't be added to the template" << std::endl;
+	    }
+	    continue;
+	  }
+	}
+
+	// Create the refined pulse waveform
+	TH1D* hPulseToFit = CreateRefinedPulseHistogram(pulse, "hPulseToFit", "hPulseToFit", 5);
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
@@ -125,9 +136,9 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	double template_amplitude;
 	double template_time;
 
-	double pulse_pedestal = (pulse)->GetSamples().at(0);
-	double pulse_amplitude = (pulse)->GetAmplitude();
-	double pulse_time = (pulse)->GetPeakSample(); // between 0 and n_samples-1
+	double pulse_pedestal = hPulseToFit->GetBinContent(1);
+	double pulse_amplitude;
+	double pulse_time;
 
 	double pedestal_offset_estimate = template_pedestal - pulse_pedestal;
 	double amplitude_scale_factor_estimate;
@@ -136,12 +147,18 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  template_amplitude = (hTemplate->GetMaximum() - template_pedestal);
 	  template_time = hTemplate->GetMaximumBin() - 1; // go from bin numbering (1, n_samples) to clock ticks (0, n_samples-1)
 
+	  pulse_amplitude = (hPulseToFit->GetMaximum() - pulse_pedestal);
+	  pulse_time = hPulseToFit->GetMaximumBin() - 1;
+
 	  amplitude_scale_factor_estimate = pulse_amplitude / template_amplitude;  // estimated scale factor
 	  time_offset_estimate = pulse_time - template_time;
 	}
 	else if (TSetupData::Instance()->GetTriggerPolarity(bankname) == -1) {
 	  template_amplitude = (template_pedestal - hTemplate->GetMinimum());
 	  template_time = hTemplate->GetMinimumBin() - 1; // go from bin numbering (1, n_samples) to clock ticks (0, n_samples-1)
+
+	  pulse_amplitude = (pulse_pedestal - hPulseToFit->GetMinimum());
+	  pulse_time = hPulseToFit->GetMinimumBin() - 1; // go from bin numbering (1, n_samples) to clock ticks (0, n_samples-1)
 
 	  amplitude_scale_factor_estimate = pulse_amplitude / template_amplitude;  // estimated scale factor
 	  time_offset_estimate = pulse_time - template_time;
@@ -157,7 +174,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 		    << ", time = " << time_offset_estimate << std::endl;
 	}
 
-	int fit_status = fTemplateFitter->FitPulseToTemplate(hTemplate, pulse);
+	int fit_status = fTemplateFitter->FitPulseToTemplate(hTemplate, hPulseToFit, bankname);
 	++n_fit_attempts;
 	if (fit_status != 0) {
 	  if (Debug()) {
@@ -175,7 +192,6 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	}
 
 	// Now add the fitted pulse to the template
-/*
 	if (n_pulses_in_template <= 10 || 
 	    (n_pulses_in_template <= 100 && n_pulses_in_template%10 == 0) ||
 	    (n_pulses_in_template%100 == 0) ) {
@@ -183,11 +199,11 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  newhistname << "hTemplate_" << n_pulses_in_template << "Pulses_" << detname;
 	  TH1D* new_template = (TH1D*) hTemplate->Clone(newhistname.str().c_str());
 	}
-*/
-/*	// Add the pulse to the template (we'll do the correcting there)
-	AddPulseToTemplate(hTemplate, pulse);
+
+	// Add the pulse to the template (we'll do the correcting there)
+	AddPulseToTemplate(hTemplate, hPulseToFit, bankname);
 	++n_pulses_in_template;
-	double error_of_max_bin;
+	/*	double error_of_max_bin;
 	if (TSetupData::Instance()->GetTriggerPolarity(bankname) == 1) {
 	  error_of_max_bin = hTemplate->GetBinError(hTemplate->GetMaximumBin());
 	}
@@ -199,10 +215,9 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	if (prob != 0) {
 	  fProbVsPulseAddedHistograms.at(detname)->Fill(n_pulses_in_template, -(TMath::Log(prob)));
 	}
-*/
-/*	
+	*/
+	
 	// Create the corrected pulse
-	const std::vector<int>& theSamples = (pulse)->GetSamples();
 	std::stringstream histname;
 	histname << template_name << "_Event" << *gEntryNumber << "_Pulse" << pulseIter - thePulseIslands.begin();
 	TH1D* hUncorrectedPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), theSamples.size(), 0, theSamples.size());
@@ -220,7 +235,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  hCorrectedPulse->SetBinContent(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), corrected_value); 
 	  hCorrectedPulse->SetBinError(sampleIter - theSamples.begin()+1 +0.5 - fTemplateFitter->GetTimeOffset(), pedestal_error);
 	}
-*/
+
 	// we keep on adding pulses until adding pulses has no effect on the template
       }
     }
@@ -262,28 +277,14 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData,TSetupData *setup){
 
 /// AddPulseToTemplate()
 /// Adds the given pulse to the template
-void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* pulse) {
+void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, TH1D* & hPulse, std::string bankname) {
 
-  // Get the samples so that we can add them to the template
-  const std::vector<int>& theSamples = pulse->GetSamples();
-  int n_samples = theSamples.size();
-
-  std::string bankname = pulse->GetBankName();
   std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
 
   // Wnat to increase the bin resolution (this may become a module option at some point)
   int refine_factor = 5;
 
-  // If the template histogram is NULL, then create it
-  if (hTemplate == NULL) {
-
-    // Names for the histograms
-    std::string histname = "hTemplate_" + detname;
-    std::string histtitle = "Template Histogram for the " + detname + " channel";
-
-    // Create a refined pulse histogram from the first pulse we are given
-    hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), refine_factor);
-
+  /*
     // Create some histograms that monitor the progression of the template
     std::string error_histname = "hErrorVsPulseAdded_" + detname;
     std::string error_histtitle = "Plot of the Error as each new Pulse is added to the template for the " + detname + " channel";
@@ -298,44 +299,44 @@ void TemplateCreator::AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* 
     std::string prob_histtitle = "Plot of the Prob as each new Pulse is added to the template for the " + detname + " channel";
     TH1D* prob_hist = new TH1D(prob_histname.c_str(), prob_histtitle.c_str(), n_bins,0,n_bins);
     fProbVsPulseAddedHistograms[detname] = prob_hist;
+  */
+
+  int n_pulses = fNPulsesInTemplate.at(detname);
+  if (Debug()) {
+    std::cout << "AddPulseToTemplate(): n_pulses = " << n_pulses << std::endl;
   }
 
-  else { // add subsequent pulses
-    int n_pulses = fNPulsesInTemplate.at(detname);
+  // Loop through the pulse histogram
+  double template_pedestal = hTemplate->GetBinContent(1);
+  for (int iPulseBin = 1; iPulseBin < hPulse->GetNbinsX(); ++iPulseBin) {
+    //    for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
+
+    double uncorrected_value = hPulse->GetBinContent(iPulseBin);
+    double corrected_value = CorrectSampleValue(uncorrected_value, template_pedestal);
+
+    int bin_number = iPulseBin + 0.5 - fTemplateFitter->GetTimeOffset(); // +0.5 so that we round to the nearest integer and subtract time offset because this value might not want to go direct into the template
+
+    // Only change the bin contents of bins within the range of the template histogram
+    if (bin_number < 1 || bin_number > hTemplate->GetNbinsX()) {
+      continue;
+    }
+    double old_bin_content = hTemplate->GetBinContent(bin_number);
+    double old_bin_error = hTemplate->GetBinError(bin_number);
+
+    double new_bin_content = n_pulses * old_bin_content + corrected_value;
+    new_bin_content /= (n_pulses + 1);
+
+    double new_bin_error = ((n_pulses - 1)*old_bin_error*old_bin_error) + (corrected_value - old_bin_content)*(corrected_value - new_bin_content);
+    new_bin_error = std::sqrt(new_bin_error / n_pulses);
+
     if (Debug()) {
-      std::cout << "AddPulseToTemplate(): n_pulses = " << n_pulses << std::endl;
+      std::cout << "TemplateCreator::AddPulseToTemplate(): Bin #" << bin_number << ": Corrected Sample Value = " << corrected_value << std::endl
+		<< "\t\t\tOld Value (Error) = " << old_bin_content << "(" << old_bin_error << ")" << std::endl
+		<< "\t\t\tNew Value (Error) = " << new_bin_content << "(" << new_bin_error << ")" << std::endl;
     }
 
-    // Loop through the pulse samples
-    double template_pedestal = hTemplate->GetBinContent(1);
-    for (std::vector<int>::const_iterator sampleIter = theSamples.begin(); sampleIter != theSamples.end(); ++sampleIter) {
-
-      double corrected_value = CorrectSampleValue(*sampleIter, template_pedestal);
-
-      int bin_number = sampleIter - theSamples.begin() + 1 + 0.5 - fTemplateFitter->GetTimeOffset(); // +1 because ROOT numbers bins from 1, +0.5 to round to the nearest integer and subtract time offset because this value might not want to go direct into the template
-
-      // Only change the bin contents of bins within the range of the template histogram
-      if (bin_number < 1 || bin_number > hTemplate->GetNbinsX()) {
-	continue;
-      }
-      double old_bin_content = hTemplate->GetBinContent(bin_number);
-      double old_bin_error = hTemplate->GetBinError(bin_number);
-
-      double new_bin_content = n_pulses * old_bin_content + corrected_value;
-      new_bin_content /= (n_pulses + 1);
-
-      double new_bin_error = ((n_pulses - 1)*old_bin_error*old_bin_error) + (corrected_value - old_bin_content)*(corrected_value - new_bin_content);
-      new_bin_error = std::sqrt(new_bin_error / n_pulses);
-
-      if (Debug()) {
-	std::cout << "TemplateCreator::AddPulseToTemplate(): Bin #" << bin_number << ": Corrected Sample Value = " << corrected_value << std::endl
-		  << "\t\t\tOld Value (Error) = " << old_bin_content << "(" << old_bin_error << ")" << std::endl
-		  << "\t\t\tNew Value (Error) = " << new_bin_content << "(" << new_bin_error << ")" << std::endl;
-      }
-
-      hTemplate->SetBinContent(bin_number, new_bin_content);
-      hTemplate->SetBinError(bin_number, new_bin_error);
-    }
+    hTemplate->SetBinContent(bin_number, new_bin_content);
+    hTemplate->SetBinError(bin_number, new_bin_error);
   }
 }
 
@@ -375,7 +376,6 @@ TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, st
       sample_value = theSamples.at(sample_number);
     }
     
-    std::cout << "i: " << i << ", Bin: " << bin << ", Sample Number: " << sample_number << ", Sample Value: " << sample_value << std::endl;
     hist->SetBinContent( bin, sample_value);
     hist->SetBinError( bin, pedestal_error);
   }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.cpp
@@ -100,7 +100,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	  std::string histname = "hTemplate_" + detname;
 	  std::string histtitle = "Template Histogram for the " + detname + " channel";
 
-	  hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), refine_factor);
+	  hTemplate = CreateRefinedPulseHistogram(pulse, histname.c_str(), histtitle.c_str(), refine_factor, true);
 	  ++n_pulses_in_template;
 
 	  if (Debug()) {
@@ -128,7 +128,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	}
 
 	// Create the refined pulse waveform
-	TH1D* hPulseToFit = CreateRefinedPulseHistogram(pulse, "hPulseToFit", "hPulseToFit", 5);
+	TH1D* hPulseToFit = CreateRefinedPulseHistogram(pulse, "hPulseToFit", "hPulseToFit", 5, false);
 
 	// all the other pulses will be fitted to the template and then added to it
 	// Get some initial estimates for the fitter
@@ -223,6 +223,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData,TSetupData *setup){
 	TH1D* hUncorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
 	histname << "_Corrected";
 	TH1D* hCorrectedPulse = (TH1D*) hPulseToFit->Clone(histname.str().c_str());
+	hCorrectedPulse->SetEntries(0); // set entries back to 0
 
 	double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname);
 	for (int iPulseBin = 1; iPulseBin <= hPulseToFit->GetNbinsX(); ++iPulseBin) {
@@ -349,7 +350,7 @@ double TemplateCreator::CorrectSampleValue(double old_value, double template_ped
 }
 
 // Creates a histogram with sub-bin resolution
-TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, int refine_factor) {
+TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, int refine_factor, bool interpolate) {
 
   std::string bankname = pulse->GetBankName();
   const std::vector<int>& theSamples = pulse->GetSamples();
@@ -364,13 +365,18 @@ TH1D* TemplateCreator::CreateRefinedPulseHistogram(const TPulseIsland* pulse, st
     int sample_number = i / refine_factor;
     double remainder = i % refine_factor;
     double sample_value;
-    try {
-      sample_value = theSamples.at(sample_number) + (remainder / refine_factor)*(theSamples.at(sample_number+1) - theSamples.at(sample_number));
+
+    if (interpolate) {
+      try {
+	sample_value = theSamples.at(sample_number) + (remainder / refine_factor)*(theSamples.at(sample_number+1) - theSamples.at(sample_number));
+      }
+      catch (const std::out_of_range& oor) { // if we'll be going out of range of the samples vector
+	sample_value = theSamples.at(sample_number);
+      }
     }
-    catch (const std::out_of_range& oor) { // if we'll be going out of range of the samples vector
+    else {
       sample_value = theSamples.at(sample_number);
     }
-    
     hist->SetBinContent( bin, sample_value);
     hist->SetBinError( bin, pedestal_error);
   }

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -49,7 +49,11 @@ class TemplateCreator : public BaseModule{
 
   /// \brief
   /// Creates a refined histogram for a given TPulseIsland
-  TH1D* CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, int refine_factor, bool interpolate);
+  TH1D* CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, bool interpolate);
+
+  /// \brief
+  /// The factor that we scale the number of bins in the template histogram by
+  int fRefineFactor;
 
   TemplateFitter* fTemplateFitter;
 };

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -58,6 +58,12 @@ class TemplateCreator : public BaseModule{
   /// If true, then print out all pulses that get added to the templates and also
   /// print out certain templates as we go along
   bool fPulseDebug;
+
+  /// \brief
+  /// Checks if the template has converged and that adding a new pulse has not effect on the template
+  /// Returns: true if converged
+  bool CheckConvergence(TH1D* hTemplate, std::string bankname);
+  std::map<std::string, TH1D*> fErrorVsPulseAddedHistograms;
 };
 
 #endif //TEMPLATECREATOR_H_

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -45,7 +45,7 @@ class TemplateCreator : public BaseModule{
 
   /// \brief
   /// Corrects a given sample value
-  double CorrectSampleValue(double old_value);
+  double CorrectSampleValue(double old_value, double template_pedestal);
 
   TemplateFitter* fTemplateFitter;
 };

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -41,6 +41,10 @@ class TemplateCreator : public BaseModule{
   std::map<std::string, int> fNPulsesInTemplate;
 
   /// \brief
+  /// A map of the template histograms
+  std::map<std::string, TH1D*> fTemplates;
+
+  /// \brief
   /// Corrects a given sample value
   double CorrectSampleValue(double old_value, double template_pedestal);
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -47,6 +47,10 @@ class TemplateCreator : public BaseModule{
   /// Corrects a given sample value
   double CorrectSampleValue(double old_value, double template_pedestal);
 
+  /// \brief
+  /// Creates a refined histogram for a given TPulseIsland
+  TH1D* CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, int refine_factor);
+
   TemplateFitter* fTemplateFitter;
 };
 

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -68,6 +68,7 @@ class TemplateCreator : public BaseModule{
   /// Returns: true if converged
   bool CheckConvergence(TH1D* hTemplate, std::string bankname);
   std::map<std::string, TH1D*> fErrorVsPulseAddedHistograms;
+  std::map<std::string, bool> fConvergedStatuses;
 };
 
 #endif //TEMPLATECREATOR_H_

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -49,7 +49,7 @@ class TemplateCreator : public BaseModule{
 
   /// \brief
   /// Creates a refined histogram for a given TPulseIsland
-  TH1D* CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, int refine_factor);
+  TH1D* CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, int refine_factor, bool interpolate);
 
   TemplateFitter* fTemplateFitter;
 };

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -40,9 +40,6 @@ class TemplateCreator : public BaseModule{
   /// A map of the number of pulses in the template
   std::map<std::string, int> fNPulsesInTemplate;
 
-  std::map<std::string, TH1D*> fErrorVsPulseAddedHistograms;
-  std::map<std::string, TH1D*> fProbVsPulseAddedHistograms;
-
   /// \brief
   /// Corrects a given sample value
   double CorrectSampleValue(double old_value, double template_pedestal);
@@ -56,6 +53,11 @@ class TemplateCreator : public BaseModule{
   int fRefineFactor;
 
   TemplateFitter* fTemplateFitter;
+
+  /// \brief
+  /// If true, then print out all pulses that get added to the templates and also
+  /// print out certain templates as we go along
+  bool fPulseDebug;
 };
 
 #endif //TEMPLATECREATOR_H_

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -27,8 +27,20 @@ class TemplateCreator : public BaseModule{
 
   void AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* pulse);
 
+  /// \brief 
+  /// A map of the number of fit attempts on each detector
   std::map<std::string, int> fNFitAttempts;
+
+  /// \brief 
+  /// A map of the number of successful fits on each detector
   std::map<std::string, int> fNSuccessfulFits;
+
+  /// \brief 
+  /// A map of the number of pulses in the template
+  std::map<std::string, int> fNPulsesInTemplate;
+
+  std::map<std::string, TH1D*> fErrorVsPulseAddedHistograms;
+  std::map<std::string, TH1D*> fProbVsPulseAddedHistograms;
 };
 
 #endif //TEMPLATECREATOR_H_

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -26,7 +26,7 @@ class TemplateCreator : public BaseModule{
 
   TemplateArchive* fTemplateArchive;
 
-  void AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* pulse);
+  void AddPulseToTemplate(TH1D* & hTemplate, TH1D* & hPulse, std::string bankname);
 
   /// \brief 
   /// A map of the number of fit attempts on each detector

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -26,6 +26,9 @@ class TemplateCreator : public BaseModule{
   TemplateArchive* fTemplateArchive;
 
   void AddPulseToTemplate(TH1D* & hTemplate, const TPulseIsland* pulse);
+
+  std::map<std::string, int> fNFitAttempts;
+  std::map<std::string, int> fNSuccessfulFits;
 };
 
 #endif //TEMPLATECREATOR_H_

--- a/analyzer/rootana/src/TAP_generators/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateCreator.h
@@ -8,6 +8,7 @@ class gModulesOptions;
 
 #include "utils/TemplateArchive.h"
 #include "utils/PulseCandidateFinder.h"
+#include "utils/TemplateFitter.h"
 
 class TemplateCreator : public BaseModule{
 
@@ -41,6 +42,12 @@ class TemplateCreator : public BaseModule{
 
   std::map<std::string, TH1D*> fErrorVsPulseAddedHistograms;
   std::map<std::string, TH1D*> fProbVsPulseAddedHistograms;
+
+  /// \brief
+  /// Corrects a given sample value
+  double CorrectSampleValue(double old_value);
+
+  TemplateFitter* fTemplateFitter;
 };
 
 #endif //TEMPLATECREATOR_H_

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -30,7 +30,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   double T_flt = par[2] - (double)T_int; // Floating point offset for linear interpolation
 
   static bool print_dbg = true;
-  if (print_dbg) {
+  if (print_dbg) { 
     std::cout << "At start of HistogramFitFCN::operator()" << std::endl;
     std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
   }

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -39,7 +39,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   bounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
   bounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
   if (print_dbg) {
-    std::cout << "NBinsX: HTEMPLATE = " << fTemplateHist->GetNbinsX() << ", HPULSE = " << fPulseHist->GetNbinsX() << std::endl;
+    std::cout << "NBinsX: hTemplate = " << fTemplateHist->GetNbinsX() << ", hPulse = " << fPulseHist->GetNbinsX() << std::endl;
     std::cout << "Bound Defns: " << std::endl;
     std::cout << "\tbounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1) = " << bounds[0] << std::endl;
     std::cout << "\tbounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX()) = " << bounds[1] << std::endl;
@@ -54,13 +54,14 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     f = fTemplateHist->GetBinContent(i - T_int) + (fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)) * T_flt;
     f = A * f + P;
 
-    double dev = fPulseHist->GetBinContent(i) - f;
+    double delta = fPulseHist->GetBinContent(i) - f;
     double hTemplate_bin_error = fTemplateHist->GetBinError(i);
     double hPulse_bin_error = fPulseHist->GetBinError(i);
-    chi2 += dev*dev / ((hTemplate_bin_error*hTemplate_bin_error) + (hPulse_bin_error)*(hPulse_bin_error));
+    chi2 += delta*delta / ((hTemplate_bin_error*hTemplate_bin_error) + (hPulse_bin_error)*(hPulse_bin_error));
     
-    std::cout << "hTemplate_bin_content = " << fTemplateHist->GetBinContent(i - T_int) << ", hPulse_bin_content = " << fPulseHist->GetBinContent(i) << ", f = " << f << std::endl;
-    std::cout << "dev = " << dev << ", hTemplate_bin_error = " << hTemplate_bin_error << ", hPulse_bin_error = " << hPulse_bin_error << ", chi2 = " << chi2 << std::endl;
+    std::cout << "hTemplate_bin_content(i - T_int) = " << fTemplateHist->GetBinContent(i - T_int) << ", hTemplate_bin_content(i - T_int + 1) = " << fTemplateHist->GetBinContent(i - T_int + 1) << std::endl;
+    std::cout << "hPulse_bin_content = " << fPulseHist->GetBinContent(i) << ", f = " << f << std::endl;
+    std::cout << "delta = " << delta << ", hTemplate_bin_error = " << hTemplate_bin_error << ", hPulse_bin_error = " << hPulse_bin_error << ", chi2 = " << chi2 << std::endl;
   }
 
   if (print_dbg) {

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -61,6 +61,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     double hTemplate_bin_error = fTemplateHist->GetBinError(i);
     double hPulse_bin_error = fPulseHist->GetBinError(i);
     chi2 += delta*delta / ((hTemplate_bin_error*hTemplate_bin_error) + (hPulse_bin_error)*(hPulse_bin_error));
+    //    std::cout << "Histogram Errors: Template = " << hTemplate_bin_error << ", Pulse = " << hPulse_bin_error << std::endl;
   }
 
   if (print_dbg) {

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -54,7 +54,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   for (int i = bounds[0]; i <= bounds[1]; ++i) {
     // We shift and scale the template so that it matches the pulse.
     // This is because, when we have a normalised template, we will get the actual amplitude, pedestal and time from the fit and not just offsets
-    f = fTemplateHist->GetBinContent(i - T_int) + (fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)) * T_flt;
+    f = fTemplateHist->GetBinContent(i - T_int) + T_flt*(fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)); // linear interpolation between the i'th and the (i+1)'th bin
     f = A * f + P;
 
     double delta = fPulseHist->GetBinContent(i) - f;

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -29,7 +29,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   int T_int = (int)par[2];            // Integral part of time shift
   double T_flt = par[2] - (double)T_int; // Floating point offset for linear interpolation
 
-  static bool print_dbg = false;
+  static bool print_dbg = true;
   if (print_dbg) { 
     std::cout << "HistogramFitFCN::operator() (start):" << std::endl;
     std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
@@ -45,8 +45,8 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   if (print_dbg) {
     std::cout << "NBinsX: hTemplate = " << fTemplateHist->GetNbinsX() << ", hPulse = " << fPulseHist->GetNbinsX() << std::endl;
     std::cout << "Bound Defns: " << std::endl;
-    std::cout << "\tbounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1) = " << bounds[0] << std::endl;
-    std::cout << "\tbounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX()) = " << bounds[1] << std::endl;
+    std::cout << "\tbounds[0] = " << bounds[0] << std::endl;
+    std::cout << "\tbounds[1] = " << bounds[1] << std::endl;
   }
 
   // Chi2 will be zero if shift is too high
@@ -60,7 +60,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     // We shift and scale the template so that it matches the pulse.
     // This is because, when we have a normalised template, we will get the actual amplitude, pedestal and time from the fit and not just offsets
     f = fTemplateHist->GetBinContent(i - T_int) + T_flt*(fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)); // linear interpolation between the i'th and the (i+1)'th bin
-    f = A * f + P; // apply the transformation to this bin
+    f = A * (f + P); // apply the transformation to this bin
 
     double delta = fPulseHist->GetBinContent(i) - f;
     double hTemplate_bin_error = fTemplateHist->GetBinError(i - T_int);

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -35,7 +35,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
   }
  
-  int half_range = 10;
+  int half_range = 10; // remove a few bins from the fit
   int bounds[2];
   bounds[0] = half_range+1;//std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
   bounds[1] = std::min(fTemplateHist->GetNbinsX(), fPulseHist->GetNbinsX()) - half_range-1; //std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -39,6 +39,8 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   bounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
   bounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
 
+  fNDoF = bounds[1] - bounds[0] - par.size();
+
   if (print_dbg) {
     std::cout << "NBinsX: hTemplate = " << fTemplateHist->GetNbinsX() << ", hPulse = " << fPulseHist->GetNbinsX() << std::endl;
     std::cout << "Bound Defns: " << std::endl;

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -49,8 +49,10 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   }
 
   // Chi2 will be zero if shift is too high
-  if (bounds[1] <= bounds[0])
-    std::cout << "ERROR: Fit of two histograms involves shifting one out-of-bounds (no overlap)!" << std::endl;
+  if (print_dbg) {
+    if (bounds[1] <= bounds[0])
+      std::cout << "ERROR: Fit of two histograms involves shifting one out-of-bounds (no overlap)!" << std::endl;
+  }
 
   double f;
   for (int i = bounds[0]; i <= bounds[1]; ++i) {

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -35,9 +35,10 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
   }
  
+  int half_range = 10;
   int bounds[2];
-  bounds[0] = 1;//std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
-  bounds[1] = fTemplateHist->GetNbinsX(); //std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
+  bounds[0] = half_range+1;//std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
+  bounds[1] = std::min(fTemplateHist->GetNbinsX(), fPulseHist->GetNbinsX()) - half_range-1; //std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
 
   fNDoF = bounds[1] - bounds[0] + 1 - par.size(); // +1 because we include both ends of the bounds when we loop through
 
@@ -62,7 +63,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     f = A * f + P; // apply the transformation to this bin
 
     double delta = fPulseHist->GetBinContent(i) - f;
-    double hTemplate_bin_error = fTemplateHist->GetBinError(i);
+    double hTemplate_bin_error = fTemplateHist->GetBinError(i - T_int);
     double hPulse_bin_error = fPulseHist->GetBinError(i);
     chi2 += delta*delta / ((hTemplate_bin_error*hTemplate_bin_error) + (hPulse_bin_error)*(hPulse_bin_error));
     //    std::cout << "Histogram Errors: Template = " << hTemplate_bin_error << ", Pulse = " << hPulse_bin_error << std::endl;

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -70,7 +70,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     double delta = fPulseHist->GetBinContent(i) - f;
     double hTemplate_bin_error = fTemplateHist->GetBinError(i - T_int);
     double hPulse_bin_error = fPulseHist->GetBinError(i);
-    chi2 += delta*delta / ((hTemplate_bin_error*hTemplate_bin_error) + (hPulse_bin_error)*(hPulse_bin_error));
+    chi2 += delta*delta / (hTemplate_bin_error*hTemplate_bin_error);
     //    std::cout << "Histogram Errors: Template = " << hTemplate_bin_error << ", Pulse = " << hPulse_bin_error << std::endl;
   }
 

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -36,15 +36,8 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   }
  
   int bounds[2];
-  bounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
-  bounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
-
-  if (print_dbg) {
-    std::cout << "NBinsX: hTemplate = " << fTemplateHist->GetNbinsX() << ", hPulse = " << fPulseHist->GetNbinsX() << std::endl;
-    std::cout << "Bound Defns: " << std::endl;
-    std::cout << "\tbounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1) = " << bounds[0] << std::endl;
-    std::cout << "\tbounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX()) = " << bounds[1] << std::endl;
-  }
+  bounds[0] = std::max(T_int - fH1->GetNbinsX() / 2, 1);
+  bounds[1] = std::min(T_int + fH1->GetNbinsX() / 2 - 1, fH2->GetNbinsX());
 
   // Chi2 will be zero if shift is too high
   if (bounds[1] <= bounds[0])
@@ -52,9 +45,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
 
   double f;
   for (int i = bounds[0]; i <= bounds[1]; ++i) {
-    // We shift and scale the template so that it matches the pulse.
-    // This is because, when we have a normalised template, we will get the actual amplitude, pedestal and time from the fit and not just offsets
-    f = fTemplateHist->GetBinContent(i - T_int) + T_flt*(fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)); // linear interpolation between the i'th and the (i+1)'th bin
+    f = fH1->GetBinContent(i - T_int) + (fH1->GetBinContent(i - T_int + 1) - fH1->GetBinContent(i - T_int)) * T_flt;
     f = A * f + P;
 
     double delta = fPulseHist->GetBinContent(i) - f;
@@ -64,10 +55,13 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   }
 
   if (print_dbg) {
-    std::cout << "HistogramFitFCN::operator() (end): " << std::endl;
-    std::cout << "\tFit:\tChi2 " << chi2 << "\tP "
+    std::cout << "Fit:\tChi2 " << chi2 << "\tP "
 	      << P << "(" << par[0] << ")\tA " << A << "(" << par[1] << ")\tT " << T_int << " " << T_flt << "(" << par[2] << ")" << " " << 0.02345
-	      << std::endl << std::endl;
+	      << std::endl;
+    std::cout << "Bounds " << bounds[0] << "-" << bounds[1]
+	      << "\tH1NX " << fH1->GetNbinsX()
+	      << "\tH2NX " << fH2->GetNbinsX()
+	      << std::endl; 
   }
   return chi2;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -52,10 +52,10 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
 
   double f;
   for (int i = bounds[0]; i <= bounds[1]; ++i) {
-    if (i - T_int < 1) {
+    /*    if (i - T_int < 1) {
       continue;
     }
-
+    */
     f = fTemplateHist->GetBinContent(i - T_int) + (fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)) * T_flt;
     f = A * f + P;
 

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -39,7 +39,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   bounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
   bounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
 
-  fNDoF = bounds[1] - bounds[0] - par.size();
+  fNDoF = bounds[1] - bounds[0] + 1 - par.size(); // +1 because we include both ends of the bounds when we loop through
 
   if (print_dbg) {
     std::cout << "NBinsX: hTemplate = " << fTemplateHist->GetNbinsX() << ", hPulse = " << fPulseHist->GetNbinsX() << std::endl;

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -39,12 +39,12 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
   }
  
-  int half_range = 10*5; // remove a few bins from the fit
+  int half_range = 10*fRefineFactor; // remove a few bins from the fit
   int bounds[2];
   bounds[0] = half_range+1;//std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
   bounds[1] = std::min(fTemplateHist->GetNbinsX(), fPulseHist->GetNbinsX()) - half_range-1; //std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
 
-  fNDoF = bounds[1] - bounds[0] + 1 - par.size(); // +1 because we include both ends of the bounds when we loop through
+  fNDoF = ((bounds[1] - bounds[0] + 1)/fRefineFactor) - par.size(); // +1 because we include both ends of the bounds when we loop through
 
   if (print_dbg) {
     std::cout << "NBinsX: hTemplate = " << fTemplateHist->GetNbinsX() << ", hPulse = " << fPulseHist->GetNbinsX() << std::endl;
@@ -61,7 +61,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
 
   double f;
   double template_pedestal = fTemplateHist->GetBinContent(1);
-  for (int i = bounds[0]; i <= bounds[1]; ++i) {
+  for (int i = bounds[0]+(fRefineFactor/2.0); i <= bounds[1]-(fRefineFactor/2.0); i += fRefineFactor) { // calculate the chi^2 based on the centre of the 5 bins to avoid getting abonus from mathcing all 5
     // We shift and scale the template so that it matches the pulse.
     // This is because, when we have a normalised template, we will get the actual amplitude, pedestal and time from the fit and not just offsets
     f = fTemplateHist->GetBinContent(i - T_int) + T_flt*(fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)); // linear interpolation between the i'th and the (i+1)'th bin

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -65,7 +65,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     // We shift and scale the template so that it matches the pulse.
     // This is because, when we have a normalised template, we will get the actual amplitude, pedestal and time from the fit and not just offsets
     f = fTemplateHist->GetBinContent(i - T_int) + T_flt*(fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)); // linear interpolation between the i'th and the (i+1)'th bin
-    f = A * (f + P - template_pedestal); // apply the transformation to this bin
+    f = A * (f - template_pedestal) + P; // apply the transformation to this bin
 
     double delta = fPulseHist->GetBinContent(i) - f;
     double hTemplate_bin_error = fTemplateHist->GetBinError(i - T_int);

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -33,7 +33,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   int T_int = (int)fTimeOffset;            // Integral part of time shift
   double T_flt = fTimeOffset - (double)T_int; // Floating point offset for linear interpolation
 
-  static bool print_dbg = true;
+  static bool print_dbg = false;
   if (print_dbg) { 
     std::cout << "HistogramFitFCN::operator() (start):" << std::endl;
     std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -33,13 +33,13 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   int T_int = (int)fTimeOffset;            // Integral part of time shift
   double T_flt = fTimeOffset - (double)T_int; // Floating point offset for linear interpolation
 
-  static bool print_dbg = false;
+  static bool print_dbg = true;
   if (print_dbg) { 
     std::cout << "HistogramFitFCN::operator() (start):" << std::endl;
     std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
   }
  
-  int half_range = 10; // remove a few bins from the fit
+  int half_range = 10*5; // remove a few bins from the fit
   int bounds[2];
   bounds[0] = half_range+1;//std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
   bounds[1] = std::min(fTemplateHist->GetNbinsX(), fPulseHist->GetNbinsX()) - half_range-1; //std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -26,13 +26,12 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   double chi2 = 0.;
   double P = par[0];
   double A = par[1];
-  int T_i = (int)par[2];            // Integral part of time shift
-  double T_f = par[2] - (double)T_i; // Floating point offset for linear interpolation
-  
+  int T_int = (int)par[2];            // Integral part of time shift
+  double T_flt = par[2] - (double)T_int; // Floating point offset for linear interpolation
 
   int bounds[2];
-  bounds[0] = std::max(T_i - fH1->GetNbinsX() / 2, 1);
-  bounds[1] = std::min(T_i + fH1->GetNbinsX() / 2 - 1, fH2->GetNbinsX());
+  bounds[0] = std::max(T_int - fH1->GetNbinsX() / 2, 1);
+  bounds[1] = std::min(T_int + fH1->GetNbinsX() / 2 - 1, fH2->GetNbinsX());
 
   // Chi2 will be zero if shift is too high
   if (bounds[1] <= bounds[0])
@@ -40,7 +39,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
 
   double f;
   for (int i = bounds[0]; i <= bounds[1]; ++i) {
-    f = fH1->GetBinContent(i - T_i) + (fH1->GetBinContent(i - T_i + 1) - fH1->GetBinContent(i - T_i)) * T_f;
+    f = fH1->GetBinContent(i - T_int) + (fH1->GetBinContent(i - T_int + 1) - fH1->GetBinContent(i - T_int)) * T_flt;
     f = A * f + P;
     chi2 += std::pow((fH1->GetBinContent(i) - f) / fH1->GetBinError(i), 2.);
   }
@@ -48,7 +47,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   static bool print_dbg = false;
   if (print_dbg) {
     std::cout << "Fit:\tChi2 " << chi2 << "\tP "
-	      << P << "(" << par[0] << ")\tA " << A << "(" << par[1] << ")\tT " << T_i << " " << T_f << "(" << par[2] << ")" << " " << 0.02345
+	      << P << "(" << par[0] << ")\tA " << A << "(" << par[1] << ")\tT " << T_int << " " << T_flt << "(" << par[2] << ")" << " " << 0.02345
 	      << std::endl;
     std::cout << "Bounds " << bounds[0] << "-" << bounds[1]
 	      << "\tH1NX " << fH1->GetNbinsX()

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -36,8 +36,8 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   }
  
   int bounds[2];
-  bounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
-  bounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
+  bounds[0] = 1;//std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
+  bounds[1] = fTemplateHist->GetNbinsX(); //std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
 
   fNDoF = bounds[1] - bounds[0] + 1 - par.size(); // +1 because we include both ends of the bounds when we loop through
 
@@ -59,7 +59,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     // We shift and scale the template so that it matches the pulse.
     // This is because, when we have a normalised template, we will get the actual amplitude, pedestal and time from the fit and not just offsets
     f = fTemplateHist->GetBinContent(i - T_int) + T_flt*(fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)); // linear interpolation between the i'th and the (i+1)'th bin
-    f = A * f + P;
+    f = A * f + P; // apply the transformation to this bin
 
     double delta = fPulseHist->GetBinContent(i) - f;
     double hTemplate_bin_error = fTemplateHist->GetBinError(i);

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -30,21 +30,22 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   double T_flt = par[2] - (double)T_int; // Floating point offset for linear interpolation
 
   static bool print_dbg = true;
-  if (print_dbg) { 
+  /*  if (print_dbg) { 
     std::cout << "At start of HistogramFitFCN::operator()" << std::endl;
     std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
   }
-
+  */
   int bounds[2];
   bounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
   bounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
+  /*
   if (print_dbg) {
     std::cout << "NBinsX: hTemplate = " << fTemplateHist->GetNbinsX() << ", hPulse = " << fPulseHist->GetNbinsX() << std::endl;
     std::cout << "Bound Defns: " << std::endl;
     std::cout << "\tbounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1) = " << bounds[0] << std::endl;
     std::cout << "\tbounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX()) = " << bounds[1] << std::endl;
   }
-
+  */
   // Chi2 will be zero if shift is too high
   if (bounds[1] <= bounds[0])
     std::cout << "ERROR: Fit of two histograms involves shifting one out-of-bounds (no overlap)!" << std::endl;
@@ -62,10 +63,11 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     double hTemplate_bin_error = fTemplateHist->GetBinError(i);
     double hPulse_bin_error = fPulseHist->GetBinError(i);
     chi2 += delta*delta / ((hTemplate_bin_error*hTemplate_bin_error) + (hPulse_bin_error)*(hPulse_bin_error));
-    
+    /*
     std::cout << "hTemplate_bin_content(i - T_int) = " << fTemplateHist->GetBinContent(i - T_int) << ", hTemplate_bin_content(i - T_int + 1) = " << fTemplateHist->GetBinContent(i - T_int + 1) << std::endl;
     std::cout << "hPulse_bin_content = " << fPulseHist->GetBinContent(i) << ", f = " << f << std::endl;
     std::cout << "delta = " << delta << ", hTemplate_bin_error = " << hTemplate_bin_error << ", hPulse_bin_error = " << hPulse_bin_error << ", chi2 = " << chi2 << std::endl;
+    */
   }
 
   if (print_dbg) {

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -51,6 +51,10 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
 
   double f;
   for (int i = bounds[0]; i <= bounds[1]; ++i) {
+    if (i - T_int < 1) {
+      continue;
+    }
+
     f = fTemplateHist->GetBinContent(i - T_int) + (fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)) * T_flt;
     f = A * f + P;
 

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -71,7 +71,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   }
 
   if (print_dbg) {
-    std::cout << "Fit:\tChi2 " << chi2 << "\tP "
+    std::cout << "HistogramFitFCN::operator(): Fit:\tChi2 " << chi2 << "\tP "
 	      << P << "(" << par[0] << ")\tA " << A << "(" << par[1] << ")\tT " << T_int << " " << T_flt << "(" << par[2] << ")" << " " << 0.02345
 	      << std::endl;
   }

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -3,18 +3,18 @@
 #include <cmath>
 #include <iostream>
 
-HistogramFitFCN::HistogramFitFCN(TH1D* h1, TH1D* h2) : fH1(h1), fH2(h2) {
+HistogramFitFCN::HistogramFitFCN(TH1D* hTemplate, TH1D* hPulse) : fTemplateHist(hTemplate), fPulseHist(hPulse) {
 }
 
 HistogramFitFCN::~HistogramFitFCN() {
 }
 
-void HistogramFitFCN::SetH1(TH1D* h1) {
-  fH1 = h1;
+void HistogramFitFCN::SetTemplateHist(TH1D* hTemplate) {
+  fTemplateHist = hTemplate;
 }
 
-void HistogramFitFCN::SetH2(TH1D* h2) {
-  fH2 = h2;
+void HistogramFitFCN::SetPulseHist(TH1D* hPulse) {
+  fPulseHist = hPulse;
 }
 
 double HistogramFitFCN::operator() (const std::vector<double>& par) const {
@@ -29,9 +29,21 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   int T_int = (int)par[2];            // Integral part of time shift
   double T_flt = par[2] - (double)T_int; // Floating point offset for linear interpolation
 
+  static bool print_dbg = true;
+  if (print_dbg) {
+    std::cout << "At start of HistogramFitFCN::operator()" << std::endl;
+    std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
+  }
+
   int bounds[2];
-  bounds[0] = std::max(T_int - fH1->GetNbinsX() / 2, 1);
-  bounds[1] = std::min(T_int + fH1->GetNbinsX() / 2 - 1, fH2->GetNbinsX());
+  bounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1);
+  bounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX());
+  if (print_dbg) {
+    std::cout << "NBinsX: HTEMPLATE = " << fTemplateHist->GetNbinsX() << ", HPULSE = " << fPulseHist->GetNbinsX() << std::endl;
+    std::cout << "Bound Defns: " << std::endl;
+    std::cout << "\tbounds[0] = std::max(T_int - fTemplateHist->GetNbinsX() / 2, 1) = " << bounds[0] << std::endl;
+    std::cout << "\tbounds[1] = std::min(T_int + fTemplateHist->GetNbinsX() / 2 - 1, fPulseHist->GetNbinsX()) = " << bounds[1] << std::endl;
+  }
 
   // Chi2 will be zero if shift is too high
   if (bounds[1] <= bounds[0])
@@ -39,20 +51,22 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
 
   double f;
   for (int i = bounds[0]; i <= bounds[1]; ++i) {
-    f = fH1->GetBinContent(i - T_int) + (fH1->GetBinContent(i - T_int + 1) - fH1->GetBinContent(i - T_int)) * T_flt;
+    f = fTemplateHist->GetBinContent(i - T_int) + (fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)) * T_flt;
     f = A * f + P;
-    chi2 += std::pow((fH1->GetBinContent(i) - f) / fH1->GetBinError(i), 2.);
+
+    double dev = fPulseHist->GetBinContent(i) - f;
+    double hTemplate_bin_error = fTemplateHist->GetBinError(i);
+    double hPulse_bin_error = fPulseHist->GetBinError(i);
+    chi2 += dev*dev / ((hTemplate_bin_error*hTemplate_bin_error) + (hPulse_bin_error)*(hPulse_bin_error));
+    
+    std::cout << "hTemplate_bin_content = " << fTemplateHist->GetBinContent(i - T_int) << ", hPulse_bin_content = " << fPulseHist->GetBinContent(i) << ", f = " << f << std::endl;
+    std::cout << "dev = " << dev << ", hTemplate_bin_error = " << hTemplate_bin_error << ", hPulse_bin_error = " << hPulse_bin_error << ", chi2 = " << chi2 << std::endl;
   }
 
-  static bool print_dbg = false;
   if (print_dbg) {
     std::cout << "Fit:\tChi2 " << chi2 << "\tP "
 	      << P << "(" << par[0] << ")\tA " << A << "(" << par[1] << ")\tT " << T_int << " " << T_flt << "(" << par[2] << ")" << " " << 0.02345
 	      << std::endl;
-    std::cout << "Bounds " << bounds[0] << "-" << bounds[1]
-	      << "\tH1NX " << fH1->GetNbinsX()
-	      << "\tH2NX " << fH2->GetNbinsX()
-	      << std::endl; 
   }
   return chi2;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
@@ -9,15 +9,15 @@
 class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
 
  private:
-  TH1D* fH1; // The template
-  TH1D* fH2; // The histogram to fit
+  TH1D* fTemplateHist; // The template
+  TH1D* fPulseHist; // The histogram to fit
 
  public:
   HistogramFitFCN(TH1D* = NULL, TH1D* = NULL);
   ~HistogramFitFCN();
 
-  void SetH1(TH1D*);
-  void SetH2(TH1D*);
+  void SetTemplateHist(TH1D*);
+  void SetPulseHist(TH1D*);
 
   // Used for calls with parameters
   // The return value is the chi squared

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
@@ -35,6 +35,12 @@ class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
   
  public:
   int GetNDoF() { return fNDoF; }
+
+ private:
+  double fTimeOffset; // the time offset to use
+
+ public:
+  void SetTimeOffset(double time_offset);
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
@@ -41,6 +41,12 @@ class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
 
  public:
   void SetTimeOffset(double time_offset);
+
+ private:
+  int fRefineFactor;
+
+ public:
+  void SetRefineFactor(int refine_factor) {fRefineFactor = refine_factor;}
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
@@ -21,7 +21,7 @@ class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
 
   // Used for calls with parameters
   // The return value is the chi squared
-  // weighted by errors in fH1
+  // weighted by errors in fTemplateHist
   // Parameters:
   // 1. Pedestal
   // 2. Amplitude
@@ -29,6 +29,12 @@ class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
   double operator() (const std::vector<double>& par) const;
   // Used for error... somehow?
   double Up() const;
+
+ private:
+  mutable int fNDoF; // record this for TemplateFitter to retrieve later (NB mutable so that it can be set in operator(), which is const)
+  
+ public:
+  int GetNDoF() { return fNDoF; }
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -1,5 +1,7 @@
 #include "PulseCandidateFinder.h"
 
+#include "SetupNavigator.h"
+
 #include "definitions.h"
 
 #include <iostream>
@@ -187,8 +189,9 @@ void PulseCandidateFinder::FillParameterHistogram(TH1D* histogram) {
     FillSampleDifferencesHistogram(histogram);
   }
 
-  std::string histtitle = "Plot of " + parameter_name + " for " + detname + " for Run 2808";
-  histogram->SetTitle(histtitle.c_str());
+  std::stringstream histtitle;
+  histtitle << "Plot of " << parameter_name << " for " << detname << " for Run " << SetupNavigator::Instance()->GetRunNumber();
+  histogram->SetTitle(histtitle.str().c_str());
   histogram->GetYaxis()->SetTitle("");
   histogram->GetXaxis()->SetTitle(parameter_name.c_str());
 }

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -285,7 +285,7 @@ void PulseCandidateFinder::SetDefaultParameterValues() {
   fDefaultParameterValues[IDs::channel("ScL")] = 20;
   fDefaultParameterValues[IDs::channel("ScR")] = 20;
   fDefaultParameterValues[IDs::channel("ScGe")] = 20;
-  fDefaultParameterValues[IDs::channel("ScVe")] = 40;
+  fDefaultParameterValues[IDs::channel("ScVe")] = 30;
 
   fDefaultParameterValues[IDs::channel("SiL2-F")] = 80;
   fDefaultParameterValues[IDs::channel("SiL1-1-F")] = 40;

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -287,9 +287,6 @@ std::map<IDs::channel, double> PulseCandidateFinder::fOneSigmaValues;
 /// Sets the one sigma values that we get from the text file
 void PulseCandidateFinder::SetOneSigmaValues() {
 
-  // Open the text file
-  std::ifstream file_in("pedestal-and-noise.txt", std::ifstream::in);
-
   // The values that we will read in
   std::string detname, bankname;
   std::string pedestal, noise;

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -166,7 +166,6 @@ void PulseCandidateFinder::FindCandidatePulses_Slow(int threshold) {
 	}
 
 	start = stop = 0;
-	std::cout << "Location: start = " << location.start << ", stop = " << location.stop << std::endl;
 	fPulseCandidateLocations.push_back(location);
 	found = false;
       }

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -291,6 +291,7 @@ std::map<IDs::channel, double> PulseCandidateFinder::fOneSigmaValues;
 void PulseCandidateFinder::SetOneSigmaValues() {
 
   // The values that we will read in
+  std::string run_number;
   std::string detname, bankname;
   std::string pedestal, noise;
 
@@ -307,11 +308,12 @@ void PulseCandidateFinder::SetOneSigmaValues() {
 
     TSQLiteRow* row = (TSQLiteRow*) result->Next(); // get the first row
     while (row != NULL) {
-      //      std::cout << row->GetField(0) << " " << row->GetField(1) << " " << row->GetField(2) << " " << row->GetField(3) << std::endl;
-      detname = row->GetField(0);
-      bankname = row->GetField(1);
-      pedestal = row->GetField(2);
-      noise = row->GetField(3);
+      //      std::cout << row->GetField(0) << " " << row->GetField(1) << " " << row->GetField(2) << " " << row->GetField(3) << " " << row->GetField(4) << std::endl;
+      run_number = row->GetField(0);
+      detname = row->GetField(1);
+      bankname = row->GetField(2);
+      pedestal = row->GetField(3);
+      noise = row->GetField(4);
 
       fOneSigmaValues[IDs::channel(detname)] = atof(noise.c_str());
       

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -145,20 +145,29 @@ void PulseCandidateFinder::FindCandidatePulses_Slow(int threshold) {
   Location location;
 
   // Loop through the samples
+  int n_border_samples = 20; // take some samples before and after the candidate officially stops
   for (unsigned int i = 0; i < n_samples; ++i) {
     sample_height = polarity * (samples[i] - pedestal);
 
     if (found) {
       if (sample_height < 0) { // stop if the sample goes below pedestal
-	location.stop = (int)i;
+	location.stop = (int)i + n_border_samples;
+	if (location.stop >= samples.size()) {
+	  location.stop = samples.size() - 1;
+	}
+
 	start = stop = 0;
+	std::cout << "Location: start = " << location.start << ", stop = " << location.stop << std::endl;
 	fPulseCandidateLocations.push_back(location);
 	found = false;
       }
     } else {
       if (sample_height > threshold) {
 	found = true;
-	location.start = (int)(i);
+	location.start = (int)(i) - n_border_samples;
+	if (location.start < 0) {
+	  location.start = 0;
+	}
       }
     }
   }

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -110,6 +110,7 @@ void PulseCandidateFinder::FindCandidatePulses_Fast(int rise) {
   Location location;
 
   // Loop through the samples
+  int n_border_samples = 10; // take some samples before and after the candidate officially stops
   for (unsigned int i = 1; i < n_samples; ++i) {
     s1 = polarity * (samples[i-1] - pedestal);
     s2 = polarity * (samples[i] - pedestal);
@@ -117,14 +118,22 @@ void PulseCandidateFinder::FindCandidatePulses_Fast(int rise) {
 
     if (found) {
       if (s2 < 0) { // stop if the sample goes below pedestal
-	location.stop = (int)i;
+	location.stop = (int)i + n_border_samples;
+	if (location.stop >= samples.size()) {
+	  location.stop = samples.size() - 1;
+	}
+
 	fPulseCandidateLocations.push_back(location);
 	found = false;
       }
     } else {
       if (ds > rise) {
 	found = true;
-	location.start = (int)(i - 1);
+	location.start = (int)(i - 1) - n_border_samples;
+
+	if (location.start < 0) {
+	  location.start = 0;
+	}
       }
     }
   }
@@ -145,7 +154,7 @@ void PulseCandidateFinder::FindCandidatePulses_Slow(int threshold) {
   Location location;
 
   // Loop through the samples
-  int n_border_samples = 20; // take some samples before and after the candidate officially stops
+  int n_border_samples = 10; // take some samples before and after the candidate officially stops
   for (unsigned int i = 0; i < n_samples; ++i) {
     sample_height = polarity * (samples[i] - pedestal);
 

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateArchive.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateArchive.cpp
@@ -22,8 +22,10 @@ TH1D* TemplateArchive::GetTemplate(const char* template_name) {
 // -- saves a template to the template file
 void TemplateArchive::SaveTemplate(TH1* hTemplate) {
 
+  TDirectory* oldDir = TDirectory::CurrentDirectory(); // should be the directory we were already in
   if (hTemplate) {
     fTemplateFile->cd();
     hTemplate->Write();
   }
+  oldDir->cd(); // go back to the old directory
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -37,9 +37,13 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
   HistogramFitFCN* fcn = (HistogramFitFCN*)fMinuitFitter->GetMinuitFCN();
   fcn->SetTemplateHist(hTemplate);
   fcn->SetPulseHist(hPulse);
-  fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, 0, 0);
-  fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1, 0, 0);
-  fMinuitFitter->SetParameter(2, "TimeOffset", fTimeOffset, 1., 0, 0); // Timing should have step size no smaller than binning,
+
+  int n_bits = TSetupData::Instance()->GetNBits(bankname);
+  double max_adc_value = std::pow(2, n_bits);
+
+  fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, 0, max_adc_value);
+  fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1*fAmplitudeScaleFactor, 0, 10);
+  fMinuitFitter->SetParameter(2, "TimeOffset", fTimeOffset, 1., -10, 10); // Timing should have step size no smaller than binning,
                                                     // *IF* the fourth argument is step size this is okay,
                                                     // or later implement some interpolation method, note
                                                     // *DERIVATIVES* at bounderies of interpolation may cause

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -3,6 +3,8 @@
 #include "HistogramFitFCN.h"
 #include "SetupNavigator.h"
 
+#include "TMath.h"
+
 TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
 
   HistogramFitFCN* fcn = new HistogramFitFCN();
@@ -62,10 +64,13 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
   params.push_back(fTimeOffset); 
   fChi2 = (*fcn)(params);
 
+  fNDoF = fcn->GetNDoF();
+
   static int print_dbg = false;
   if (print_dbg) {
     std::cout << "TemplateFitter::FitPulseToTemplate(): Fit:\tChi2 " << fChi2 << "\tP "
-	      << fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" << std::endl;
+	      << fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" 
+	      << ", ndof = " << fNDoF << ", prob = " << TMath::Prob(fChi2, fNDoF) << std::endl;
   }
 
   delete hPulse;

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -14,7 +14,7 @@ TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
 TemplateFitter::~TemplateFitter() {
 }
 
-void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pulse) {
+int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pulse) {
   // First make a histogram out of the pulse with the same bin width as the template,
   // Then pass to the Minuit fitter.
   // Returns ped in units of ADC counts, amp in... scale units(?), and time in units
@@ -69,6 +69,8 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   }
 
   delete hPulse;
+
+  return status; // return status for the calling module to look at
 }
 
 /*

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -47,11 +47,17 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
     std::cout << "ERROR: Problem with fit (" << status << ")!" << std::endl;
 
   // Store the Chi2, and then we can delete the pulse
+  fPedestal = fMinuitFitter->GetParameter(0);
+  fAmplitude = fMinuitFitter->GetParameter(1);
+  fTime = fMinuitFitter->GetParameter(2);
   std::vector<double> params; 
   params.push_back(fPedestal); 
   params.push_back(fAmplitude); 
   params.push_back(fTime); 
   fChi2 = (*fcn)(params);
+
+  std::cout << "TemplateFitter::FitPulseToTempalte(): Fit:\tChi2 " << fChi2 << "\tP "
+	    << fPedestal << "(" << params.at(0) << ")\tA " << fAmplitude << "(" << params.at(1) << ")\tT " << fTime << "(" << params.at(2) << ")" << std::endl;
 
   delete hPulse;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -11,7 +11,6 @@ TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
   fMinuitFitter = new TFitterMinuit(3); //  Three (3) parameters to modify (amplitude, time, pedestal)
   fMinuitFitter->SetMinuitFCN(fcn);
   fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
-  fMinuitFitter->CreateMinimizer(TFitterMinuit::kMigrad);
 }
 
 TemplateFitter::~TemplateFitter() {
@@ -50,7 +49,7 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
                                                     // *DERIVATIVES* at bounderies of interpolation may cause
                                                     // problems since MIGRAD (the default method) relies on
                                                     // these heavily.
-  fMinuitFitter->CreateMinimizer();
+  fMinuitFitter->CreateMinimizer(TFitterMinuit::kMigrad);
 
   // Minimize and notify if there was a problem
   int status = fMinuitFitter->Minimize();

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -41,7 +41,7 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, TH1D* hPulse, std::strin
                                                     // these heavily.
 
   // Loop through some time offsets ourselved
-  double max_time_offset = 4; // maximum distance to go from the initial estimate
+  double max_time_offset = 4*5; // maximum distance to go from the initial estimate
   double best_time_offset = 0;
   double best_pedestal_offset = 0;
   double best_amplitude_scale_factor = 0;

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -5,12 +5,13 @@
 
 #include "TMath.h"
 
-TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
+TemplateFitter::TemplateFitter(std::string detname, int refine_factor): fChannel(detname), fRefineFactor(refine_factor) {
 
   HistogramFitFCN* fcn = new HistogramFitFCN();
   fMinuitFitter = new TFitterMinuit(2); //  Two (2) parameters to modify (amplitude, pedestal). We will try and do the time one ourselves
   fMinuitFitter->SetMinuitFCN(fcn);
   fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
+  fcn->SetRefineFactor(fRefineFactor);
 }
 
 TemplateFitter::~TemplateFitter() {
@@ -41,7 +42,7 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, TH1D* hPulse, std::strin
                                                     // these heavily.
 
   // Loop through some time offsets ourselved
-  double max_time_offset = 4*5; // maximum distance to go from the initial estimate
+  double max_time_offset = 4*fRefineFactor; // maximum distance to go from the initial estimate
   double best_time_offset = 0;
   double best_pedestal_offset = 0;
   double best_amplitude_scale_factor = 0;

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -31,9 +31,9 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   HistogramFitFCN* fcn = (HistogramFitFCN*)fMinuitFitter->GetMinuitFCN();
   fcn->SetTemplateHist(hTemplate);
   fcn->SetPulseHist(hPulse);
-  fMinuitFitter->SetParameter(0, "Pedestal", fPedestal, 0.1, 0, 0);
-  fMinuitFitter->SetParameter(1, "Amplitude", fAmplitude, 0.1, 0, 0);
-  fMinuitFitter->SetParameter(2, "Time", fTime, 1., 0, 0); // Timing should have step size no smaller than binning,
+  fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, 0, 0);
+  fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1, 0, 0);
+  fMinuitFitter->SetParameter(2, "TimeOffset", fTimeOffset, 1., 0, 0); // Timing should have step size no smaller than binning,
                                                     // *IF* the fourth argument is step size this is okay,
                                                     // or later implement some interpolation method, note
                                                     // *DERIVATIVES* at bounderies of interpolation may cause
@@ -47,19 +47,19 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
     std::cout << "ERROR: Problem with fit (" << status << ")!" << std::endl;
 
   // Get the fitted values
-  fPedestal = fMinuitFitter->GetParameter(0);
-  fAmplitude = fMinuitFitter->GetParameter(1);
-  fTime = fMinuitFitter->GetParameter(2);
+  fPedestalOffset = fMinuitFitter->GetParameter(0);
+  fAmplitudeScaleFactor = fMinuitFitter->GetParameter(1);
+  fTimeOffset = fMinuitFitter->GetParameter(2);
 
   // Store the Chi2, and then we can delete the pulse
   std::vector<double> params; 
-  params.push_back(fPedestal); 
-  params.push_back(fAmplitude); 
-  params.push_back(fTime); 
+  params.push_back(fPedestalOffset); 
+  params.push_back(fAmplitudeScaleFactor); 
+  params.push_back(fTimeOffset); 
   fChi2 = (*fcn)(params);
 
-  std::cout << "TemplateFitter::FitPulseToTempalte(): Fit:\tChi2 " << fChi2 << "\tP "
-	    << fPedestal << "(" << params.at(0) << ")\tA " << fAmplitude << "(" << params.at(1) << ")\tT " << fTime << "(" << params.at(2) << ")" << std::endl;
+  std::cout << "TemplateFitter::FitPulseToTemplate(): Fit:\tChi2 " << fChi2 << "\tP "
+	    << fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" << std::endl;
 
   delete hPulse;
 }
@@ -77,7 +77,7 @@ double PulseTemplate::Correlation(TPulseIsland* pulse, double& ped, double& amp,
 */
 
 void TemplateFitter::SetInitialParameterEstimates(double pedestal, double amplitude, double time) {
-  fPedestal = pedestal;
-  fAmplitude = amplitude;
-  fTime = time;
+  fPedestalOffset = pedestal;
+  fAmplitudeScaleFactor = amplitude;
+  fTimeOffset = time;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -41,7 +41,7 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
   int n_bits = TSetupData::Instance()->GetNBits(bankname);
   double max_adc_value = std::pow(2, n_bits);
 
-  fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, 0, max_adc_value);
+  fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, -10*max_adc_value, 10*max_adc_value);
   fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1, 0, 100);
   //  fMinuitFitter->SetParameter(2, "TimeOffset", fTimeOffset, 1., -10, 10); // Timing should have step size no smaller than binning,
                                                     // *IF* the fourth argument is step size this is okay,
@@ -56,6 +56,8 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
   // Loop through some time offsets ourselved
   double max_time_offset = 1; // maximum distance to go from the initial estimate
   double best_time_offset = 0;
+  double best_pedestal_offset = 0;
+  double best_amplitude_scale_factor = 0;
   double best_chi2 = 99999999999;
 
   for (double time_offset = fTimeOffset - max_time_offset; time_offset <= fTimeOffset + max_time_offset; ++time_offset) {
@@ -87,6 +89,8 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
 
     if (status == 0 && fChi2 < best_chi2) {
       best_time_offset = time_offset;
+      best_pedestal_offset = fPedestalOffset;
+      best_amplitude_scale_factor = fAmplitudeScaleFactor;
       best_chi2 = fChi2;
     }
 
@@ -100,6 +104,8 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
   // Store the final best values
   fChi2 = best_chi2;
   fTimeOffset = best_time_offset;
+  fPedestalOffset = best_pedestal_offset;
+  fAmplitudeScaleFactor = best_amplitude_scale_factor;
 
   delete hPulse;
 

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -47,14 +47,11 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
     std::cout << "ERROR: Problem with fit (" << status << ")!" << std::endl;
 
   // Get the fitted values
-  fPedestalOffset = fMinuitFitter->GetParameter(0);
-  fAmplitudeScaleFactor = fMinuitFitter->GetParameter(1);
-  fTimeOffset = fMinuitFitter->GetParameter(2);
-
-  // Store the Chi2, and then we can delete the pulse
   fPedestal = fMinuitFitter->GetParameter(0);
   fAmplitude = fMinuitFitter->GetParameter(1);
   fTime = fMinuitFitter->GetParameter(2);
+
+  // Store the Chi2, and then we can delete the pulse
   std::vector<double> params; 
   params.push_back(fPedestalOffset); 
   params.push_back(fAmplitudeScaleFactor); 

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -29,8 +29,8 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   // Prepare for minimizations
   fMinuitFitter->Clear();
   HistogramFitFCN* fcn = (HistogramFitFCN*)fMinuitFitter->GetMinuitFCN();
-  fcn->SetH1(hTemplate);
-  fcn->SetH2(hPulse);
+  fcn->SetTemplateHist(hTemplate);
+  fcn->SetPulseHist(hPulse);
   fMinuitFitter->SetParameter(0, "Pedestal", fPedestal, 0.1, 0, 0);
   fMinuitFitter->SetParameter(1, "Amplitude", fAmplitude, 0.1, 0, 0);
   fMinuitFitter->SetParameter(2, "Time", fTime, 1., 0, 0); // Timing should have step size no smaller than binning,
@@ -67,3 +67,9 @@ double PulseTemplate::Correlation(TPulseIsland* pulse, double& ped, double& amp,
   return 0.;
 }
 */
+
+void TemplateFitter::SetInitialParameterEstimates(double pedestal, double amplitude, double time) {
+  fPedestal = pedestal;
+  fAmplitude = amplitude;
+  fTime = time;
+}

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -152,6 +152,14 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
   fPedestalOffset = best_pedestal_offset;
   fAmplitudeScaleFactor = best_amplitude_scale_factor;
 
+  double delta_time_offset_error = 1;
+  if ( (fTimeOffset < fTimeOffset_minimum + delta_time_offset_error && fTimeOffset > fTimeOffset_minimum - delta_time_offset_error) ||
+       (fTimeOffset < fTimeOffset_maximum + delta_time_offset_error && fTimeOffset > fTimeOffset_maximum - delta_time_offset_error) ) {
+
+      std::cout << "ERROR: TimeOffset has hit a boundary (" << fTimeOffset << ")" << std::endl;
+      best_status = -9999;
+  }
+
   delete hPulse;
 
   return best_status; // return status for the calling module to look at

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -2,12 +2,12 @@
 
 #include "HistogramFitFCN.h"
 
-TemplateFitter::TemplateFitter() {
+TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
 
   HistogramFitFCN* fcn = new HistogramFitFCN();
   fMinuitFitter = new TFitterMinuit(3); //  Three (3) parameters to modify (amplitude, time, pedestal)
   fMinuitFitter->SetMinuitFCN(fcn);
-  fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
+  fMinuitFitter->SetPrintLevel(1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
 }
 
 TemplateFitter::~TemplateFitter() {
@@ -15,7 +15,7 @@ TemplateFitter::~TemplateFitter() {
 
 void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pulse) {
   // First make a histogram out of the pulse with the same bin width as the template,
-  // Then pass to fitter.
+  // Then pass to the Minuit fitter.
   // Returns ped in units of ADC counts, amp in... scale units(?), and time in units
   // of bins since the beginning of pulse
   std::vector<int> samples = pulse->GetSamples();

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -10,7 +10,7 @@ TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
   HistogramFitFCN* fcn = new HistogramFitFCN();
   fMinuitFitter = new TFitterMinuit(3); //  Three (3) parameters to modify (amplitude, time, pedestal)
   fMinuitFitter->SetMinuitFCN(fcn);
-  fMinuitFitter->SetPrintLevel(1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
+  fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
 }
 
 TemplateFitter::~TemplateFitter() {
@@ -49,8 +49,12 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
 
   // Minimize and notify if there was a problem
   int status = fMinuitFitter->Minimize();
-  if (status != 0)
-    std::cout << "ERROR: Problem with fit (" << status << ")!" << std::endl;
+
+  static int print_dbg = false;
+  if (print_dbg) {
+    if (status != 0)
+      std::cout << "ERROR: Problem with fit (" << status << ")!" << std::endl;
+  }
 
   // Get the fitted values
   fPedestalOffset = fMinuitFitter->GetParameter(0);
@@ -66,7 +70,6 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
 
   fNDoF = fcn->GetNDoF();
 
-  static int print_dbg = false;
   if (print_dbg) {
     std::cout << "TemplateFitter::FitPulseToTemplate(): Fit:\tChi2 " << fChi2 << "\tP "
 	      << fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" 

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -31,9 +31,9 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   HistogramFitFCN* fcn = (HistogramFitFCN*)fMinuitFitter->GetMinuitFCN();
   fcn->SetTemplateHist(hTemplate);
   fcn->SetPulseHist(hPulse);
-  fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, 0, 0);
-  fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1, 0, 0);
-  fMinuitFitter->SetParameter(2, "TimeOffset", fTimeOffset, 1., 0, 0); // Timing should have step size no smaller than binning,
+  fMinuitFitter->SetParameter(0, "Pedestal", fPedestal, 0.1, 0, 0);
+  fMinuitFitter->SetParameter(1, "Amplitude", fAmplitude, 0.1, 0, 0);
+  fMinuitFitter->SetParameter(2, "Time", fTime, 1., 0, 0); // Timing should have step size no smaller than binning,
                                                     // *IF* the fourth argument is step size this is okay,
                                                     // or later implement some interpolation method, note
                                                     // *DERIVATIVES* at bounderies of interpolation may cause
@@ -80,7 +80,7 @@ double PulseTemplate::Correlation(TPulseIsland* pulse, double& ped, double& amp,
 */
 
 void TemplateFitter::SetInitialParameterEstimates(double pedestal, double amplitude, double time) {
-  fPedestalOffset = pedestal;
-  fAmplitudeScaleFactor = amplitude;
-  fTimeOffset = time;
+  fPedestal = pedestal;
+  fAmplitude = amplitude;
+  fTime = time;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -52,17 +52,17 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   fTimeOffset = fMinuitFitter->GetParameter(2);
 
   // Store the Chi2, and then we can delete the pulse
+  fPedestal = fMinuitFitter->GetParameter(0);
+  fAmplitude = fMinuitFitter->GetParameter(1);
+  fTime = fMinuitFitter->GetParameter(2);
   std::vector<double> params; 
   params.push_back(fPedestalOffset); 
   params.push_back(fAmplitudeScaleFactor); 
   params.push_back(fTimeOffset); 
   fChi2 = (*fcn)(params);
 
-  static int print_dbg = false;
-  if (print_dbg) {
-    std::cout << "TemplateFitter::FitPulseToTemplate(): Fit:\tChi2 " << fChi2 << "\tP "
-	      << fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" << std::endl;
-  }
+  std::cout << "TemplateFitter::FitPulseToTempalte(): Fit:\tChi2 " << fChi2 << "\tP "
+	    << fPedestal << "(" << params.at(0) << ")\tA " << fAmplitude << "(" << params.at(1) << ")\tT " << fTime << "(" << params.at(2) << ")" << std::endl;
 
   delete hPulse;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -7,7 +7,7 @@ TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
   HistogramFitFCN* fcn = new HistogramFitFCN();
   fMinuitFitter = new TFitterMinuit(3); //  Three (3) parameters to modify (amplitude, time, pedestal)
   fMinuitFitter->SetMinuitFCN(fcn);
-  fMinuitFitter->SetPrintLevel(1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
+  fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
 }
 
 TemplateFitter::~TemplateFitter() {

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -42,7 +42,7 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* puls
   double max_adc_value = std::pow(2, n_bits);
 
   fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, 0, max_adc_value);
-  fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1*fAmplitudeScaleFactor, 0, 10);
+  fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1*fAmplitudeScaleFactor, 0, 100);
   fMinuitFitter->SetParameter(2, "TimeOffset", fTimeOffset, 1., -10, 10); // Timing should have step size no smaller than binning,
                                                     // *IF* the fourth argument is step size this is okay,
                                                     // or later implement some interpolation method, note

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -125,7 +125,7 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, TH1D* hPulse, std::strin
 
     if (print_dbg) {
       std::cout << "TemplateFitter::FitPulseToTemplate(): Fit:\tChi2 " << fChi2 << "\tP "
-		<< fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" 
+		<< fPedestalOffset << "\tA " << fAmplitudeScaleFactor << "\tT " << fTimeOffset 
 		<< ", ndof = " << fNDoF << ", prob = " << TMath::Prob(fChi2, fNDoF) << std::endl;
     }
   }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -53,10 +53,10 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, TH1D* hPulse, std::strin
   fTimeOffset_minimum = fTimeOffset_estimate - max_time_offset;
   fTimeOffset_maximum = fTimeOffset_estimate + max_time_offset;
 
-  fPedestalOffset_minimum = -10*max_adc_value;
-  fPedestalOffset_maximum = 10*max_adc_value;
+  fPedestalOffset_minimum = 0;
+  fPedestalOffset_maximum = max_adc_value;
 
-  fAmplitudeScaleFactor_minimum = 0;
+  fAmplitudeScaleFactor_minimum = 0.1;
   fAmplitudeScaleFactor_maximum = 100;
 
   for (double time_offset = fTimeOffset_minimum; time_offset <= fTimeOffset_maximum; ++time_offset) {
@@ -71,7 +71,6 @@ int TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, TH1D* hPulse, std::strin
     fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, fPedestalOffset_minimum, fPedestalOffset_maximum);
     fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1, fAmplitudeScaleFactor_minimum, fAmplitudeScaleFactor_maximum);
     fMinuitFitter->CreateMinimizer(TFitterMinuit::kMigrad);
-
 
 
     // Minimize and notify if there was a problem

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -31,9 +31,9 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   HistogramFitFCN* fcn = (HistogramFitFCN*)fMinuitFitter->GetMinuitFCN();
   fcn->SetTemplateHist(hTemplate);
   fcn->SetPulseHist(hPulse);
-  fMinuitFitter->SetParameter(0, "Pedestal", fPedestal, 0.1, 0, 0);
-  fMinuitFitter->SetParameter(1, "Amplitude", fAmplitude, 0.1, 0, 0);
-  fMinuitFitter->SetParameter(2, "Time", fTime, 1., 0, 0); // Timing should have step size no smaller than binning,
+  fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestalOffset, 0.1, 0, 0);
+  fMinuitFitter->SetParameter(1, "AmplitudeScaleFactor", fAmplitudeScaleFactor, 0.1, 0, 0);
+  fMinuitFitter->SetParameter(2, "TimeOffset", fTimeOffset, 1., 0, 0); // Timing should have step size no smaller than binning,
                                                     // *IF* the fourth argument is step size this is okay,
                                                     // or later implement some interpolation method, note
                                                     // *DERIVATIVES* at bounderies of interpolation may cause
@@ -47,9 +47,9 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
     std::cout << "ERROR: Problem with fit (" << status << ")!" << std::endl;
 
   // Get the fitted values
-  fPedestal = fMinuitFitter->GetParameter(0);
-  fAmplitude = fMinuitFitter->GetParameter(1);
-  fTime = fMinuitFitter->GetParameter(2);
+  fPedestalOffset = fMinuitFitter->GetParameter(0);
+  fAmplitudeScaleFactor = fMinuitFitter->GetParameter(1);
+  fTimeOffset = fMinuitFitter->GetParameter(2);
 
   // Store the Chi2, and then we can delete the pulse
   std::vector<double> params; 
@@ -58,8 +58,8 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   params.push_back(fTimeOffset); 
   fChi2 = (*fcn)(params);
 
-  std::cout << "TemplateFitter::FitPulseToTempalte(): Fit:\tChi2 " << fChi2 << "\tP "
-	    << fPedestal << "(" << params.at(0) << ")\tA " << fAmplitude << "(" << params.at(1) << ")\tT " << fTime << "(" << params.at(2) << ")" << std::endl;
+  std::cout << "TemplateFitter::FitPulseToTemplate(): Fit:\tChi2 " << fChi2 << "\tP "
+	    << fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" << std::endl;
 
   delete hPulse;
 }
@@ -77,7 +77,7 @@ double PulseTemplate::Correlation(TPulseIsland* pulse, double& ped, double& amp,
 */
 
 void TemplateFitter::SetInitialParameterEstimates(double pedestal, double amplitude, double time) {
-  fPedestal = pedestal;
-  fAmplitude = amplitude;
-  fTime = time;
+  fPedestalOffset = pedestal;
+  fAmplitudeScaleFactor = amplitude;
+  fTimeOffset = time;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -7,7 +7,7 @@ TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
   HistogramFitFCN* fcn = new HistogramFitFCN();
   fMinuitFitter = new TFitterMinuit(3); //  Three (3) parameters to modify (amplitude, time, pedestal)
   fMinuitFitter->SetMinuitFCN(fcn);
-  fMinuitFitter->SetPrintLevel(1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
+  fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
 }
 
 TemplateFitter::~TemplateFitter() {
@@ -58,8 +58,11 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   params.push_back(fTimeOffset); 
   fChi2 = (*fcn)(params);
 
-  std::cout << "TemplateFitter::FitPulseToTemplate(): Fit:\tChi2 " << fChi2 << "\tP "
-	    << fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" << std::endl;
+  static int print_dbg = false;
+  if (print_dbg) {
+    std::cout << "TemplateFitter::FitPulseToTemplate(): Fit:\tChi2 " << fChi2 << "\tP "
+	      << fPedestalOffset << "(" << params.at(0) << ")\tA " << fAmplitudeScaleFactor << "(" << params.at(1) << ")\tT " << fTimeOffset << "(" << params.at(2) << ")" << std::endl;
+  }
 
   delete hPulse;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -7,7 +7,7 @@ TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
   HistogramFitFCN* fcn = new HistogramFitFCN();
   fMinuitFitter = new TFitterMinuit(3); //  Three (3) parameters to modify (amplitude, time, pedestal)
   fMinuitFitter->SetMinuitFCN(fcn);
-  fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
+  fMinuitFitter->SetPrintLevel(1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
 }
 
 TemplateFitter::~TemplateFitter() {

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -46,10 +46,12 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
   if (status != 0)
     std::cout << "ERROR: Problem with fit (" << status << ")!" << std::endl;
 
-  // Store the Chi2, and then we can delete the pulse
+  // Get the fitted values
   fPedestal = fMinuitFitter->GetParameter(0);
   fAmplitude = fMinuitFitter->GetParameter(1);
   fTime = fMinuitFitter->GetParameter(2);
+
+  // Store the Chi2, and then we can delete the pulse
   std::vector<double> params; 
   params.push_back(fPedestal); 
   params.push_back(fAmplitude); 

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -11,6 +11,7 @@ TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
   fMinuitFitter = new TFitterMinuit(3); //  Three (3) parameters to modify (amplitude, time, pedestal)
   fMinuitFitter->SetMinuitFCN(fcn);
   fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
+  fMinuitFitter->CreateMinimizer(TFitterMinuit::kMigrad);
 }
 
 TemplateFitter::~TemplateFitter() {

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.cpp
@@ -1,12 +1,7 @@
 #include "TemplateFitter.h"
 
 #include "HistogramFitFCN.h"
-
-#include <TSQLiteServer.h>
-#include <TSQLiteResult.h>
-#include <TSQLiteRow.h>
-
-#include <sstream>
+#include "SetupNavigator.h"
 
 TemplateFitter::TemplateFitter(std::string detname): fChannel(detname) {
 
@@ -29,7 +24,7 @@ void TemplateFitter::FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pul
 
   TH1D* hPulse = new TH1D("hPulseToFit", "hPulseToFit", n_samples, -0.5, n_samples - 0.5);
   std::string bankname = pulse->GetBankName();
-  double pedestal_error = GetPedestalError(bankname); // should probably move to TSetupData or whatever
+  double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname); // should probably move to TSetupData or whatever
   for (int i = 0; i < n_samples; ++i) {
     hPulse->SetBinContent(i+1, samples.at(i));
     hPulse->SetBinError(i+1, pedestal_error);
@@ -92,37 +87,4 @@ void TemplateFitter::SetInitialParameterEstimates(double pedestal, double amplit
   fPedestalOffset = pedestal;
   fAmplitudeScaleFactor = amplitude;
   fTimeOffset = time;
-}
-
-
-double TemplateFitter::GetPedestalError(std::string bankname) {
-
-  // The values that we will read in
-  double noise;
-
-  // Get the SQLite database file
-  TSQLiteServer* server = new TSQLiteServer("sqlite://pedestals-and-noises.sqlite");
-
-  std::stringstream query; 
-  std::string tablename = "pedestals_and_noises";
-  if (server) {
-
-    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\';"; // get all the pedestals and noises
-    TSQLiteResult* result = (TSQLiteResult*) server->Query(query.str().c_str());  // get the result of this query
-    query.str(""); // clear the stringstream after use
-
-    TSQLiteRow* row = (TSQLiteRow*) result->Next(); // get the first row
-    while (row != NULL) {
-      noise = atof(row->GetField(3));
-      
-      delete row;
-      row = (TSQLiteRow*) result->Next(); // get the next row
-    }
-    delete result; // user has to delete the result
-  }
-  else {
-    std::cout << "Error: Couldn't connect to SQLite database" << std::endl;
-  }
-  server->Close();
-  return noise;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -16,7 +16,7 @@ class TemplateFitter {
   TFitterMinuit* fMinuitFitter;
 
  public:
-  void FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pulse);
+  int FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pulse);
   double GetPedestalOffset() { return fPedestalOffset; }
   double GetAmplitudeScaleFactor() { return fAmplitudeScaleFactor; }
   double GetTimeOffset() { return fTimeOffset; }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -17,16 +17,16 @@ class TemplateFitter {
 
  public:
   void FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pulse);
-  double GetPedestal() { return fPedestal; }
-  double GetAmplitude() { return fAmplitude; }
-  double GetTime() { return fTime; }
+  double GetPedestalOffset() { return fPedestalOffset; }
+  double GetAmplitudeScaleFactor() { return fAmplitudeScaleFactor; }
+  double GetTimeOffset() { return fTimeOffset; }
   double GetChi2() { return fChi2; }
 
  private:
   IDs::channel fChannel;
-  double fPedestal;
-  double fAmplitude;
-  double fTime;
+  double fPedestalOffset;
+  double fAmplitudeScaleFactor;
+  double fTimeOffset;
   double fChi2;
 
  public:

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -31,9 +31,23 @@ class TemplateFitter {
   double fChi2;
   int fNDoF; // number of degress of freedom in fit
 
+  /// \brief
+  /// Store the initial estimates for the parameters
   double fPedestalOffset_estimate;
   double fAmplitudeScaleFactor_estimate;
   double fTimeOffset_estimate;
+
+  /// \brief
+  /// Store the minimum parameter bounds
+  double fPedestalOffset_minimum;
+  double fAmplitudeScaleFactor_minimum;
+  double fTimeOffset_minimum;
+
+  /// \brief
+  /// Store the maximum parameter bounds
+  double fPedestalOffset_maximum;
+  double fAmplitudeScaleFactor_maximum;
+  double fTimeOffset_maximum;
 
  public:
   /// \brief

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -5,7 +5,7 @@
 #include "TPulseIsland.h"
 #include "TH1D.h"
 
-#include "defintiions.h"
+#include "definitions.h"
 
 class TemplateFitter {
  public:
@@ -28,6 +28,11 @@ class TemplateFitter {
   double fAmplitude;
   double fTime;
   double fChi2;
+
+ public:
+  /// \brief
+  /// Sets the intial estimates for the template fitter
+  void SetInitialParameterEstimates(double pedestal, double amplitude, double time);
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -33,10 +33,6 @@ class TemplateFitter {
   /// \brief
   /// Sets the intial estimates for the template fitter
   void SetInitialParameterEstimates(double pedestal, double amplitude, double time);
-
-  /// \brief
-  /// Gets the error on the pedestal from the SQLite database
-  double GetPedestalError(std::string bankname);
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -16,7 +16,7 @@ class TemplateFitter {
   TFitterMinuit* fMinuitFitter;
 
  public:
-  int FitPulseToTemplate(TH1D* hTemplate, const TPulseIsland* pulse);
+  int FitPulseToTemplate(TH1D* hTemplate, TH1D* hPulse, std::string bankname);
   double GetPedestalOffset() { return fPedestalOffset; }
   double GetAmplitudeScaleFactor() { return fAmplitudeScaleFactor; }
   double GetTimeOffset() { return fTimeOffset; }

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -5,7 +5,7 @@
 #include "TPulseIsland.h"
 #include "TH1D.h"
 
-#include "defintiions.h"
+#include "definitions.h"
 
 class TemplateFitter {
  public:

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -24,9 +24,9 @@ class TemplateFitter {
 
  private:
   IDs::channel fChannel;
-  double fPedestal;
-  double fAmplitude;
-  double fTime;
+  double fPedestalOffset;
+  double fAmplitudeScaleFactor;
+  double fTimeOffset;
   double fChi2;
 
  public:

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -31,6 +31,10 @@ class TemplateFitter {
   double fChi2;
   int fNDoF; // number of degress of freedom in fit
 
+  double fPedestalOffset_estimate;
+  double fAmplitudeScaleFactor_estimate;
+  double fTimeOffset_estimate;
+
  public:
   /// \brief
   /// Sets the intial estimates for the template fitter

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -5,7 +5,7 @@
 #include "TPulseIsland.h"
 #include "TH1D.h"
 
-#include "definitions.h"
+#include "defintiions.h"
 
 class TemplateFitter {
  public:
@@ -24,9 +24,9 @@ class TemplateFitter {
 
  private:
   IDs::channel fChannel;
-  double fPedestalOffset;
-  double fAmplitudeScaleFactor;
-  double fTimeOffset;
+  double fPedestal;
+  double fAmplitude;
+  double fTime;
   double fChi2;
 
  public:

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -21,6 +21,7 @@ class TemplateFitter {
   double GetAmplitudeScaleFactor() { return fAmplitudeScaleFactor; }
   double GetTimeOffset() { return fTimeOffset; }
   double GetChi2() { return fChi2; }
+  double GetNDoF() { return fNDoF; }
 
  private:
   IDs::channel fChannel;
@@ -28,6 +29,7 @@ class TemplateFitter {
   double fAmplitudeScaleFactor;
   double fTimeOffset;
   double fChi2;
+  int fNDoF; // number of degress of freedom in fit
 
  public:
   /// \brief

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -5,9 +5,11 @@
 #include "TPulseIsland.h"
 #include "TH1D.h"
 
+#include "defintiions.h"
+
 class TemplateFitter {
  public:
-  TemplateFitter();
+  TemplateFitter(std::string detname);
   ~TemplateFitter();
 
  private:
@@ -21,6 +23,7 @@ class TemplateFitter {
   double GetChi2() { return fChi2; }
 
  private:
+  IDs::channel fChannel;
   double fPedestal;
   double fAmplitude;
   double fTime;

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -33,6 +33,10 @@ class TemplateFitter {
   /// \brief
   /// Sets the intial estimates for the template fitter
   void SetInitialParameterEstimates(double pedestal, double amplitude, double time);
+
+  /// \brief
+  /// Gets the error on the pedestal from the SQLite database
+  double GetPedestalError(std::string bankname);
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TemplateFitter.h
@@ -9,7 +9,7 @@
 
 class TemplateFitter {
  public:
-  TemplateFitter(std::string detname);
+  TemplateFitter(std::string detname, int refine_factor);
   ~TemplateFitter();
 
  private:
@@ -53,6 +53,9 @@ class TemplateFitter {
   /// \brief
   /// Sets the intial estimates for the template fitter
   void SetInitialParameterEstimates(double pedestal, double amplitude, double time);
+
+ private:
+  int fRefineFactor;
 };
 
 #endif

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -40,7 +40,7 @@ double SetupNavigator::GetPedestalError(std::string bankname) {
 
     TSQLiteRow* row = (TSQLiteRow*) result->Next(); // get the first row
     while (row != NULL) {
-      noise = atof(row->GetField(3));
+      noise = atof(row->GetField(4));
       
       delete row;
       row = (TSQLiteRow*) result->Next(); // get the next row

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -2,6 +2,14 @@
 #include "ModulesParser.h"
 #include "TSetupData.h"
 
+#include <TSQLiteServer.h>
+#include <TSQLiteResult.h>
+#include <TSQLiteRow.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
 SetupNavigator* SetupNavigator::fThis=NULL;
 
 std::string SetupNavigator::GetBank(const IDs::channel& src)const{
@@ -12,4 +20,35 @@ std::string SetupNavigator::GetBank(const IDs::channel& src)const{
         if(modules::parser::iequals(it->second , src.str())) return it->first;
     }
     return "invalid-det-bank";
+
+double SetupNavigator::GetPedestalError(std::string bankname) {
+
+  // The values that we will read in
+  double noise;
+
+  // Get the SQLite database file
+  TSQLiteServer* server = new TSQLiteServer("sqlite://pedestals-and-noises.sqlite");
+
+  std::stringstream query; 
+  std::string tablename = "pedestals_and_noises";
+  if (server) {
+
+    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\';"; // get all the pedestals and noises
+    TSQLiteResult* result = (TSQLiteResult*) server->Query(query.str().c_str());  // get the result of this query
+    query.str(""); // clear the stringstream after use
+
+    TSQLiteRow* row = (TSQLiteRow*) result->Next(); // get the first row
+    while (row != NULL) {
+      noise = atof(row->GetField(3));
+      
+      delete row;
+      row = (TSQLiteRow*) result->Next(); // get the next row
+    }
+    delete result; // user has to delete the result
+  }
+  else {
+    std::cout << "Error: Couldn't connect to SQLite database" << std::endl;
+  }
+  server->Close();
+  return noise;
 }

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -31,9 +31,10 @@ double SetupNavigator::GetPedestalError(std::string bankname) {
 
   std::stringstream query; 
   std::string tablename = "pedestals_and_noises";
+  int run_number = GetRunNumber(); // get this run number (Note that if we don't have a catalogue of pedestals and noises for each run then we will want to change this)
   if (server) {
 
-    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\';"; // get all the pedestals and noises
+    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\' AND run=" << run_number << ";"; // get all the pedestals and noises
     TSQLiteResult* result = (TSQLiteResult*) server->Query(query.str().c_str());  // get the result of this query
     query.str(""); // clear the stringstream after use
 

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -29,7 +29,7 @@ double SetupNavigator::GetPedestalError(std::string bankname) {
 
     TSQLiteRow* row = (TSQLiteRow*) result->Next(); // get the first row
     while (row != NULL) {
-      noise = atof(row->GetField(3));
+      noise = atof(row->GetField(4));
       
       delete row;
       row = (TSQLiteRow*) result->Next(); // get the next row

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -20,9 +20,10 @@ double SetupNavigator::GetPedestalError(std::string bankname) {
 
   std::stringstream query; 
   std::string tablename = "pedestals_and_noises";
+  int run_number = GetRunNumber(); // get this run number (Note that if we don't have a catalogue of pedestals and noises for each run then we will want to change this)
   if (server) {
 
-    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\';"; // get all the pedestals and noises
+    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\' AND run=" << run_number << ";"; // get all the pedestals and noises
     TSQLiteResult* result = (TSQLiteResult*) server->Query(query.str().c_str());  // get the result of this query
     query.str(""); // clear the stringstream after use
 

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -53,3 +53,36 @@ double SetupNavigator::GetPedestalError(std::string bankname) {
   server->Close();
   return noise;
 }
+
+double SetupNavigator::GetPedestal(std::string bankname) {
+
+  // The values that we will read in
+  double pedestal;
+
+  // Get the SQLite database file
+  TSQLiteServer* server = new TSQLiteServer("sqlite://pedestals-and-noises.sqlite");
+
+  std::stringstream query; 
+  std::string tablename = "pedestals_and_noises";
+  int run_number = GetRunNumber(); // get this run number (Note that if we don't have a catalogue of pedestals and noises for each run then we will want to change this)
+  if (server) {
+
+    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\' AND run=" << run_number << ";"; // get all the pedestals and noises
+    TSQLiteResult* result = (TSQLiteResult*) server->Query(query.str().c_str());  // get the result of this query
+    query.str(""); // clear the stringstream after use
+
+    TSQLiteRow* row = (TSQLiteRow*) result->Next(); // get the first row
+    while (row != NULL) {
+      pedestal = atof(row->GetField(3));
+      
+      delete row;
+      row = (TSQLiteRow*) result->Next(); // get the next row
+    }
+    delete result; // user has to delete the result
+  }
+  else {
+    std::cout << "Error: Couldn't connect to SQLite database" << std::endl;
+  }
+  server->Close();
+  return pedestal;
+}

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -1,3 +1,43 @@
 #include "SetupNavigator.h"
 
+#include <TSQLiteServer.h>
+#include <TSQLiteResult.h>
+#include <TSQLiteRow.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
 SetupNavigator* SetupNavigator::fThis=NULL;
+
+double SetupNavigator::GetPedestalError(std::string bankname) {
+
+  // The values that we will read in
+  double noise;
+
+  // Get the SQLite database file
+  TSQLiteServer* server = new TSQLiteServer("sqlite://pedestals-and-noises.sqlite");
+
+  std::stringstream query; 
+  std::string tablename = "pedestals_and_noises";
+  if (server) {
+
+    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\';"; // get all the pedestals and noises
+    TSQLiteResult* result = (TSQLiteResult*) server->Query(query.str().c_str());  // get the result of this query
+    query.str(""); // clear the stringstream after use
+
+    TSQLiteRow* row = (TSQLiteRow*) result->Next(); // get the first row
+    while (row != NULL) {
+      noise = atof(row->GetField(3));
+      
+      delete row;
+      row = (TSQLiteRow*) result->Next(); // get the next row
+    }
+    delete result; // user has to delete the result
+  }
+  else {
+    std::cout << "Error: Couldn't connect to SQLite database" << std::endl;
+  }
+  server->Close();
+  return noise;
+}

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -42,3 +42,36 @@ double SetupNavigator::GetPedestalError(std::string bankname) {
   server->Close();
   return noise;
 }
+
+double SetupNavigator::GetPedestal(std::string bankname) {
+
+  // The values that we will read in
+  double pedestal;
+
+  // Get the SQLite database file
+  TSQLiteServer* server = new TSQLiteServer("sqlite://pedestals-and-noises.sqlite");
+
+  std::stringstream query; 
+  std::string tablename = "pedestals_and_noises";
+  int run_number = GetRunNumber(); // get this run number (Note that if we don't have a catalogue of pedestals and noises for each run then we will want to change this)
+  if (server) {
+
+    query << "SELECT * FROM " << tablename << " WHERE bank=\'" << bankname << "\' AND run=" << run_number << ";"; // get all the pedestals and noises
+    TSQLiteResult* result = (TSQLiteResult*) server->Query(query.str().c_str());  // get the result of this query
+    query.str(""); // clear the stringstream after use
+
+    TSQLiteRow* row = (TSQLiteRow*) result->Next(); // get the first row
+    while (row != NULL) {
+      pedestal = atof(row->GetField(3));
+      
+      delete row;
+      row = (TSQLiteRow*) result->Next(); // get the next row
+    }
+    delete result; // user has to delete the result
+  }
+  else {
+    std::cout << "Error: Couldn't connect to SQLite database" << std::endl;
+  }
+  server->Close();
+  return pedestal;
+}

--- a/analyzer/rootana/src/framework/SetupNavigator.h
+++ b/analyzer/rootana/src/framework/SetupNavigator.h
@@ -15,6 +15,10 @@ class SetupNavigator{
   int GetRunNumber()const{return fCommandLineArgs.run;};
   std::string GetBank(const IDs::channel&)const;
 
+  /// \brief
+  /// Gets the error on the pedestal from the SQLite database
+  double GetPedestalError(std::string bankname);
+
  private:
   static SetupNavigator* fThis;
   ARGUMENTS fCommandLineArgs;

--- a/analyzer/rootana/src/framework/SetupNavigator.h
+++ b/analyzer/rootana/src/framework/SetupNavigator.h
@@ -19,6 +19,10 @@ class SetupNavigator{
   /// Gets the error on the pedestal from the SQLite database
   double GetPedestalError(std::string bankname);
 
+  /// \brief
+  /// Gets the pedestal from the SQLite database
+  double GetPedestal(std::string bankname);
+
  private:
   static SetupNavigator* fThis;
   ARGUMENTS fCommandLineArgs;

--- a/analyzer/rootana/src/framework/SetupNavigator.h
+++ b/analyzer/rootana/src/framework/SetupNavigator.h
@@ -13,6 +13,10 @@ class SetupNavigator{
 
   int GetRunNumber(){return fCommandLineArgs.run;};
 
+  /// \brief
+  /// Gets the error on the pedestal from the SQLite database
+  double GetPedestalError(std::string bankname);
+
  private:
   static SetupNavigator* fThis;
   ARGUMENTS fCommandLineArgs;

--- a/analyzer/rootana/src/framework/SetupNavigator.h
+++ b/analyzer/rootana/src/framework/SetupNavigator.h
@@ -17,6 +17,10 @@ class SetupNavigator{
   /// Gets the error on the pedestal from the SQLite database
   double GetPedestalError(std::string bankname);
 
+  /// \brief
+  /// Gets the pedestal from the SQLite database
+  double GetPedestal(std::string bankname);
+
  private:
   static SetupNavigator* fThis;
   ARGUMENTS fCommandLineArgs;

--- a/analyzer/rootana/src/plotters/ExportPulse.cpp
+++ b/analyzer/rootana/src/plotters/ExportPulse.cpp
@@ -18,7 +18,7 @@
 #include "MaxBinAPGenerator.h"
 #include "RegisterModule.inc"
 #include "EventNavigator.h"
-
+#include "SetupNavigator.h"
 
 using std::cout;
 using std::endl;
@@ -244,8 +244,10 @@ int ExportPulse::PlotTPI(const TPulseIsland* pulse, const PulseInfo_t& info)cons
   double max= min + num_samples * fClockTick;
   TH1F* hPulse = new TH1F(hist.c_str(), title.str().c_str(), num_samples,min,max);
   
+  double pedestal_error = SetupNavigator::Instance()->GetPedestalError(info.bankname);
   for ( size_t i=0;i <num_samples; ++i) {
     hPulse->SetBinContent(i+1, pulse->GetSamples().at(i));
+    hPulse->SetBinError(i+1, pedestal_error);
   }
   
   return 0;

--- a/analyzer/rootana/src/plotters/ExportPulse.cpp
+++ b/analyzer/rootana/src/plotters/ExportPulse.cpp
@@ -13,6 +13,8 @@
 
 #include <TH1F.h>
 
+#include "SetupNavigator.h"
+
 using std::cout;
 using std::endl;
 using std::string;
@@ -222,9 +224,11 @@ int ExportPulse::PlotTPI(const TPulseIsland* pulse, const PulseInfo_t& info)cons
    double max= ((pulse->GetTimeStamp() + num_samples) * fClockTick) - fTimeShift;
    double min= -fTimeShift;
    TH1F* hPulse = new TH1F(hist.c_str(), title.str().c_str(), num_samples,min,max);
-   
+   std::string bankname = pulse->GetBankName();
+   double pedestal_error = SetupNavigator::Instance()->GetPedestalError(bankname); // should probably move to TSetupData or whatever
    for ( size_t i=0;i <num_samples; ++i) {
      hPulse->SetBinContent(i+1, pulse->GetSamples().at(i));
+     hPulse->SetBinError(i+1, pedestal_error);
    }
 
    return 0;

--- a/analyzer/rootana/src/plotters/PlotPedestalAndNoise.cpp
+++ b/analyzer/rootana/src/plotters/PlotPedestalAndNoise.cpp
@@ -101,7 +101,7 @@ int PlotPedestalAndNoise::ProcessEntry(TGlobalData* gData,TSetupData *setup){
       for (int iSample = 0; iSample < fNSamples; ++iSample) {
 	sum_of_deviations_squared += (theSamples.at(iSample) - mean)*(theSamples.at(iSample) - mean);
       }
-      double RMS = std::sqrt(sum_of_deviations_squared);
+      double RMS = std::sqrt(sum_of_deviations_squared / fNSamples);
 
       pedestal_vs_noise_histogram->Fill(mean, RMS);
     } // end loop through pulses

--- a/analyzer/rootana/src/plotters/PlotPedestalAndNoise.cpp
+++ b/analyzer/rootana/src/plotters/PlotPedestalAndNoise.cpp
@@ -99,7 +99,7 @@ int PlotPedestalAndNoise::ProcessEntry(TGlobalData* gData,TSetupData *setup){
       for (int iSample = 0; iSample < fNSamples; ++iSample) {
 	sum_of_deviations_squared += (theSamples.at(iSample) - mean)*(theSamples.at(iSample) - mean);
       }
-      double RMS = std::sqrt(sum_of_deviations_squared);
+      double RMS = std::sqrt(sum_of_deviations_squared / fNSamples);
 
       pedestal_vs_noise_histogram->Fill(mean, RMS);
     } // end loop through pulses


### PR DESCRIPTION
Here's the final TemplateCreator module. I will try and write up a detailed wiki about this tomorrow but it basically works and it should just need tweaking for optimisation (which I'm not worrying too much about now).

Currently, it takes about 15 minutes to run on run 2808 and most channels have a converged template by the end (although not all and not all that converge are that good).

There were only a couple of files that already existed and had work done on develop which I want to draw attention to:
- SetupNavigator: I added a function to get the pedestal noise from the SQLite database generated by PlotPedestalsAndNoises
- ExportPulse: I slightly modified the DrawTPI function so that the correct pulse errors were included in the histogram. This was because I wanted to draw them for debugging but in the end I think I never used ExportPulse and did it myself in TemplateCreator

I'll leave this here for a couple of days but would like to merge it onto develop soon so that I can rebranch off and get started on the TemplateAPGenerator.
