### PR TITLE
Feature/ae split generators and algorithms

### DIFF
--- a/analyzer/rootana/src/TAP_generators/CFTimeAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/CFTimeAPGenerator.cpp
@@ -2,6 +2,7 @@
 #include "CFTimeAPGenerator.h"
 #include "TPulseIsland.h"
 #include "TAnalysedPulse.h"
+#include "SetupNavigator.h"
 
 #include <numeric>
 #include <algorithm>
@@ -28,6 +29,15 @@ int CFTimeAPGenerator::ProcessPulses(const PulseIslandList& pulseList,
   fConstantFractionTime.th_frac = 0.25;
 
   TSetupData* setup = TSetupData::Instance();
+
+  // Get the variables we want from TSetupData/SetupNavigator
+  std::string bankname = pulseList[0]->GetBankName();
+  fConstantFractionTime.pedestal = SetupNavigator::Instance()->GetPedestal(bankname);
+  fConstantFractionTime.trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+  fConstantFractionTime.max_adc_value = std::pow(2, TSetupData::Instance()->GetNBits(bankname)) - 1;
+  fConstantFractionTime.clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
+  fConstantFractionTime.time_shift = TSetupData::Instance()->GetTimeShift(bankname);
+
 
   for (unsigned int iTPI = 0; iTPI < pulseList.size(); ++iTPI) {
     TPulseIsland* tpi = pulseList.at(iTPI);

--- a/analyzer/rootana/src/TAP_generators/CFTimeAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/CFTimeAPGenerator.h
@@ -5,11 +5,9 @@
 #include "TVAnalysedPulseGenerator.h"
 #include "definitions.h"
 #include "TFile.h"
+#include "utils/TAPAlgorithms.h"
 
 class CFTimeAPGenerator:public TVAnalysedPulseGenerator {
-
- private:
-  double fConstantFraction;
 
  public:
   CFTimeAPGenerator(TAPGeneratorOptions* opts);
@@ -22,6 +20,10 @@ class CFTimeAPGenerator:public TVAnalysedPulseGenerator {
    // into more than one TAP
    virtual bool MayDivideTPIs(){return true;};
 
+ private:
+   /// \brief
+   /// The algorithms that will be used by this generator
+   Algorithm::ConstantFractionTime fConstantFractionTime;
 };
 
 #endif //CFTIME_H__

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
@@ -1,0 +1,76 @@
+#include "TAPGeneratorFactory.h"
+#include "FirstCompleteAPGenerator.h"
+#include "TPulseIsland.h"
+#include "TAnalysedPulse.h"
+#include "SetupNavigator.h"
+
+#include <iostream>
+#include <cmath>
+
+using std::cout;
+using std::endl;
+
+FirstCompleteAPGenerator::FirstCompleteAPGenerator(TAPGeneratorOptions* opts):
+	TVAnalysedPulseGenerator("FirstComplete",opts){
+	// Do things to set up the generator here. 
+}
+
+int FirstCompleteAPGenerator::ProcessPulses( 
+		const PulseIslandList& pulseList,
+		AnalysedPulseList& analysedList){
+    // Do something here that takes the TPIs in the PulseIslandList and
+    // fills the list of TAPS
+
+  // The variables that this generator will be filling
+  double amplitude, time, integral;
+
+  // Get the relevant TSetupData/SetupNavigator variables for the algorithms
+  std::string bankname = pulseList[0]->GetBankName();
+
+  fMaxBinAmplitude.pedestal = fConstantFractionTime.pedestal = fSimpleIntegral.pedestal = SetupNavigator::Instance()->GetPedestal(bankname);
+  fMaxBinAmplitude.trigger_polarity = fConstantFractionTime.trigger_polarity = fSimpleIntegral.trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+  fConstantFractionTime.max_adc_value = std::pow(2, TSetupData::Instance()->GetNBits(bankname)) - 1;
+  fConstantFractionTime.clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
+  fConstantFractionTime.time_shift = TSetupData::Instance()->GetTimeShift(bankname);
+
+  TAnalysedPulse* tap;
+  // Loop over all the TPIs given to us
+  for (PulseIslandList::const_iterator tpi=pulseList.begin();
+       tpi!=pulseList.end(); tpi++){
+
+    // Analyse each TPI
+    amplitude=fMaxBinAmplitude(*tpi);
+    time=fConstantFractionTime(*tpi);
+    integral=fSimpleIntegral(*tpi);
+
+    // Now that we've found the information we were looking for make a TAP to
+    // hold it.  This method makes a TAP and sets the parent TPI info.  It needs
+    // the index of the parent TPI in the container as an argument
+    tap = MakeNewTAP(tpi-pulseList.begin());
+    tap->SetAmplitude(amplitude);
+    tap->SetTime(time);
+    tap->SetIntegral(integral);
+
+    // Finally add the new TAP to the output list
+    analysedList.push_back(tap);
+   }
+	
+	// Generators have a Debug method similar to modules
+	if(Debug()){
+    // They also have a unique ID, retrievable by GetSource and
+		// a GetChannel method to get the ID of just the channel
+    cout<<"Now running source: "<<GetSource().str()<<" which looks for TAPs on "
+        "channel: "<<GetChannel().str()<<'\n';
+	}
+
+	// returning 0 tells the caller that we were successful, return non-zero if not
+	return 0;
+}
+
+// Similar to the modules, this macro registers the generator with
+// MakeAnalysedPulses. The first argument is compulsory and gives the name of
+// this generator. All subsequent arguments will be used as names for arguments
+// given directly within the modules file.  See the github wiki for more.
+//
+// NOTE: for TAP generators OMIT the APGenerator part of the class' name
+ALCAP_TAP_GENERATOR(FirstComplete);

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.h
@@ -1,0 +1,30 @@
+#ifndef FIRSTCOMPLETE_H__
+#define FIRSTCOMPLETE_H__
+
+#include "TSetupData.h"
+#include "TVAnalysedPulseGenerator.h"
+#include "definitions.h"
+
+#include "utils/TAPAlgorithms.h"
+
+class FirstCompleteAPGenerator:public TVAnalysedPulseGenerator {
+
+ public:
+  FirstCompleteAPGenerator(TAPGeneratorOptions* opts);
+  virtual ~FirstCompleteAPGenerator(){};
+
+ public:
+   virtual int ProcessPulses( const PulseIslandList&,AnalysedPulseList&);
+
+   // This function should return true if this generator could break up a TPI
+   // into more than one TAP
+   virtual bool MayDivideTPIs(){return true;};
+
+ private:
+   // The algorithms that this generator will use
+   Algorithm::MaxBinAmplitude fMaxBinAmplitude;
+   Algorithm::ConstantFractionTime fConstantFractionTime;
+   Algorithm::SimpleIntegral fSimpleIntegral;
+};
+
+#endif //FIRSTCOMPLETE_H__

--- a/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.cpp
@@ -16,41 +16,22 @@ static bool IsTimeOrdered(TAnalysedPulse* a, TAnalysedPulse* b) {
 
 //======================================================================
 
-//----------------------------------------------------------------------
-void MaxBinAPGenerator::SetBankInfo(std::string bankname){
-  const TSetupData* fSetup = EventNavigator::Instance().GetSetupData();
-  fBankname=bankname;
-  fPedestal = fSetup->GetPedestal(bankname);
-  fTriggerPolarity = fSetup->GetTriggerPolarity(bankname);
-  fECalibSlope = fSetup->GetADCSlopeCalib(bankname);
-  fECalibOffset = fSetup->GetADCOffsetCalib(bankname);
-  fClockTick = fSetup->GetClockTick(bankname);
-  fTimeShift = fSetup->GetTimeShift(bankname);
-  fDetName=fSetup->GetDetectorName(bankname);
-}
-
 
 //----------------------------------------------------------------------
 int MaxBinAPGenerator::ProcessPulses(const PulseIslandList& pulseList,
                                      AnalysedPulseList& analysedList)
 {
-  SetBankInfo(pulseList.at(0)->GetBankName());
-  
-  double amplitude, time, integral, energy;
+  double amplitude, time;
   TAnalysedPulse* outPulse;
   for (PulseIslandList::const_iterator pulseIter = pulseList.begin(); pulseIter != pulseList.end(); pulseIter++) {
-    amplitude = 0;
-    time = 0;
-    integral = 0;
-    energy = 0.;
-    // Assume one TAnalysedPulse per TPulseIsland
-    GetAllParameters_MaxBin(*pulseIter,amplitude,time,integral,energy);
+    amplitude = fMaxBinAmplitude(*pulseIter);
+    time = fMaxBinTime(*pulseIter);
     
     // Make the TAnalysedPulse pulse
     outPulse=MakeNewTAP(pulseIter-pulseList.begin());
-    outPulse->SetAmplitude(fMaxBinAmplitude(*pulseIter));
+    outPulse->SetAmplitude(amplitude);
     outPulse->SetTime(time);
-    outPulse->SetEnergy(energy);
+    //    outPulse->SetEnergy(energy); //AE (3rd Aug 2014): Commenting this out for the time being since we don't really know how we're doing calibration. The equation used before was:   energy = fECalibSlope * amplitude + fECalibOffset;
     // Add the pulse into the list
     analysedList.push_back(outPulse);
     
@@ -58,25 +39,4 @@ int MaxBinAPGenerator::ProcessPulses(const PulseIslandList& pulseList,
   std::sort(analysedList.begin(), analysedList.end(), IsTimeOrdered);
   return 0;
 }
-
-//----------------------------------------------------------------------
-void MaxBinAPGenerator::GetAllParameters_MaxBin(const TPulseIsland* pulse,
-                                                double& amplitude, double& time,
-                                                double& integral, double& energy)
-{
-  // First find the position of the peak
-  std::vector<int> pulseSamples = pulse->GetSamples();  
-  std::vector<int>::iterator peak_sample_pos;
-  if (fTriggerPolarity == 1)
-    peak_sample_pos = std::max_element(pulseSamples.begin(), pulseSamples.end());
-  else
-    peak_sample_pos = std::min_element(pulseSamples.begin(), pulseSamples.end());
-
-  // Now assign the parameters
-  amplitude = fTriggerPolarity*(*peak_sample_pos - fPedestal);
-  time = ((pulse->GetTimeStamp() + (peak_sample_pos - pulseSamples.begin())) * fClockTick) - fTimeShift;
-  integral = 0;
-  energy = fECalibSlope * amplitude + fECalibOffset;
-}
-
 ALCAP_TAP_GENERATOR(MaxBin);

--- a/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.cpp
@@ -3,6 +3,7 @@
 #include "TPulseIsland.h"
 #include "TAnalysedPulse.h"
 #include "EventNavigator.h"
+#include "SetupNavigator.h"
 #include <algorithm>
 
 // IsTimeOrdered()
@@ -23,6 +24,18 @@ int MaxBinAPGenerator::ProcessPulses(const PulseIslandList& pulseList,
 {
   double amplitude, time;
   TAnalysedPulse* outPulse;
+
+  // Get the various variables we need from TSetupData/SetupNavigator
+  std::string bankname = pulseList[0]->GetBankName();
+  fMaxBinAmplitude.pedestal = SetupNavigator::Instance()->GetPedestal(bankname);
+
+  fMaxBinAmplitude.trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+  fMaxBinTime.trigger_polarity = fMaxBinAmplitude.trigger_polarity;
+
+  fMaxBinTime.clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
+  fMaxBinTime.time_shift = TSetupData::Instance()->GetTimeShift(bankname);
+
+
   for (PulseIslandList::const_iterator pulseIter = pulseList.begin(); pulseIter != pulseList.end(); pulseIter++) {
     amplitude = fMaxBinAmplitude(*pulseIter);
     time = fMaxBinTime(*pulseIter);

--- a/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.cpp
@@ -48,7 +48,7 @@ int MaxBinAPGenerator::ProcessPulses(const PulseIslandList& pulseList,
     
     // Make the TAnalysedPulse pulse
     outPulse=MakeNewTAP(pulseIter-pulseList.begin());
-    outPulse->SetAmplitude(amplitude);
+    outPulse->SetAmplitude(fMaxBinAmplitude(*pulseIter));
     outPulse->SetTime(time);
     outPulse->SetEnergy(energy);
     // Add the pulse into the list

--- a/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.h
@@ -2,6 +2,7 @@
 #define MAXBINAPGENERATOR_H__
 
 #include "TVAnalysedPulseGenerator.h"
+#include "utils/TAPAlgorithms.h"
 #include <vector>
 #include <string>
 
@@ -36,6 +37,8 @@ private:
   double fECalibOffset;
   double fClockTick;
   double fTimeShift; 
+
+  Algorithm::MaxBinAmplitude fMaxBinAmplitude;
 };
 
 #endif // MAXBINAPGENERATOR_H__

--- a/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/MaxBinAPGenerator.h
@@ -17,28 +17,17 @@ class MaxBinAPGenerator:public TVAnalysedPulseGenerator {
   {};
 
   virtual ~MaxBinAPGenerator(){};
-  void SetBankInfo(std::string bankname);
   
 public:
   virtual int ProcessPulses(const PulseIslandList&,AnalysedPulseList&);
   virtual bool MayDivideTPIs(){return false;};
 
-  void GetAllParameters_MaxBin(const TPulseIsland* pulse, double& amplitude,
-                               double& time, double& integral, double& energy) ;
-  
 private:
-  // Ideally we would have the TSetupData storing all this as a single struct so
-  // we wouldn't need the following fields
-  std::string fBankname;
-  std::string fDetName;
-  double fPedestal;
-  int fTriggerPolarity;
-  double fECalibSlope;
-  double fECalibOffset;
-  double fClockTick;
-  double fTimeShift; 
 
+  /// \brief
+  /// The algorithms that this generator uses
   Algorithm::MaxBinAmplitude fMaxBinAmplitude;
+  Algorithm::MaxBinTime fMaxBinTime;
 };
 
 #endif // MAXBINAPGENERATOR_H__

--- a/analyzer/rootana/src/TAP_generators/SimpIntAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/SimpIntAPGenerator.h
@@ -5,22 +5,14 @@
 #include "TVAnalysedPulseGenerator.h"
 #include "definitions.h"
 
+#include "utils/TAPAlgorithms.h"
+
 class SimpIntAPGenerator:public TVAnalysedPulseGenerator {
 
  public:
   SimpIntAPGenerator(TAPGeneratorOptions* opts):
-  TVAnalysedPulseGenerator("SimpInt", opts),fSetup(TSetupData::Instance()){};
+  TVAnalysedPulseGenerator("SimpInt", opts){};
   virtual ~SimpIntAPGenerator(){};
-
-  void SetBankInfo(std::string bankname)
-  {
-    fBankname= bankname;
-    fDetname = fSetup->GetDetectorName(bankname);
-    fPedestal = fSetup->GetPedestal(bankname);
-    fTriggerPolarity = fSetup->GetTriggerPolarity(bankname);
-    fECalibSlope = fSetup->GetADCSlopeCalib(bankname);
-    fECalibOffset = fSetup->GetADCOffsetCalib(bankname);
-  }
 
 
  public:
@@ -29,13 +21,8 @@ class SimpIntAPGenerator:public TVAnalysedPulseGenerator {
 
 
  private:
-   // This will likely be unnecessary
-
-   std::string fBankname;
-   std::string fDetname;
-   double fPedestal, fECalibSlope, fECalibOffset;
-   int fTriggerPolarity;
-   TSetupData* fSetup;
+   // The algorithms that this generator will use
+   Algorithm::SimpleIntegral fSimpleIntegral;
 };
 
 #endif //SIMPLEINTEGRATOR_H__

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <cmath>
 
 double Algorithm::MaxBinAmplitude::operator() (const TPulseIsland* tpi) {
 
@@ -52,6 +53,36 @@ double Algorithm::MaxBinTime::operator() (const TPulseIsland* tpi) {
   double clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
   double time_shift = TSetupData::Instance()->GetTimeShift(bankname);
   double time = ((tpi->GetTimeStamp() + (peak_sample_pos - pulseSamples.begin())) * clock_tick_in_ns) - time_shift;
+
+  return time;
+}
+
+double Algorithm::ConstantFractionTime::operator() (const TPulseIsland* tpi) {
+  std::string bankname = tpi->GetBankName();
+
+  std::vector<int> samps = tpi->GetSamples();
+  std::vector<int>::iterator b = samps.begin(), e = samps.end();
+
+  double ped = SetupNavigator::Instance()->GetPedestal(bankname);
+  int pol = TSetupData::Instance()->GetTriggerPolarity(bankname);
+  unsigned int max_adc_value = std::pow(2, TSetupData::Instance()->GetNBits(bankname)) - 1;
+
+  std::vector<int>::iterator m = pol > 0 ? std::max_element(b, e) : std::min_element(b, e);
+  unsigned int amp = *m;
+  unsigned int thresh = pol > 0 ? (unsigned int)(th_frac*(double)(max_adc_value - ped) + ped) : (unsigned int)((1.-th_frac)*ped);
+  unsigned int cf = pol > 0 ? (unsigned int)(constant_fraction*(double)(amp-ped)) + ped : (unsigned int)((double)(ped-amp)*(1.-constant_fraction) + amp);
+
+  double t;
+  if ((pol > 0 ? amp > thresh : amp < thresh) && (pol > 0 ? amp < max_adc_value : amp > 0)) {
+    std::vector<int>::iterator c = m;
+    while ((pol > 0 ? *--m > (int)cf : *--m < (int)cf) && m != b);
+    if (*(m+1) == *m)
+      t = (double)(m-b);
+    else
+      t = (double)((int)cf - *m)/(double)(*(m+1) - *m) + (double)(m-b);
+  }
+
+  double time = tpi->GetClockTickInNs() * (t + (double)tpi->GetTimeStamp()) - TSetupData::Instance()->GetTimeShift(tpi->GetBankName());
 
   return time;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -1,8 +1,30 @@
 #include "TAPAlgorithms.h"
+#include "TSetupData.h"
 
 #include <iostream>
+#include <algorithm>
 
 double Algorithm::MaxBinAmplitude::operator() (const TPulseIsland* tpi) {
-  std::cout << "Algorithm::MaxBinAmplitude::operator()" << std::endl;
-  return 0;
+
+  // Get the samples and get an iterator ready to find the peak sample
+  std::vector<int> pulseSamples = tpi->GetSamples();  
+  std::vector<int>::iterator peak_sample_pos;
+
+  // Get the trigger polarity
+  std::string bankname = tpi->GetBankName();
+  int trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+
+  // Find the position of the peak samples
+  if (trigger_polarity == 1)
+    peak_sample_pos = std::max_element(pulseSamples.begin(), pulseSamples.end());
+  else if (trigger_polarity == -1)
+    peak_sample_pos = std::min_element(pulseSamples.begin(), pulseSamples.end());
+  else
+    std::cout << "Algorithm::MaxBinAmplitude: Trigger Polarity for channel " << bankname << " is not +- 1!" << std::endl;
+
+  // Now calculate the amplitude
+  double pedestal = TSetupData::Instance()->GetPedestal(bankname);
+  double amplitude = trigger_polarity*(*peak_sample_pos - pedestal);
+
+  return amplitude;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -1,1 +1,8 @@
 #include "TAPAlgorithms.h"
+
+#include <iostream>
+
+double Algorithm::MaxBinAmplitude::operator() (const TPulseIsland* tpi) {
+  std::cout << "Algorithm::MaxBinAmplitude::operator()" << std::endl;
+  return 0;
+}

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -1,0 +1,1 @@
+#include "TAPAlgorithms.h"

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -66,3 +66,16 @@ double Algorithm::ConstantFractionTime::operator() (const TPulseIsland* tpi) {
 
   return time;
 }
+
+double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
+  std::vector<int> samples = tpi->GetSamples();
+  
+  double length = samples.size();
+  double tempint = 0;
+  for(std::vector<int>::iterator sIt = samples.begin(); sIt != samples.end(); sIt++)
+    tempint += *sIt;
+  
+  double integral = trigger_polarity * (tempint - (pedestal * length));
+
+  return integral;
+}

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -12,20 +12,13 @@ double Algorithm::MaxBinAmplitude::operator() (const TPulseIsland* tpi) {
   std::vector<int> pulseSamples = tpi->GetSamples();  
   std::vector<int>::iterator peak_sample_pos;
 
-  // Get the trigger polarity
-  std::string bankname = tpi->GetBankName();
-  int trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
-
   // Find the position of the peak samples
   if (trigger_polarity == 1)
     peak_sample_pos = std::max_element(pulseSamples.begin(), pulseSamples.end());
   else if (trigger_polarity == -1)
     peak_sample_pos = std::min_element(pulseSamples.begin(), pulseSamples.end());
-  else
-    std::cout << "Algorithm::MaxBinAmplitude: Trigger Polarity for channel " << bankname << " is not +- 1!" << std::endl;
 
   // Now calculate the amplitude
-  double pedestal = SetupNavigator::Instance()->GetPedestal(bankname);
   double amplitude = trigger_polarity*(*peak_sample_pos - pedestal);
 
   return amplitude;
@@ -37,52 +30,39 @@ double Algorithm::MaxBinTime::operator() (const TPulseIsland* tpi) {
   std::vector<int> pulseSamples = tpi->GetSamples();  
   std::vector<int>::iterator peak_sample_pos;
 
-  // Get the trigger polarity
-  std::string bankname = tpi->GetBankName();
-  int trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
-
   // Find the position of the peak samples
   if (trigger_polarity == 1)
     peak_sample_pos = std::max_element(pulseSamples.begin(), pulseSamples.end());
   else if (trigger_polarity == -1)
     peak_sample_pos = std::min_element(pulseSamples.begin(), pulseSamples.end());
-  else
-    std::cout << "Algorithm::MaxBinTime: Trigger Polarity for channel " << bankname << " is not +- 1!" << std::endl;
 
   // Now calculate the time
-  double clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
-  double time_shift = TSetupData::Instance()->GetTimeShift(bankname);
   double time = ((tpi->GetTimeStamp() + (peak_sample_pos - pulseSamples.begin())) * clock_tick_in_ns) - time_shift;
 
   return time;
 }
 
 double Algorithm::ConstantFractionTime::operator() (const TPulseIsland* tpi) {
-  std::string bankname = tpi->GetBankName();
 
   std::vector<int> samps = tpi->GetSamples();
   std::vector<int>::iterator b = samps.begin(), e = samps.end();
 
-  double ped = SetupNavigator::Instance()->GetPedestal(bankname);
-  int pol = TSetupData::Instance()->GetTriggerPolarity(bankname);
-  unsigned int max_adc_value = std::pow(2, TSetupData::Instance()->GetNBits(bankname)) - 1;
-
-  std::vector<int>::iterator m = pol > 0 ? std::max_element(b, e) : std::min_element(b, e);
+  std::vector<int>::iterator m = trigger_polarity > 0 ? std::max_element(b, e) : std::min_element(b, e);
   unsigned int amp = *m;
-  unsigned int thresh = pol > 0 ? (unsigned int)(th_frac*(double)(max_adc_value - ped) + ped) : (unsigned int)((1.-th_frac)*ped);
-  unsigned int cf = pol > 0 ? (unsigned int)(constant_fraction*(double)(amp-ped)) + ped : (unsigned int)((double)(ped-amp)*(1.-constant_fraction) + amp);
+  unsigned int thresh = trigger_polarity > 0 ? (unsigned int)(th_frac*(double)(max_adc_value - pedestal) + pedestal) : (unsigned int)((1.-th_frac)*pedestal);
+  unsigned int cf = trigger_polarity > 0 ? (unsigned int)(constant_fraction*(double)(amp-pedestal)) + pedestal : (unsigned int)((double)(pedestal-amp)*(1.-constant_fraction) + amp);
 
   double t;
-  if ((pol > 0 ? amp > thresh : amp < thresh) && (pol > 0 ? amp < max_adc_value : amp > 0)) {
+  if ((trigger_polarity > 0 ? amp > thresh : amp < thresh) && (trigger_polarity > 0 ? amp < max_adc_value : amp > 0)) {
     std::vector<int>::iterator c = m;
-    while ((pol > 0 ? *--m > (int)cf : *--m < (int)cf) && m != b);
+    while ((trigger_polarity > 0 ? *--m > (int)cf : *--m < (int)cf) && m != b);
     if (*(m+1) == *m)
       t = (double)(m-b);
     else
       t = (double)((int)cf - *m)/(double)(*(m+1) - *m) + (double)(m-b);
   }
 
-  double time = tpi->GetClockTickInNs() * (t + (double)tpi->GetTimeStamp()) - TSetupData::Instance()->GetTimeShift(tpi->GetBankName());
+  double time = clock_tick_in_ns * (t + (double)tpi->GetTimeStamp() - time_shift);
 
   return time;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -28,3 +28,29 @@ double Algorithm::MaxBinAmplitude::operator() (const TPulseIsland* tpi) {
 
   return amplitude;
 }
+
+double Algorithm::MaxBinTime::operator() (const TPulseIsland* tpi) {
+
+  // Get the samples and get an iterator ready to find the peak sample
+  std::vector<int> pulseSamples = tpi->GetSamples();  
+  std::vector<int>::iterator peak_sample_pos;
+
+  // Get the trigger polarity
+  std::string bankname = tpi->GetBankName();
+  int trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+
+  // Find the position of the peak samples
+  if (trigger_polarity == 1)
+    peak_sample_pos = std::max_element(pulseSamples.begin(), pulseSamples.end());
+  else if (trigger_polarity == -1)
+    peak_sample_pos = std::min_element(pulseSamples.begin(), pulseSamples.end());
+  else
+    std::cout << "Algorithm::MaxBinTime: Trigger Polarity for channel " << bankname << " is not +- 1!" << std::endl;
+
+  // Now calculate the time
+  double clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
+  double time_shift = TSetupData::Instance()->GetTimeShift(bankname);
+  double time = ((tpi->GetTimeStamp() + (peak_sample_pos - pulseSamples.begin())) * clock_tick_in_ns) - time_shift;
+
+  return time;
+}

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -44,17 +44,17 @@ double Algorithm::MaxBinTime::operator() (const TPulseIsland* tpi) {
 
 double Algorithm::ConstantFractionTime::operator() (const TPulseIsland* tpi) {
 
-  std::vector<int> samps = tpi->GetSamples();
-  std::vector<int>::iterator b = samps.begin(), e = samps.end();
+  const std::vector<int>& samps = tpi->GetSamples();
+  std::vector<int>::const_iterator b = samps.begin(), e = samps.end();
 
-  std::vector<int>::iterator m = trigger_polarity > 0 ? std::max_element(b, e) : std::min_element(b, e);
+  std::vector<int>::const_iterator m = trigger_polarity > 0 ? std::max_element(b, e) : std::min_element(b, e);
   unsigned int amp = *m;
   unsigned int thresh = trigger_polarity > 0 ? (unsigned int)(th_frac*(double)(max_adc_value - pedestal) + pedestal) : (unsigned int)((1.-th_frac)*pedestal);
   unsigned int cf = trigger_polarity > 0 ? (unsigned int)(constant_fraction*(double)(amp-pedestal)) + pedestal : (unsigned int)((double)(pedestal-amp)*(1.-constant_fraction) + amp);
 
   double t;
   if ((trigger_polarity > 0 ? amp > thresh : amp < thresh) && (trigger_polarity > 0 ? amp < max_adc_value : amp > 0)) {
-    std::vector<int>::iterator c = m;
+    std::vector<int>::const_iterator c = m;
     while ((trigger_polarity > 0 ? *--m > (int)cf : *--m < (int)cf) && m != b);
     if (*(m+1) == *m)
       t = (double)(m-b);
@@ -68,11 +68,11 @@ double Algorithm::ConstantFractionTime::operator() (const TPulseIsland* tpi) {
 }
 
 double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
-  std::vector<int> samples = tpi->GetSamples();
+  const std::vector<int>& samples = tpi->GetSamples();
   
   double length = samples.size();
   double tempint = 0;
-  for(std::vector<int>::iterator sIt = samples.begin(); sIt != samples.end(); sIt++)
+  for(std::vector<int>::const_iterator sIt = samples.begin(); sIt != samples.end(); sIt++)
     tempint += *sIt;
   
   double integral = trigger_polarity * (tempint - (pedestal * length));

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -1,5 +1,6 @@
 #include "TAPAlgorithms.h"
 #include "TSetupData.h"
+#include "SetupNavigator.h"
 
 #include <iostream>
 #include <algorithm>
@@ -23,7 +24,7 @@ double Algorithm::MaxBinAmplitude::operator() (const TPulseIsland* tpi) {
     std::cout << "Algorithm::MaxBinAmplitude: Trigger Polarity for channel " << bankname << " is not +- 1!" << std::endl;
 
   // Now calculate the amplitude
-  double pedestal = TSetupData::Instance()->GetPedestal(bankname);
+  double pedestal = SetupNavigator::Instance()->GetPedestal(bankname);
   double amplitude = trigger_polarity*(*peak_sample_pos - pedestal);
 
   return amplitude;

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -16,16 +16,30 @@ namespace Algorithm {
 struct Algorithm::MaxBinAmplitude {
   public:
   double operator() (const TPulseIsland* tpi);
+
+  int trigger_polarity;
+  double pedestal;
 };
 
 struct Algorithm::MaxBinTime {
   public:
   double operator() (const TPulseIsland* tpi);
+
+  int trigger_polarity;
+  double clock_tick_in_ns;
+  double time_shift;
 };
 
 struct Algorithm::ConstantFractionTime {
   public:
   double operator() (const TPulseIsland* tpi);
+
+  double pedestal;
+  int trigger_polarity;
+  int max_adc_value;
+  double clock_tick_in_ns;
+  double time_shift;
+
   double constant_fraction;
   double th_frac;
 };

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -18,4 +18,9 @@ struct Algorithm::MaxBinAmplitude {
   double operator() (const TPulseIsland* tpi);
 };
 
+struct Algorithm::MaxBinTime {
+  public:
+  double operator() (const TPulseIsland* tpi);
+};
+
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -44,4 +44,13 @@ struct Algorithm::ConstantFractionTime {
   double th_frac;
 };
 
+
+struct Algorithm::SimpleIntegral {
+  public:
+  double operator() (const TPulseIsland* tpi);
+
+  double pedestal;
+  int trigger_polarity;
+};
+
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -1,6 +1,8 @@
 #ifndef TAPAlgorithms_h_
 #define TAPAlgorithms_h_
 
+#include "TPulseIsland.h"
+
 // We will keep all the algorthims in their own namespace
 namespace Algorithm {
 
@@ -9,6 +11,11 @@ namespace Algorithm {
   struct MaxBinTime;
   struct ConstantFractionTime;
   struct SimpleIntegral;
+};
+
+struct Algorithm::MaxBinAmplitude {
+  public:
+  double operator() (const TPulseIsland* tpi);
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -1,0 +1,14 @@
+#ifndef TAPAlgorithms_h_
+#define TAPAlgorithms_h_
+
+// We will keep all the algorthims in their own namespace
+namespace Algorithm {
+
+  // The list of algorthims we have
+  struct MaxBinAmplitude;
+  struct MaxBinTime;
+  struct ConstantFractionTime;
+  struct SimpleIntegral;
+};
+
+#endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -23,4 +23,11 @@ struct Algorithm::MaxBinTime {
   double operator() (const TPulseIsland* tpi);
 };
 
+struct Algorithm::ConstantFractionTime {
+  public:
+  double operator() (const TPulseIsland* tpi);
+  double constant_fraction;
+  double th_frac;
+};
+
 #endif


### PR DESCRIPTION
To repeat what I said in issue #167:
- for all the algorithms the pedestal is retrieved from the SQLite database that is produced by `PlotPedestalsAndNoises`. If you don't have the SQLite database locally, then you can create one by running rootana with this module and setting `export_sql=1` in your modules file.
- the various pedestal/trigger polarity/etc. variables should be assigned in the generator and not the algorithm so that we don't get a massive slow-down. I would quite like a way to check that these variables exist before running the algorithm (i.e. fail loudly) but can't think of a way to do it

Could people please check that I haven't either:
- broken an algorithm while copying it over, or
- done something dangerously/inefficiently/badly

Cheers
