### PR TITLE
Feature/bk tap tree

### DIFF
--- a/analyzer/rootana/src/LibraryLinkDef.h
+++ b/analyzer/rootana/src/LibraryLinkDef.h
@@ -35,9 +35,12 @@
 #pragma link C++ class std::vector<std::string>+;
 
 #pragma link C++ class std::map<IDs::source, int>+;
+#pragma link C++ class std::pair<IDs::source, int> +;
 #pragma link C++ class std::vector<IDs::source>+;
-#pragma link C++ class FlyWeight<IDs::source, TAnalysedPulse::Tag>;
-#pragma link C++ class FlyWeight<IDs::source, TDetectorPulse::Tag>;
+#pragma link C++ class FlyWeightLists<IDs::source, TAnalysedPulse::Tag>+;
+#pragma link C++ class FlyWeightLists<IDs::source, TDetectorPulse::Tag>+;
+#pragma link C++ class FlyWeight<IDs::source, TAnalysedPulse::Tag>+;
+#pragma link C++ class FlyWeight<IDs::source, TDetectorPulse::Tag>+;
 
 //#pragma link C++ class vector<TPulseIsland*>+;
 #pragma link C++ class BankBranch<vector<TPulseIsland*> >+;

--- a/analyzer/rootana/src/LibraryLinkDef.h
+++ b/analyzer/rootana/src/LibraryLinkDef.h
@@ -1,3 +1,9 @@
+#ifdef __CINT__
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclasses;
+
 #pragma link C++ class IDs::channel+;
 #pragma link C++ class IDs::generator+;
 #pragma link C++ class IDs::source+;
@@ -28,8 +34,10 @@
 //#pragma link C++ class pair<IDs::source,vector<TMuonEvent*> >+;
 #pragma link C++ class std::vector<std::string>+;
 
-#pragma link C++ class FlyWeight<IDs::source, TAnalysedPulse::Tag>+;
-#pragma link C++ class FlyWeight<IDs::source, TDetectorPulse::Tag>+;
+#pragma link C++ class std::map<IDs::source, int>+;
+#pragma link C++ class std::vector<IDs::source>+;
+#pragma link C++ class FlyWeight<IDs::source, TAnalysedPulse::Tag>;
+#pragma link C++ class FlyWeight<IDs::source, TDetectorPulse::Tag>;
 
 //#pragma link C++ class vector<TPulseIsland*>+;
 #pragma link C++ class BankBranch<vector<TPulseIsland*> >+;
@@ -38,3 +46,4 @@
 #pragma link C++ class BankBranch<vector<TMuonEvent*> >+;
 
 #pragma link C++ class TAnalysedPulseMapWrapper+;
+#endif    /* __CINT__ */

--- a/analyzer/rootana/src/LibraryLinkDef.h
+++ b/analyzer/rootana/src/LibraryLinkDef.h
@@ -28,7 +28,8 @@
 //#pragma link C++ class pair<IDs::source,vector<TMuonEvent*> >+;
 #pragma link C++ class std::vector<std::string>+;
 
-
+#pragma link C++ class FlyWeight<IDs::source, TAnalysedPulse::Tag>+;
+#pragma link C++ class FlyWeight<IDs::source, TDetectorPulse::Tag>+;
 
 //#pragma link C++ class vector<TPulseIsland*>+;
 #pragma link C++ class BankBranch<vector<TPulseIsland*> >+;

--- a/analyzer/rootana/src/LoadPulses.cpp
+++ b/analyzer/rootana/src/LoadPulses.cpp
@@ -46,43 +46,38 @@ int LoadPulses::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
         cout<<"LoadPulses: Error: Unable to find input tree, "<<fTreeName<<" in file "<<fFileName<<endl;
         return 3;
     }
+    // Prepare the TAP flyweights
+    FlyWeight<IDs::source,TAnalysedPulse::Tag>::LoadProxyList(gDirectory,"TAP_sources");
 
     // Loop over each branch
     TObjArray* listOfArraysOfTAPs=fInTree->GetListOfBranches();
     TBranchClones* branch;
     IDs::source tmp_source;
-        DEBUG_VALUE(listOfArraysOfTAPs->GetSize());
     for(int i_array=0;i_array<listOfArraysOfTAPs->GetSize();i_array++){
-        DEBUG_VALUE(i_array);
         // Get the branch
         branch=(TBranchClones*)listOfArraysOfTAPs->At(i_array);
         if(!branch) continue;
         // Create the corrsponding source ID
         tmp_source=branch->GetName();
-        DEBUG_VALUE(tmp_source);
         // Add to the list of branches
         fBranches.push_back(std::make_pair(tmp_source,branch));
         // Prepare gAnalysedPulseMap
         gAnalysedPulseMap[tmp_source];
     }
-
-    // Get the first entry to read from
-    //fCurrentEntry=EventNavigator::Instance().GetStartEntry();
-    fCurrentEntry=3;
-    //fInTree->SetDebug();
-  return 0;
-}
-
-int LoadPulses::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
     for(BranchList::iterator i_branch=fBranches.begin();
             i_branch!=fBranches.end(); ++i_branch){
         // Set the TClonesArray address
         i_branch->second->SetAddress(&fArrays[i_branch->first]);
     }
+    //fInTree->SetDebug();
 
-    DEBUG_VALUE(fCurrentEntry);
-    fInTree->SetDebug();
-    //fInTree->LoadTree(fCurrentEntry);
+    // Get the first entry to read from
+    fCurrentEntry=EventNavigator::Instance().GetStartEntry();
+  return 0;
+}
+
+int LoadPulses::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+
     fInTree->GetEntry(fCurrentEntry);
     int n_entries=0;
     SourceAnalPulseMap::iterator i_output;
@@ -96,11 +91,9 @@ int LoadPulses::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
             return 1;
         }
         pulseList=&i_output->second;
-        DEBUG_VALUE(pulseList->size());
 
         // Loop over each TAP on file and put it into gAnalysedPulseMap;
         n_entries=i_array->second->GetEntries();
-        DEBUG_VALUE(n_entries);
         TAnalysedPulse* pulse;
         for(int i_pulse=0;i_pulse<n_entries;++i_pulse){
             pulse=(TAnalysedPulse*)(i_array->second->At(i_pulse));

--- a/analyzer/rootana/src/LoadPulses.cpp
+++ b/analyzer/rootana/src/LoadPulses.cpp
@@ -1,0 +1,123 @@
+#include "EventNavigator.h"
+#include "LoadPulses.h"
+#include "RegisterModule.inc"
+#include "TGlobalData.h"
+#include "TSetupData.h"
+#include "ModulesOptions.h"
+#include "definitions.h"
+#include "TAnalysedPulse.h"
+#include "debug_tools.h"
+
+#include "TFile.h"
+#include "TTree.h"
+#include "TClonesArray.h"
+#include "TBranchClones.h"
+
+#include <iostream>
+#include <utility>
+using std::cout;
+using std::endl;
+
+extern SourceAnalPulseMap gAnalysedPulseMap;
+
+LoadPulses::LoadPulses(modules::options* opts):
+   BaseModule("LoadPulses",opts){
+       fFileName=opts->GetString("file_name");
+       fTreeName=opts->GetString("tree_name","TAP_tree");
+}
+
+LoadPulses::~LoadPulses(){
+}
+
+int LoadPulses::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
+    // open the file
+    if(fFileName.empty()){
+        cout<<"LoadPulses: Error: no input file specified "<<endl;
+        return 1;
+    }
+    TFile* inFile=TFile::Open(fFileName.c_str(), "READ");
+    if(!inFile){
+        cout<<"LoadPulses: Error: Unable to open input file, "<<fFileName<<endl;
+        return 2;
+    }
+    // open the tree
+    inFile->GetObject(fTreeName.c_str(),fInTree);
+    if(!fInTree){
+        cout<<"LoadPulses: Error: Unable to find input tree, "<<fTreeName<<" in file "<<fFileName<<endl;
+        return 3;
+    }
+
+    // Loop over each branch
+    TObjArray* listOfArraysOfTAPs=fInTree->GetListOfBranches();
+    TBranchClones* branch;
+    IDs::source tmp_source;
+        DEBUG_VALUE(listOfArraysOfTAPs->GetSize());
+    for(int i_array=0;i_array<listOfArraysOfTAPs->GetSize();i_array++){
+        DEBUG_VALUE(i_array);
+        // Get the branch
+        branch=(TBranchClones*)listOfArraysOfTAPs->At(i_array);
+        if(!branch) continue;
+        // Create the corrsponding source ID
+        tmp_source=branch->GetName();
+        DEBUG_VALUE(tmp_source);
+        // Add to the list of branches
+        fBranches.push_back(std::make_pair(tmp_source,branch));
+        // Prepare gAnalysedPulseMap
+        gAnalysedPulseMap[tmp_source];
+    }
+
+    // Get the first entry to read from
+    //fCurrentEntry=EventNavigator::Instance().GetStartEntry();
+    fCurrentEntry=3;
+    //fInTree->SetDebug();
+  return 0;
+}
+
+int LoadPulses::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+    for(BranchList::iterator i_branch=fBranches.begin();
+            i_branch!=fBranches.end(); ++i_branch){
+        // Set the TClonesArray address
+        i_branch->second->SetAddress(&fArrays[i_branch->first]);
+    }
+
+    DEBUG_VALUE(fCurrentEntry);
+    fInTree->SetDebug();
+    //fInTree->LoadTree(fCurrentEntry);
+    fInTree->GetEntry(fCurrentEntry);
+    int n_entries=0;
+    SourceAnalPulseMap::iterator i_output;
+    AnalysedPulseList* pulseList;
+    for(SourceToClonesArrayMap::iterator i_array=fArrays.begin();
+            i_array!=fArrays.end(); ++i_array){
+        // Get the pulse list to put the TAPs into
+        i_output=gAnalysedPulseMap.find(i_array->first);
+        if(i_output==gAnalysedPulseMap.end()){
+            cout<<"LoadPulses: Error: gAnalysedPulseMap doesn't contain a pulse list for "<<i_array->first<<endl;
+            return 1;
+        }
+        pulseList=&i_output->second;
+        DEBUG_VALUE(pulseList->size());
+
+        // Loop over each TAP on file and put it into gAnalysedPulseMap;
+        n_entries=i_array->second->GetEntries();
+        DEBUG_VALUE(n_entries);
+        TAnalysedPulse* pulse;
+        for(int i_pulse=0;i_pulse<n_entries;++i_pulse){
+            pulse=(TAnalysedPulse*)(i_array->second->At(i_pulse));
+            pulseList->push_back(pulse);
+        }
+    }
+
+    //for (SourceAnalPulseMap::const_iterator i_source = gAnalysedPulseMap.begin();
+    //        i_source != gAnalysedPulseMap.end(); ++i_source) {
+    //    cout<<i_source->second.size()<<" pulses for source: "<<i_source->first<<"  "<<endl;
+    //}
+    ++fCurrentEntry;
+  return 0;
+}
+
+int LoadPulses::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
+  return 0;
+}
+
+ALCAP_REGISTER_MODULE(LoadPulses,file_name,tree_name);

--- a/analyzer/rootana/src/LoadPulses.cpp
+++ b/analyzer/rootana/src/LoadPulses.cpp
@@ -73,10 +73,15 @@ int LoadPulses::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
 
     // Get the first entry to read from
     fCurrentEntry=EventNavigator::Instance().GetStartEntry();
+    fNumEntries=fInTree->GetEntries();
   return 0;
 }
 
 int LoadPulses::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+    if(fCurrentEntry>fNumEntries){
+        cout<<"LoadPulses: Error: input file contains no more entries so I'm stopping the run"<<endl;
+        return 1;
+    }
 
     fInTree->GetEntry(fCurrentEntry);
     int n_entries=0;

--- a/analyzer/rootana/src/LoadPulses.h
+++ b/analyzer/rootana/src/LoadPulses.h
@@ -1,0 +1,67 @@
+#ifndef LOADPULSES_H_
+#define LOADPULSES_H_
+
+#include "BaseModule.h"
+class TGlobalData;
+class TSetupData;
+namespace modules {class options;}
+namespace IDs {class source;}
+class TClonesArray;
+class TTree;
+
+////////////////////////////////////////////////////////////////////////////////
+/// \ingroup rootana_modules
+/// \author AuthorName
+///
+/// \brief
+/// A one line description of what your module does.
+///
+/// \details
+/// A longer, more descriptive block of text.
+/// Specifics like members and methods will be described later.
+/// You can add this to other groups instead of rootana_modules or in addition
+/// to rootana_modules by adding more of the ingroup tags.
+////////////////////////////////////////////////////////////////////////////////
+class LoadPulses : public BaseModule {
+
+ public:
+  /// \brief
+  /// Constructor description. If necessary, add a details tag like above.
+  ///
+  /// \param[in] opts Describe the options this module takes.
+  LoadPulses(modules::options* opts);
+  /// \brief
+  /// Is anything done in the destructor?
+  ~LoadPulses();
+
+ private:
+  /// \brief
+  /// What's calculated for every entry?
+  /// Don't hesitate to repeat what was said in the class description.
+  /// 
+  /// \return Non-zero to indicate a problem.
+  virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
+  /// \brief
+  /// What needes to be done before each run?
+  /// Don't hesitate to repeat what was said in the class description.
+  ///
+  /// \return Non-zero to indicate a problem.
+  virtual int BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup);
+  /// \brief
+  /// What needs to be done after each run?
+  /// Don't hesitate to repeat what was said in the class description.
+  ///
+  /// \return Non-zero to indicate a problem.
+  virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
+
+  std::string fFileName; 
+  std::string fTreeName;
+  TTree* fInTree;
+  Long64_t fCurrentEntry;
+  typedef std::map<IDs::source,TClonesArray*> SourceToClonesArrayMap;
+  SourceToClonesArrayMap fArrays;
+  typedef std::vector<std::pair<IDs::source, TBranch*> > BranchList;
+  BranchList fBranches;
+};
+
+#endif //LOADPULSES_H_

--- a/analyzer/rootana/src/LoadPulses.h
+++ b/analyzer/rootana/src/LoadPulses.h
@@ -58,6 +58,7 @@ class LoadPulses : public BaseModule {
   std::string fTreeName;
   TTree* fInTree;
   Long64_t fCurrentEntry;
+  Long64_t fNumEntries;
   typedef std::map<IDs::source,TClonesArray*> SourceToClonesArrayMap;
   SourceToClonesArrayMap fArrays;
   typedef std::vector<std::pair<IDs::source, TBranch*> > BranchList;

--- a/analyzer/rootana/src/SavePulses.cpp
+++ b/analyzer/rootana/src/SavePulses.cpp
@@ -1,0 +1,74 @@
+#include "SavePulses.h"
+#include "RegisterModule.inc"
+#include "TGlobalData.h"
+#include "TSetupData.h"
+#include "ModulesOptions.h"
+#include "ModulesNavigator.h"
+#include "definitions.h"
+#include "IdSource.h"
+#include "TAnalysedPulse.h"
+
+#include "TTree.h"
+#include "TClonesArray.h"
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+extern SourceAnalPulseMap gAnalysedPulseMap;
+
+SavePulses::SavePulses(modules::options* opts):
+   BaseModule("SavePulses",opts,false){
+       fTree=new TTree("TAP_tree","Tree storing all TAPs made in rootana");
+}
+
+SavePulses::~SavePulses(){
+}
+
+int SavePulses::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
+
+    // Check we're after MakeAnalysedPulses
+    if(!modules::navigator::Instance()->Before("MakeAnalysedPulses",GetName())){
+        cout<<"SavePulses: Error: I need to be run after MakeAnalysedPulses"<<endl;
+        return 1;
+    }
+
+    // Loop over gAnalysedPulseMap and add a branch for each source
+    TClonesArray* array;
+    for (SourceAnalPulseMap::const_iterator i_source = gAnalysedPulseMap.begin();
+            i_source != gAnalysedPulseMap.end(); ++i_source) {
+        array=new TClonesArray(TAnalysedPulse::Class());
+        fArrays[i_source->first]=array;
+        fTree->Branch(i_source->first.str().c_str(), array);
+    }
+
+  return 0;
+}
+
+int SavePulses::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+    const AnalysedPulseList* pulseList;
+    TClonesArray* array;
+    TAnalysedPulse* tap;
+    for (SourceAnalPulseMap::const_iterator i_source = gAnalysedPulseMap.begin();
+            i_source != gAnalysedPulseMap.end(); ++i_source) {
+        pulseList=&i_source->second;
+        array=fArrays[i_source->first];
+        for (AnalysedPulseList::const_iterator i_pulse = pulseList->begin();
+                i_pulse != pulseList->end(); ++i_pulse) {
+            tap=(TAnalysedPulse*) array->ConstructedAt(i_pulse-pulseList->begin());
+            *tap=**i_pulse;
+        }
+    }
+    fTree->Fill();
+    for(SourceToClonesArrayMap::iterator i_array=fArrays.begin();
+            i_array!=fArrays.end(); ++i_array){
+        i_array->second->Clear("C");
+    }
+  return 0;
+}
+
+int SavePulses::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
+  return 0;
+}
+
+ALCAP_REGISTER_MODULE(SavePulses);

--- a/analyzer/rootana/src/SavePulses.cpp
+++ b/analyzer/rootana/src/SavePulses.cpp
@@ -42,7 +42,7 @@ int SavePulses::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
         array=new TClonesArray(TAnalysedPulse::Class());
         fArrays[i_source->first]=array;
         name=i_source->first.str();
-        modules::parser::ReplaceAll(name,"-",'_');
+        modules::parser::ReplaceAll(name,"-","_");
         fTree->Branch(name.c_str(), array);
     }
 

--- a/analyzer/rootana/src/SavePulses.cpp
+++ b/analyzer/rootana/src/SavePulses.cpp
@@ -4,6 +4,7 @@
 #include "TSetupData.h"
 #include "ModulesOptions.h"
 #include "ModulesNavigator.h"
+#include "ModulesParser.h"
 #include "definitions.h"
 #include "IdSource.h"
 #include "TAnalysedPulse.h"
@@ -35,11 +36,14 @@ int SavePulses::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
 
     // Loop over gAnalysedPulseMap and add a branch for each source
     TClonesArray* array;
+    std::string name;
     for (SourceAnalPulseMap::const_iterator i_source = gAnalysedPulseMap.begin();
             i_source != gAnalysedPulseMap.end(); ++i_source) {
         array=new TClonesArray(TAnalysedPulse::Class());
         fArrays[i_source->first]=array;
-        fTree->Branch(i_source->first.str().c_str(), array);
+        name=i_source->first.str();
+        modules::parser::ReplaceAll(name,"-",'_');
+        fTree->Branch(name.c_str(), array);
     }
 
   return 0;
@@ -68,6 +72,7 @@ int SavePulses::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
 }
 
 int SavePulses::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
+    FlyWeight<IDs::source,TAnalysedPulse::Tag>::SaveProxyList(GetDirectory(),"TAP_sources");
   return 0;
 }
 

--- a/analyzer/rootana/src/SavePulses.h
+++ b/analyzer/rootana/src/SavePulses.h
@@ -3,7 +3,6 @@
 
 #include "BaseModule.h"
 class TTree;
-class TBranch;
 class TClonesArray;
 
 class TGlobalData;

--- a/analyzer/rootana/src/SavePulses.h
+++ b/analyzer/rootana/src/SavePulses.h
@@ -1,0 +1,66 @@
+#ifndef SAVEPULSES_H_
+#define SAVEPULSES_H_
+
+#include "BaseModule.h"
+class TTree;
+class TBranch;
+class TClonesArray;
+
+class TGlobalData;
+class TSetupData;
+namespace modules {class options;}
+namespace IDs {class source;}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \ingroup rootana_modules
+/// \author AuthorName
+///
+/// \brief
+/// A one line description of what your module does.
+///
+/// \details
+/// A longer, more descriptive block of text.
+/// Specifics like members and methods will be described later.
+/// You can add this to other groups instead of rootana_modules or in addition
+/// to rootana_modules by adding more of the ingroup tags.
+////////////////////////////////////////////////////////////////////////////////
+class SavePulses : public BaseModule {
+
+    typedef std::map<IDs::source,TClonesArray*> SourceToClonesArrayMap;
+
+ public:
+  /// \brief
+  /// Constructor description. If necessary, add a details tag like above.
+  ///
+  /// \param[in] opts Describe the options this module takes.
+  SavePulses(modules::options* opts);
+  /// \brief
+  /// Is anything done in the destructor?
+  ~SavePulses();
+
+ private:
+  /// \brief
+  /// What's calculated for every entry?
+  /// Don't hesitate to repeat what was said in the class description.
+  /// 
+  /// \return Non-zero to indicate a problem.
+  virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
+  /// \brief
+  /// What needes to be done before each run?
+  /// Don't hesitate to repeat what was said in the class description.
+  ///
+  /// \return Non-zero to indicate a problem.
+  virtual int BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup);
+  /// \brief
+  /// What needs to be done after each run?
+  /// Don't hesitate to repeat what was said in the class description.
+  ///
+  /// \return Non-zero to indicate a problem.
+  virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
+
+ private:
+  TTree* fTree;
+  SourceToClonesArrayMap fArrays;
+};
+
+#endif //SAVEPULSES_H_

--- a/analyzer/rootana/src/TAP_generators/TAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TAnalysedPulse.cpp
@@ -22,8 +22,8 @@ TAnalysedPulse::TAnalysedPulse(const IDs::source& sourceID,
   fIntegral(fDefaultValue),
   fEnergy(fDefaultValue),
   fPedestal(fDefaultValue),
-  fTriggerTime(fDefaultValue){
-    fSource.SetValue(sourceID);
+  fTriggerTime(fDefaultValue),
+  fSource(sourceID){
     SetParentTPIProperties(parentID, parentTPI);
 }
 

--- a/analyzer/rootana/src/TAP_generators/TAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TAnalysedPulse.h
@@ -87,7 +87,7 @@ class TAnalysedPulse : public TObject {
   double GetEnergy()const{return fEnergy;};
   double GetPedestal()const{return fPedestal;};
   double GetTriggerTime()const{return fTriggerTime;};
-  const IDs::source& GetSource()const{return fSource.GetValue();};
+  const IDs::source& GetSource()const{return fSource;};
   //@}
 
   /// \name Setters
@@ -136,7 +136,8 @@ class TAnalysedPulse : public TObject {
   double fEnergy;
   double fPedestal;
   double fTriggerTime;
-  FlyWeight<IDs::source,Tag> fSource;
+  IDs::source fSource;
+  //FlyWeight<IDs::source,Tag> fSource;
 
   /// \brief
   /// To enable sanity checks, we have an unphysical value that all

--- a/analyzer/rootana/src/TAP_generators/TAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TAnalysedPulse.h
@@ -87,7 +87,7 @@ class TAnalysedPulse : public TObject {
   double GetEnergy()const{return fEnergy;};
   double GetPedestal()const{return fPedestal;};
   double GetTriggerTime()const{return fTriggerTime;};
-  const IDs::source& GetSource()const{return fSource;};
+  const IDs::source& GetSource()const{return fSource.GetValue();};
   //@}
 
   /// \name Setters
@@ -136,8 +136,8 @@ class TAnalysedPulse : public TObject {
   double fEnergy;
   double fPedestal;
   double fTriggerTime;
-  IDs::source fSource;
-  //FlyWeight<IDs::source,Tag> fSource;
+  //IDs::source fSource;
+  FlyWeight<IDs::source,Tag> fSource;
 
   /// \brief
   /// To enable sanity checks, we have an unphysical value that all

--- a/analyzer/rootana/src/TAP_generators/TVAnalysedPulseGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TVAnalysedPulseGenerator.h
@@ -29,7 +29,7 @@ class TVAnalysedPulseGenerator {
             if(opts){
                 fDebug=opts->HasOption("debug");
             }
-            fSource.Generator()=IDs::generator(name);//,opts->ToOneString());
+            fSource.Generator()=IDs::generator(name,opts->StringDescription());
         };
         virtual ~TVAnalysedPulseGenerator(){};
 

--- a/analyzer/rootana/src/TDP_generators/MakeDetectorPulses.cpp
+++ b/analyzer/rootana/src/TDP_generators/MakeDetectorPulses.cpp
@@ -116,6 +116,7 @@ int MakeDetectorPulses::ProcessEntry(TGlobalData *gData, const TSetupData* gSetu
             slow_pulses=&(current->second);
             // check if the fast_pulses is empty
             if(slow_pulses->empty()) {
+                if(Debug())
                 cout<< "List of TAPs for "<<i_detector->slow<<" is empty."<<endl;
                 continue;
             }

--- a/analyzer/rootana/src/TDP_generators/TDetectorPulse.cpp
+++ b/analyzer/rootana/src/TDP_generators/TDetectorPulse.cpp
@@ -33,7 +33,7 @@ void TDetectorPulse::Reset(Option_t* o) {
     for(int i=0;i<kNumParents;++i){
         fParentPulse[i] = NULL;
         fParentID[i]=-1;
-        //fParentSource[i].Reset();
+        fParentSource[i].Reset();
     }
     fCheckedForPileUp=false;
     fPileUpSafe=false;

--- a/analyzer/rootana/src/TDP_generators/TDetectorPulse.cpp
+++ b/analyzer/rootana/src/TDP_generators/TDetectorPulse.cpp
@@ -26,14 +26,14 @@ TDetectorPulse::TDetectorPulse(const IDs::source& sourceID,
   if(f_parent) fParentSource[kFast]= f_parent->GetSource();
   fParentID[kSlow]=s_parentID;
   fParentID[kFast]=f_parentID;
-  fSource.SetValue(sourceID);
+  fSource=sourceID;
 }
 
 void TDetectorPulse::Reset(Option_t* o) {
     for(int i=0;i<kNumParents;++i){
         fParentPulse[i] = NULL;
         fParentID[i]=-1;
-        fParentSource[i].Reset();
+        //fParentSource[i].Reset();
     }
     fCheckedForPileUp=false;
     fPileUpSafe=false;

--- a/analyzer/rootana/src/TDP_generators/TDetectorPulse.h
+++ b/analyzer/rootana/src/TDP_generators/TDetectorPulse.h
@@ -41,7 +41,7 @@ class TDetectorPulse : public TObject {
             TDP_GetField(ch,Pedestal); }
         const TAnalysedPulse* GetTAP(ParentChannel_t ch)const {return fParentPulse[ch];}
 
-        const IDs::source& GetSource() const { return fSource.GetValue(); }
+        const IDs::source& GetSource() const { return fSource; }
 
         bool IsPileUpSafe()const{return fPileUpSafe&&fCheckedForPileUp;};
         void SetPileUpSafe(const bool& val=true){fPileUpSafe=val;fCheckedForPileUp=true;};
@@ -54,9 +54,10 @@ class TDetectorPulse : public TObject {
 
         const TAnalysedPulse* fParentPulse[kNumParents];
         int fParentID[kNumParents];
-        FlyWeight<IDs::source,TAnalysedPulse::Tag> fParentSource[kNumParents];
-
-        FlyWeight<IDs::source,Tag> fSource;
+        IDs::source fParentSource[kNumParents];
+        IDs::source fSource;
+        //FlyWeight<IDs::source,TAnalysedPulse::Tag> fParentSource[kNumParents];
+        //FlyWeight<IDs::source,Tag> fSource;
 
         ClassDef(TDetectorPulse, 2);
 };

--- a/analyzer/rootana/src/TDP_generators/TDetectorPulse.h
+++ b/analyzer/rootana/src/TDP_generators/TDetectorPulse.h
@@ -41,7 +41,7 @@ class TDetectorPulse : public TObject {
             TDP_GetField(ch,Pedestal); }
         const TAnalysedPulse* GetTAP(ParentChannel_t ch)const {return fParentPulse[ch];}
 
-        const IDs::source& GetSource() const { return fSource; }
+        const IDs::source& GetSource() const { return fSource.GetValue(); }
 
         bool IsPileUpSafe()const{return fPileUpSafe&&fCheckedForPileUp;};
         void SetPileUpSafe(const bool& val=true){fPileUpSafe=val;fCheckedForPileUp=true;};
@@ -54,10 +54,10 @@ class TDetectorPulse : public TObject {
 
         const TAnalysedPulse* fParentPulse[kNumParents];
         int fParentID[kNumParents];
-        IDs::source fParentSource[kNumParents];
-        IDs::source fSource;
-        //FlyWeight<IDs::source,TAnalysedPulse::Tag> fParentSource[kNumParents];
-        //FlyWeight<IDs::source,Tag> fSource;
+        //IDs::source fParentSource[kNumParents];
+        //IDs::source fSource;
+        FlyWeight<IDs::source,TAnalysedPulse::Tag> fParentSource[kNumParents];
+        FlyWeight<IDs::source,Tag> fSource;
 
         ClassDef(TDetectorPulse, 2);
 };

--- a/analyzer/rootana/src/TDP_generators/TVDetectorPulseGenerator.h
+++ b/analyzer/rootana/src/TDP_generators/TVDetectorPulseGenerator.h
@@ -13,7 +13,7 @@ class TVDetectorPulseGenerator {
  public:
   TVDetectorPulseGenerator(const char* name, TDPGeneratorOptions* opts):
       fDebug(false),fFastPulses(NULL),fSlowPulses(NULL){
-            fSource.Generator()=IDs::generator(name);//,opts->ToOneString());
+            fSource.Generator()=IDs::generator(name,opts->StringDescription());
       }
   virtual ~TVDetectorPulseGenerator(){}
 

--- a/analyzer/rootana/src/data_quality/IslandAmplitude.cpp
+++ b/analyzer/rootana/src/data_quality/IslandAmplitude.cpp
@@ -19,8 +19,6 @@ using std::endl;
 
 IslandAmplitude::IslandAmplitude(modules::options* opts)
   : BaseModule("IslandAmplitude",opts)
-  , fDirName("IslandAmplitude")
-
 {
   // Do something with opts here.
 }
@@ -43,11 +41,6 @@ int IslandAmplitude::BeforeFirstEntry(TGlobalData* data,const TSetupData *setup)
   }
 
   fNProcessed = 0;
-
-  if(!TDirectory::CurrentDirectory()->cd(fDirName.c_str()))
-     TDirectory::CurrentDirectory()->mkdir(fDirName.c_str())->cd();
-
-  fHistDir = TDirectory::CurrentDirectory();
 
   StringPulseIslandMap& islands = data->fPulseIslandToChannelMap;
 
@@ -151,9 +144,6 @@ int IslandAmplitude::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
      cout<<"-----IslandAmplitude::AfterLastEntry(): I'm debugging!"<<endl;
   }
 
-  TDirectory*pwd = TDirectory::CurrentDirectory();
-  fHistDir->cd();
-
   double run_norm = fAmpNorm->Integral(0,-1);
   for(mapSH_t::iterator it = fAmpHist.begin(); it != fAmpHist.end(); ++it)
     {
@@ -166,8 +156,6 @@ int IslandAmplitude::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
 
   for(mapSH_t::iterator it = fAmpHistNorm.begin(); it != fAmpHistNorm.end(); ++it)
     it->second->Scale(1.0/fNProcessed);
-
-  pwd->cd();
 
   return 0;
 }

--- a/analyzer/rootana/src/data_quality/IslandAmplitude.h
+++ b/analyzer/rootana/src/data_quality/IslandAmplitude.h
@@ -71,10 +71,6 @@ class IslandAmplitude : public BaseModule {
   /// \details
   /// ...and don't hesitate to include details.
 
-  std::string fDirName;
-
-  TDirectory* fHistDir;
-
   mapSH_t fAmpHist;
   mapSH_t fAmpHistNorm;
 

--- a/analyzer/rootana/src/data_quality/IslandLength.cpp
+++ b/analyzer/rootana/src/data_quality/IslandLength.cpp
@@ -12,7 +12,6 @@
 //----------------------------------------------------------------------
 IslandLength::IslandLength(modules::options* opts)
   : BaseModule("IslandLength",opts)
-  , fDirName("IslandLength")
 {
 
   // Do something with opts here.  Has the user specified any
@@ -92,9 +91,6 @@ int IslandLength::AfterLastEntry(TGlobalData* gData,const TSetupData *setup)
               << std::endl;    
   }
 
-  TDirectory* pwd = TDirectory::CurrentDirectory();
-  fHistDir->cd();
-  
   double run_norm = fNormHist->Integral(0,-1);
   for (mapSH_t::iterator it = fHistos.begin(); it != fHistos.end(); ++it){
     TH1F* h = it->second;
@@ -106,7 +102,6 @@ int IslandLength::AfterLastEntry(TGlobalData* gData,const TSetupData *setup)
   for (mapSH_t::iterator it = fHistosNorm.begin(); it != fHistosNorm.end(); ++it){
     it->second->Scale(1./fNProcessed);
   }
-  pwd->cd();
 
   return 0;
 }
@@ -114,12 +109,6 @@ int IslandLength::AfterLastEntry(TGlobalData* gData,const TSetupData *setup)
 //----------------------------------------------------------------------
 void IslandLength::Book(TGlobalData* data,const TSetupData* setup)
 {
-  if (!TDirectory::CurrentDirectory()->cd(fDirName.c_str())){
-    // this will blow up if the file is not writable.  Good!
-    TDirectory::CurrentDirectory()->mkdir(fDirName.c_str())->cd();
-  }
-  fHistDir = TDirectory::CurrentDirectory();
-
   //Change: Use the same map as when processing entries. This should
   //guarentee that all histograms we try to fill also exist 
   StringPulseIslandMap& islands = data->fPulseIslandToChannelMap;
@@ -141,7 +130,6 @@ void IslandLength::Book(TGlobalData* data,const TSetupData* setup)
                      500, 0, 2000);
     fHistosNorm[bank_name] = histo;
   }
-  TDirectory::CurrentDirectory()->cd("../");
 }
 
 //----------------------------------------------------------------------

--- a/analyzer/rootana/src/data_quality/IslandLength.h
+++ b/analyzer/rootana/src/data_quality/IslandLength.h
@@ -76,12 +76,6 @@ private:
   /// Book histograms and similar
   virtual void Book(TGlobalData* data,const TSetupData* setup);
 
-  /// The directory where the histograms will reside
-  std::string fDirName;
-
-  /// The directory where histograms arre stored
-  TDirectory* fHistDir;
-
   /// Map of histograms, keyed by bank_name;
   mapSH_t fHistos;
 

--- a/analyzer/rootana/src/debug_tools.h
+++ b/analyzer/rootana/src/debug_tools.h
@@ -10,7 +10,8 @@
 //runtime checks like memory usage and stopwatches.
 
 #define DEBUG_PREFIX std::cout << "@ " << __FILE__ << ":" << __LINE__
-#define DEBUG_PRINT DEBUG_PREFIX << std::endl;
+#define DEBUG_CHECKPOINT DEBUG_PREFIX << std::endl;
+#define DEBUG_PRINT(output) DEBUG_PREFIX<<output << std::endl;
 #define DEBUG_VALUE(value) DEBUG_PREFIX << ":\n" << std::boolalpha      \
                                         <<"  "#value"= [" << (value)    \
                                         <<"]" << std::endl;

--- a/analyzer/rootana/src/files.make
+++ b/analyzer/rootana/src/files.make
@@ -20,3 +20,4 @@ ROOT_DICT_CLASSES:=TAnalysedPulseMapWrapper\
 	IdGenerator\
 	IdSource\
         BankBranch\
+        FlyWeight\

--- a/analyzer/rootana/src/framework/BaseModule.cpp
+++ b/analyzer/rootana/src/framework/BaseModule.cpp
@@ -51,3 +51,25 @@ int BaseModule::ProcessGenericEntry(TGlobalData *gData, const TSetupData *gSetup
 
   return ret;
 }
+
+int BaseModule::Preprocess(TGlobalData *gData, const TSetupData *gSetup){
+  // This is called by our main routine and would allow later to split into different 
+  // process routines if we have more than one Tree and hence different tpyes of data input.
+
+  if(fDirectory) fDirectory->cd();
+  int ret = BeforeFirstEntry(gData, gSetup);
+  gDirectory->cd("/");
+
+  return ret;
+}
+
+int BaseModule::Postprocess(TGlobalData *gData, const TSetupData *gSetup){
+  // This is called by our main routine and would allow later to split into different 
+  // process routines if we have more than one Tree and hence different tpyes of data input.
+
+  if(fDirectory) fDirectory->cd();
+  int ret = AfterLastEntry(gData, gSetup);
+  gDirectory->cd("/");
+
+  return ret;
+}

--- a/analyzer/rootana/src/framework/BaseModule.h
+++ b/analyzer/rootana/src/framework/BaseModule.h
@@ -32,6 +32,18 @@ class BaseModule
   /// @return 0 on sucess and non-zero if a problem occurred
   int ProcessGenericEntry(TGlobalData *gData, const TSetupData* gSetup);
 
+  /// @brief Method called by the main pre-process loop.
+  /// @details Does some simple work, then hooks into the derived class through
+  /// BeforeFirstEntry.
+  /// @return 0 on sucess and non-zero if a problem occurred
+  int Preprocess(TGlobalData *gData, const TSetupData* gSetup);
+
+  /// @brief Method called by the main pre-process loop.
+  /// @details Does some simple work, then hooks into the derived class through
+  /// AfterLastEntry.
+  /// @return 0 on sucess and non-zero if a problem occurred
+  int Postprocess(TGlobalData *gData, const TSetupData* gSetup);
+
   /// Optional method which is called once before the main event loop
   /// Can be used to parse options and setup histograms.
   /// @return 0 on sucess and non-zero if a problem occurred

--- a/analyzer/rootana/src/framework/EventNavigator.h
+++ b/analyzer/rootana/src/framework/EventNavigator.h
@@ -12,7 +12,6 @@ class TTree;
 //Local
 #include "definitions.h"
 #include "TGlobalData.h"
-#include "TAnalysedPulseMapWrapper.h"
 #include "BankIter.h"
 #include "SetupRecord.h"
 #include "LoopSequence.h"
@@ -259,8 +258,6 @@ private:
 
   SetupRecord* fSetupRecord;
 
-  TAnalysedPulseMapWrapper* fAPWrapper;
-  
   LoopSequence* fLoopSequence;
 
 

--- a/analyzer/rootana/src/framework/FlyWeight.h
+++ b/analyzer/rootana/src/framework/FlyWeight.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <iostream>
 
+#include <TObject.h>
+
 /// \name SourceProxy
 ///
 /// \brief
@@ -27,7 +29,7 @@
 /// is unique, such as to separate the flyweight for TAPs from TDPs, even though
 /// the ValueType is the same
 template <typename ValueType, typename UniqueTag=int>
-class FlyWeight{
+class FlyWeight:public TObject{
     public:
         typedef int Proxy_t;
         typedef std::map<ValueType,Proxy_t> ValueToProxyMap;
@@ -46,6 +48,8 @@ class FlyWeight{
         Proxy_t fProxy;
         static ProxyToValueMap sProxyToVals;
         static ValueToProxyMap sValsToProxies;
+
+        ClassDef(FlyWeight,1);
 };
 
 template <typename ValueType, typename UniqueTag>

--- a/analyzer/rootana/src/framework/FlyWeight.h
+++ b/analyzer/rootana/src/framework/FlyWeight.h
@@ -4,10 +4,33 @@
 #include <map>
 #include <vector>
 #include <iostream>
+#include <string>
 
 #include <TObject.h>
+#include <TDirectory.h>
 
-/// \name SourceProxy
+template <typename ValueType, typename UniqueTag=int>
+class FlyWeightLists:public TObject{
+    public:
+        FlyWeightLists(){};
+        typedef int Proxy_t;
+        typedef std::map<ValueType,Proxy_t> ValueToProxyMap;
+        typedef std::vector<ValueType> ProxyToValueMap;
+
+        int GetProxy(const ValueType& v);
+        const ValueType& GetValue(const Proxy_t& v);
+
+        bool empty()const{return sProxyToVals.empty();}
+        void DumpTable()const;
+
+    private:
+        ProxyToValueMap sProxyToVals;
+        ValueToProxyMap sValsToProxies;
+
+        ClassDef(FlyWeightLists,1);
+};
+
+/// \name FlyWeight
 ///
 /// \brief
 /// A generic flyweight to store relatively bulky objects that are massively
@@ -32,10 +55,11 @@ template <typename ValueType, typename UniqueTag=int>
 class FlyWeight:public TObject{
     public:
         typedef int Proxy_t;
-        typedef std::map<ValueType,Proxy_t> ValueToProxyMap;
-        typedef std::vector<ValueType> ProxyToValueMap;
 
         FlyWeight():fProxy(-1){}
+        FlyWeight(const ValueType& val):fProxy(-1){
+            SetValue(val);
+        }
         void Reset(){fProxy=-1;}
 
         void operator=(const ValueType& v){
@@ -43,42 +67,94 @@ class FlyWeight:public TObject{
         }
         void SetValue(const ValueType&);
         const ValueType& GetValue()const;
+        void DumpTable()const {fProxyList->DumpTable();}
+
+        static int LoadProxyList(TDirectory* file, const std::string& name );
+        static int SaveProxyList(TDirectory* file, const std::string& name );
+        static void InitProxyList(){fProxyList=new FlyWeightLists<ValueType,UniqueTag>();};
 
     private:
         Proxy_t fProxy;
-        static ProxyToValueMap sProxyToVals;
-        static ValueToProxyMap sValsToProxies;
 
-        ClassDef(FlyWeight,1);
+        static FlyWeightLists<ValueType,UniqueTag>* fProxyList;
+
+        ClassDef(FlyWeight,2);
 };
 
 template <typename ValueType, typename UniqueTag>
 inline const ValueType& FlyWeight<ValueType,UniqueTag>::GetValue()const{
     if(fProxy<0) std::cerr<<"Trying to get a value "
         "from an unitialized flyweight"<<std::endl;
-    return sProxyToVals.at(fProxy);
+    return fProxyList->GetValue(fProxy);
 }
 
 template <typename ValueType, typename UniqueTag>
 inline void FlyWeight<ValueType,UniqueTag>::SetValue(const ValueType& v){
-    // Is this proxy already contained in the maps
-    typename ValueToProxyMap::const_iterator it=sValsToProxies.find(v);
-    if(it!=sValsToProxies.end()){
-        fProxy=it->second;
-    } else {
-        // if it's a new kind, add the source to the hash table
-        fProxy=sValsToProxies.size();
-        sValsToProxies[v]=fProxy;
-        sProxyToVals.push_back(v);
-    }
+    if(!fProxyList)InitProxyList();
+    fProxy=fProxyList->GetProxy(v);
 }
 
 template <typename ValueType, typename UniqueTag>
-  typename FlyWeight<ValueType,UniqueTag>::ProxyToValueMap 
-  FlyWeight<ValueType,UniqueTag>::sProxyToVals;
+inline int FlyWeight<ValueType,UniqueTag>:: LoadProxyList(
+        TDirectory* file, const std::string& name ){
+    if(fProxyList && !fProxyList->empty()){
+        std::cout<<"FlyWeight: Error: Proxy list is not empty but was asked to load the list from a file"<<std::endl;
+        return 1;
+    }
+    if(!file) {
+        std::cout<<"FlyWeight: Error: Cannot load a proxy list from a NULL file"<<std::endl;
+        return 2;
+    }
+    file->GetObject(name.c_str(),fProxyList);
+    if(!fProxyList){
+        std::cout<<"FlyWeight: Error: Couldn't find proxy list '"<<name
+            <<"' in file '"<<file->GetName()<<"'"<<std::endl;
+        return 3;
+    }
+    return 0;
+}
 
 template <typename ValueType, typename UniqueTag>
-  typename FlyWeight<ValueType,UniqueTag>::ValueToProxyMap 
-  FlyWeight<ValueType,UniqueTag>::sValsToProxies;
+inline int FlyWeight<ValueType,UniqueTag>::SaveProxyList(
+        TDirectory* file, const std::string& name ){
+    if(!file) {
+        std::cout<<"FlyWeight: Error: Cannot save a proxy list from a NULL file"<<std::endl;
+        return 1;
+    }
+    file->WriteObject(fProxyList,name.c_str());
+    return 0;
+}
 
+
+template <typename ValueType, typename UniqueTag>
+FlyWeightLists<ValueType,UniqueTag>* 
+FlyWeight<ValueType,UniqueTag>::fProxyList=NULL;
+
+template <typename ValueType, typename UniqueTag>
+inline const ValueType& FlyWeightLists<ValueType,UniqueTag>::GetValue(
+        const Proxy_t& v){
+    return sProxyToVals.at(v);
+}
+
+template <typename ValueType, typename UniqueTag>
+inline int FlyWeightLists<ValueType,UniqueTag>::GetProxy(const ValueType& v){
+    // Is this proxy already contained in the maps
+    typename ValueToProxyMap::const_iterator it=sValsToProxies.find(v);
+    if(it!=sValsToProxies.end()){
+        return it->second;
+    } 
+    // if it's a new kind, add the source to the hash table
+    int proxy=sValsToProxies.size();
+    sValsToProxies[v]=proxy;
+    sProxyToVals.push_back(v);
+    return proxy;
+}
+
+template <typename ValueType, typename UniqueTag>
+inline void FlyWeightLists<ValueType,UniqueTag>::DumpTable()const{
+    std::cout<<"Proxy | Value | Proxy"<<std::endl;
+    for(unsigned i=0;i<sProxyToVals.size();i++){
+        std::cout<<i<<" | "<<sProxyToVals[i]<<" | "<<sValsToProxies.find(sProxyToVals[i])->second<<std::endl;
+    }
+}
 #endif //FLYWEIGHT_H

--- a/analyzer/rootana/src/framework/IdGenerator.cpp
+++ b/analyzer/rootana/src/framework/IdGenerator.cpp
@@ -1,6 +1,7 @@
 #include "IdGenerator.h"
-#include <ostream>
+#include <iostream>
 
+#include "debug_tools.h"
 
 ClassImp(IDs::generator);
 
@@ -11,4 +12,17 @@ std::string IDs::generator::str()const{
 ostream& operator<< (ostream& os ,const IDs::generator& id) {
   os<<id.str();
   return os;
+}
+
+IDs::generator& IDs::generator::operator=(const std::string& rhs){
+    // Find the first delimiter
+    size_t delim=rhs.find(IDs::field_separator.c_str());
+    if(delim==std::string::npos){
+        std::cout<<"Warning: Strange looking string given to IDs::source: "<<rhs<<std::endl;
+        Type(rhs);
+    } else{
+        Type(rhs.substr(0,delim));
+        Config(rhs.substr(delim+1));
+    }
+    return *this;
 }

--- a/analyzer/rootana/src/framework/IdGenerator.h
+++ b/analyzer/rootana/src/framework/IdGenerator.h
@@ -29,11 +29,19 @@ class IDs::generator:public TObject{
 	/// 
 	/// @param g The type of the generator
 	/// @param c The configuration of the generator
-	generator(Generator_t g , Config_t c=kDefaultConfig);
+	generator(Generator_t g , Config_t c);
 
 	/// @brief Default constructor for a generator ID.
 	/// Will match true against all generator IDs
 	generator():fType(kAnyGenerator),fConfig(kAnyConfig){};
+
+    /// @brief Construct a source ID from a single string
+    /// @details Equivalent to calling the defualt constructor following by
+    /// operator=(std::string)
+    generator(const std::string& s)
+        : fType(kAnyGenerator),fConfig(kAnyConfig) {
+            operator=(s);
+        };
 
 	virtual ~generator(){};
 
@@ -41,8 +49,14 @@ class IDs::generator:public TObject{
 	/// Returns the type of generator that this ID represents
 	Generator_t Type()const{return fType;};
 
+    /// Set the type of generator that this ID represents
+	void Type(const Generator_t& g){ fType=g;};
+
 	/// Returns the configuration of the generator that this ID represents
 	Config_t Config()const{return fConfig;};
+
+    /// Set the configuration of the generator that this ID represents
+	void Config(const Config_t& c){fConfig=c;};
 
 	/// Is this generator the same as another, or is this or the other id
 	/// have fields set to kAny
@@ -60,6 +74,8 @@ class IDs::generator:public TObject{
 
 	/// Get this ID as a string
 	std::string str()const;
+
+    IDs::generator& operator=(const std::string& rhs);
 
     /// Check if the Generator_t part of the ID is a wildcard
     bool isWildCardType() const { return fType == kAnyGenerator; }

--- a/analyzer/rootana/src/framework/IdGenerator.h
+++ b/analyzer/rootana/src/framework/IdGenerator.h
@@ -11,9 +11,9 @@ namespace IDs{
 	typedef std::string Config_t;
 
 	/// Standardize the value to use to represent any generator 
-	const Generator_t kAnyGenerator="*";
+	const Generator_t kAnyGenerator="any";
 	/// Standardize the value to use to represent any configuration
-	const Config_t kAnyConfig="*";
+	const Config_t kAnyConfig="any";
 	/// Standardize the value to use to represent the default configuration of a
     /// module
 	const Config_t kDefaultConfig="default";

--- a/analyzer/rootana/src/framework/IdSource.cpp
+++ b/analyzer/rootana/src/framework/IdSource.cpp
@@ -1,5 +1,5 @@
 #include "IdSource.h"
-#include <ostream>
+#include <iostream>
 
 ClassImp(IDs::source);
 
@@ -10,4 +10,17 @@ std::string IDs::source::str()const{
 ostream& operator<< (ostream& os ,const IDs::source& id) {
   os<<id.str();
   return os;
+}
+
+IDs::source& IDs::source::operator=(const std::string& rhs){
+    // Find the first delimiter
+    size_t delim=rhs.find(IDs::field_separator.c_str());
+    if(delim==std::string::npos){
+        std::cout<<"Warning: Strange looking string given to IDs::source: "<<rhs<<std::endl;
+        Channel()=rhs;
+    } else{
+        Channel()=rhs.substr(0,delim);
+        Generator()=rhs.substr(delim+1);
+    }
+    return *this;
 }

--- a/analyzer/rootana/src/framework/IdSource.h
+++ b/analyzer/rootana/src/framework/IdSource.h
@@ -23,6 +23,14 @@ class IDs::source:public TObject{
   /// Channel and generator.
   source()
     : fChannel(),fGenerator() {};
+
+  /// @brief Construct a source ID from a single string
+  /// @details Equivalent to calling the defualt constructor following by
+  /// operator=(std::string)
+  source(const std::string& s)
+    : fChannel(),fGenerator() {
+        operator=(s);
+    };
     
   /// Construct using a given channel and generator ID
   source(const IDs::channel& ch,const IDs::generator& gen)
@@ -87,6 +95,8 @@ class IDs::source:public TObject{
 
   /// Returns the source as a string
   std::string str()const;
+
+  IDs::source& operator=(const std::string& rhs);
 
   /// Check if the Channel is a wildcard
   bool isWildCardChannel() const {return Channel().isWildCard();}

--- a/analyzer/rootana/src/framework/LoopSequence.cpp
+++ b/analyzer/rootana/src/framework/LoopSequence.cpp
@@ -79,7 +79,7 @@ void LoopSequence::Preprocess() const
   enav.GetEntry(fStart);
   int err_code =0;
   modules::navigator& mn = *modules::navigator::Instance();
-  for (modules::iterator it = mn.Begin(); it != mn.End(); ++it) {
+  for (modules::iterator it = mn.Begin(); it != mn.End() && !err_code; ++it) {
     BaseModule* mod = it->second;
     err_code |= mod->Preprocess(enav.GetRawData(), enav.GetSetupData());
   }
@@ -104,7 +104,7 @@ void LoopSequence::Process() const
     enav.GetEntry(jentry);
     int err_code = 0;
     modules::navigator& mn = *modules::navigator::Instance();
-    for (modules::iterator it = mn.Begin(); it != mn.End(); ++it) {
+    for (modules::iterator it = mn.Begin(); it != mn.End() && ! err_code; ++it) {
       BaseModule* mod = it->second;
       err_code |= mod->ProcessGenericEntry(raw_data,enav.GetSetupData());
     }
@@ -124,7 +124,7 @@ void LoopSequence::Postprocess() const
   EventNavigator& enav = EventNavigator::Instance();
   int err_code =0;
   modules::navigator& mn = *modules::navigator::Instance();
-  for (modules::iterator it = mn.Begin(); it != mn.End(); ++it) {
+  for (modules::iterator it = mn.Begin(); it != mn.End() && !err_code; ++it) {
     BaseModule* mod = it->second;
     err_code |= mod->Postprocess(enav.GetRawData(), enav.GetSetupData());
   }

--- a/analyzer/rootana/src/framework/LoopSequence.cpp
+++ b/analyzer/rootana/src/framework/LoopSequence.cpp
@@ -14,7 +14,7 @@
 #include "BaseModule.h"
 #include "TAnalysedPulseMapWrapper.h"
 
-extern TAnalysedPulseMapWrapper* gAnalysedPulseMapWrapper;
+//extern TAnalysedPulseMapWrapper* gAnalysedPulseMapWrapper;
 extern SourceAnalPulseMap gAnalysedPulseMap;
 extern TTree* gAnalysedPulseTree;
 //extern StringDetPulseMap gDetectorPulseMap;
@@ -96,7 +96,7 @@ void LoopSequence::Process() const
     TGlobalData* raw_data = enav.GetRawData();
     if (raw_data){
       raw_data->Clear("C");
-      ClearGlobalData(raw_data);
+      //ClearGlobalData(raw_data);
     }
     
     Checkpoint(jentry);
@@ -110,8 +110,8 @@ void LoopSequence::Process() const
     }
     if (err_code) throw process_error(jentry);
   
-    gAnalysedPulseMapWrapper->SetMap(gAnalysedPulseMap);
-    gAnalysedPulseTree->Fill();
+    //gAnalysedPulseMapWrapper->SetMap(gAnalysedPulseMap);
+    //gAnalysedPulseTree->Fill();
   
   }
   return;

--- a/analyzer/rootana/src/framework/LoopSequence.cpp
+++ b/analyzer/rootana/src/framework/LoopSequence.cpp
@@ -79,7 +79,7 @@ void LoopSequence::Preprocess() const
   enav.GetEntry(fStart);
   int err_code =0;
   modules::navigator& mn = *modules::navigator::Instance();
-  for (modules::iterator it = mn.Begin(); it != mn.End(); ++it) {
+  for (modules::iterator it = mn.Begin(); it != mn.End() && !err_code; ++it) {
     BaseModule* mod = it->second;
     err_code |= mod->BeforeFirstEntry(enav.GetRawData(), enav.GetSetupData());
   }
@@ -104,7 +104,7 @@ void LoopSequence::Process() const
     enav.GetEntry(jentry);
     int err_code = 0;
     modules::navigator& mn = *modules::navigator::Instance();
-    for (modules::iterator it = mn.Begin(); it != mn.End(); ++it) {
+    for (modules::iterator it = mn.Begin(); it != mn.End() && ! err_code; ++it) {
       BaseModule* mod = it->second;
       err_code |= mod->ProcessGenericEntry(raw_data,enav.GetSetupData());
     }
@@ -124,7 +124,7 @@ void LoopSequence::Postprocess() const
   EventNavigator& enav = EventNavigator::Instance();
   int err_code =0;
   modules::navigator& mn = *modules::navigator::Instance();
-  for (modules::iterator it = mn.Begin(); it != mn.End(); ++it) {
+  for (modules::iterator it = mn.Begin(); it != mn.End() && !err_code; ++it) {
     BaseModule* mod = it->second;
     err_code |= mod->AfterLastEntry(enav.GetRawData(), enav.GetSetupData());
   }

--- a/analyzer/rootana/src/framework/LoopSequence.cpp
+++ b/analyzer/rootana/src/framework/LoopSequence.cpp
@@ -12,11 +12,8 @@
 #include "EventNavigator.h"
 #include "ModulesNavigator.h"
 #include "BaseModule.h"
-#include "TAnalysedPulseMapWrapper.h"
 
-//extern TAnalysedPulseMapWrapper* gAnalysedPulseMapWrapper;
 extern SourceAnalPulseMap gAnalysedPulseMap;
-extern TTree* gAnalysedPulseTree;
 //extern StringDetPulseMap gDetectorPulseMap;
 
 extern void ClearGlobalData(TGlobalData* data);
@@ -109,9 +106,6 @@ void LoopSequence::Process() const
       err_code |= mod->ProcessGenericEntry(raw_data,enav.GetSetupData());
     }
     if (err_code) throw process_error(jentry);
-  
-    //gAnalysedPulseMapWrapper->SetMap(gAnalysedPulseMap);
-    //gAnalysedPulseTree->Fill();
   
   }
   return;

--- a/analyzer/rootana/src/framework/LoopSequence.cpp
+++ b/analyzer/rootana/src/framework/LoopSequence.cpp
@@ -81,7 +81,7 @@ void LoopSequence::Preprocess() const
   modules::navigator& mn = *modules::navigator::Instance();
   for (modules::iterator it = mn.Begin(); it != mn.End(); ++it) {
     BaseModule* mod = it->second;
-    err_code |= mod->BeforeFirstEntry(enav.GetRawData(), enav.GetSetupData());
+    err_code |= mod->Preprocess(enav.GetRawData(), enav.GetSetupData());
   }
   if (err_code) throw preprocess_error(fStart);
 }
@@ -126,7 +126,7 @@ void LoopSequence::Postprocess() const
   modules::navigator& mn = *modules::navigator::Instance();
   for (modules::iterator it = mn.Begin(); it != mn.End(); ++it) {
     BaseModule* mod = it->second;
-    err_code |= mod->AfterLastEntry(enav.GetRawData(), enav.GetSetupData());
+    err_code |= mod->Postprocess(enav.GetRawData(), enav.GetSetupData());
   }
   if ( err_code ) throw postprocess_error(fStop-1);
 }

--- a/analyzer/rootana/src/framework/LoopSequence.cpp
+++ b/analyzer/rootana/src/framework/LoopSequence.cpp
@@ -96,7 +96,7 @@ void LoopSequence::Process() const
     TGlobalData* raw_data = enav.GetRawData();
     if (raw_data){
       raw_data->Clear("C");
-      //ClearGlobalData(raw_data);
+      ClearGlobalData(raw_data);
     }
     
     Checkpoint(jentry);

--- a/analyzer/rootana/src/framework/LoopSequence.cpp
+++ b/analyzer/rootana/src/framework/LoopSequence.cpp
@@ -145,6 +145,15 @@ void LoopSequence::Run() const
               << e.fEvent << ")";
   }
   catch (process_error& e){
+    try{
+        // try to let each module finish to save plots etc
+        this->Postprocess();
+    } catch(...) {
+        // if postprocess throws an error assume it's related to the process
+        // error
+        std::cout << "\nA module returned non-zero on entry " << e.fEvent;
+        throw;
+    }
     std::cout << "\nA module returned non-zero on entry " << e.fEvent;
   }
   catch (postprocess_error& e){

--- a/analyzer/rootana/src/framework/ModulesParser.cpp
+++ b/analyzer/rootana/src/framework/ModulesParser.cpp
@@ -71,16 +71,29 @@ size_t modules::parser::RemoveWhitespace(std::string& input, std::string::iterat
 	return input.size();
 }
 
-void modules::parser::ToCppValid(std::string& input){
-    ReplaceAll(input," :#*()-=+$%^&!.,/?",'_' );
+const std::string& modules::parser::ToCppValid(const std::string& input){
+    return ReplaceAll(input," :#*()-=+$%^&!.,/?","_" );
 }
 
-void modules::parser::ReplaceAll(std::string& input, const std::string& search, char replace ){
-    for(std::string::iterator i_char=input.begin(); i_char!=input.end();++i_char){
+void modules::parser::ToCppValid(std::string& input){
+    ReplaceAll(input," :#*()-=+$%^&!.,/?","_" );
+}
+
+const std::string& modules::parser::ReplaceAll(const std::string& input, const std::string& search,const std::string& replace ){
+    static std::string output;
+    output.clear();
+    for(std::string::const_iterator i_char=input.begin(); i_char!=input.end();++i_char){
         if(std::find(search.begin(),search.end(), *i_char)!=search.end()){
-            *i_char=replace;
+            output+=replace;
+        } else{
+            output+=*i_char;
         }
     }
+    return output;
+}
+
+void modules::parser::ReplaceAll(std::string& input, const std::string& search, const std::string& replace ){
+    input=ReplaceAll(const_cast<const std::string&>(input),search,replace);
 }
 
 void modules::parser::TrimWhiteSpaceBeforeAfter(std::string& line){

--- a/analyzer/rootana/src/framework/ModulesParser.cpp
+++ b/analyzer/rootana/src/framework/ModulesParser.cpp
@@ -72,11 +72,11 @@ size_t modules::parser::RemoveWhitespace(std::string& input, std::string::iterat
 }
 
 const std::string& modules::parser::ToCppValid(const std::string& input){
-    return ReplaceAll(input," :#*()-=+$%^&!.,/?","_" );
+    return ReplaceAll(input," :{}#*()-=+$%^&!.,/?","_" );
 }
 
 void modules::parser::ToCppValid(std::string& input){
-    ReplaceAll(input," :#*()-=+$%^&!.,/?","_" );
+    ReplaceAll(input," :{}#*()-=+$%^&!.,/?","_" );
 }
 
 const std::string& modules::parser::ReplaceAll(const std::string& input, const std::string& search,const std::string& replace ){

--- a/analyzer/rootana/src/framework/ModulesParser.cpp
+++ b/analyzer/rootana/src/framework/ModulesParser.cpp
@@ -72,7 +72,7 @@ size_t modules::parser::RemoveWhitespace(std::string& input, std::string::iterat
 }
 
 void modules::parser::ToCppValid(std::string& input){
-    ReplaceAll(input," :#*()-=+$%^&!.,/?",'_' );
+    ReplaceAll(input," :{}#*()-=+$%^&!.,/?",'_' );
 }
 
 void modules::parser::ReplaceAll(std::string& input, const std::string& search, char replace ){

--- a/analyzer/rootana/src/framework/ModulesParser.h
+++ b/analyzer/rootana/src/framework/ModulesParser.h
@@ -55,7 +55,9 @@ namespace modules{
             throw(modules::parser::errors::unmatched_parenthesis);
 
         void ToCppValid(std::string& input);
-        void ReplaceAll(std::string& input, const std::string& search, char replace);
+        const std::string& ToCppValid(const std::string& input);
+        void ReplaceAll(std::string& input, const std::string& search, const std::string& replace);
+        const std::string& ReplaceAll(const std::string& input, const std::string& search, const std::string& replace);
         size_t RemoveWhitespace(std::string& input);
         size_t RemoveWhitespace(std::string& input, std::string::iterator start,std::string::iterator end);
         void TrimWhiteSpaceBeforeAfter(std::string& input);

--- a/analyzer/rootana/src/main.cpp
+++ b/analyzer/rootana/src/main.cpp
@@ -193,17 +193,19 @@ void ClearGlobalData(TGlobalData* data)
   // own the pulses, they would be deleted later. A solution is to
   // be sure that TGlobalData isn't called in alcapana, or ensure
   // that g_event owns the pulse islands at that level.  
-  StringPulseIslandMap::iterator mapIter;
-  StringPulseIslandMap::iterator mapEnd = data->fPulseIslandToChannelMap.end();
-  for(mapIter = data->fPulseIslandToChannelMap.begin(); mapIter != mapEnd; mapIter++) {
-    // The iterator is pointing to a pair<string, vector<TPulseIsland*> >
-    std::vector<TPulseIsland*>& pulse_vector= mapIter->second;
-    for(size_t i=0; i<pulse_vector.size(); i++){
-      delete pulse_vector[i];
-      pulse_vector[i] = NULL;
-    }
-    pulse_vector.clear();
-  }
+//
+//---  LoopSequence::Process now takes care of this part by invoking TGlobalData::Clear
+//  StringPulseIslandMap::iterator mapIter;
+//  StringPulseIslandMap::iterator mapEnd = data->fPulseIslandToChannelMap.end();
+//  for(mapIter = data->fPulseIslandToChannelMap.begin(); mapIter != mapEnd; mapIter++) {
+//    // The iterator is pointing to a pair<string, vector<TPulseIsland*> >
+//    std::vector<TPulseIsland*>& pulse_vector= mapIter->second;
+//    for(size_t i=0; i<pulse_vector.size(); i++){
+//      delete pulse_vector[i];
+//      pulse_vector[i] = NULL;
+//    }
+//    pulse_vector.clear();
+//  }
 
 
   for(SourceAnalPulseMap::iterator mapIter=gAnalysedPulseMap.begin();

--- a/analyzer/rootana/src/main.cpp
+++ b/analyzer/rootana/src/main.cpp
@@ -178,7 +178,7 @@ Int_t Main_event_loop(TTree* dataTree,ARGUMENTS& arguments)
   }
   
   enav.MakeLoopSequence(arguments).Run();
-  std::cout << "Finished processing data normally" << std::endl;
+  std::cout << "Finished processing data" << std::endl;
   return 0;
 }
 

--- a/analyzer/rootana/src/main.cpp
+++ b/analyzer/rootana/src/main.cpp
@@ -64,9 +64,9 @@ TTree* GetTree(TFile* inFile, const char* t_name);
 Int_t PrepareAnalysedPulseMap(TFile* fileOut);
 Int_t PrepareSingletonObjects(const ARGUMENTS&);
 
-TAnalysedPulseMapWrapper *gAnalysedPulseMapWrapper=NULL;
-TTree *gAnalysedPulseTree = NULL;
-TBranch *gAnalysedPulseBranch = NULL;
+//TAnalysedPulseMapWrapper *gAnalysedPulseMapWrapper=NULL;
+//TTree *gAnalysedPulseTree = NULL;
+//TBranch *gAnalysedPulseBranch = NULL;
 
 SourceAnalPulseMap gAnalysedPulseMap;
 SourceDetPulseMap gDetectorPulseMap;
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
   
   // and finish up
   fileOut->cd();
-  gAnalysedPulseTree->Write();
+  //gAnalysedPulseTree->Write();
   fileOut->Write();
   fileOut->Close();
   navi.Close();
@@ -265,7 +265,7 @@ void PrintSetupData(TSetupData* s_data)
 Int_t PrepareAnalysedPulseMap(TFile* fileOut)
 {
   // TAnalysedMapWrapper
-  gAnalysedPulseMapWrapper = new TAnalysedPulseMapWrapper(gAnalysedPulseMap);
+  //gAnalysedPulseMapWrapper = new TAnalysedPulseMapWrapper(gAnalysedPulseMap);
   
   int split = 1;
   int bufsize = 64000;
@@ -274,14 +274,14 @@ Int_t PrepareAnalysedPulseMap(TFile* fileOut)
   if (split < 0) {branchstyle = 0; split = -1-split;}
   TTree::SetBranchStyle(branchstyle);
   
-  gAnalysedPulseTree = new TTree("AnalysedPulseTree", "AnalysedPulseTree");
-  gAnalysedPulseTree->SetAutoSave(100000000);
-  gAnalysedPulseTree->SetMaxVirtualSize(100000000);
-  gAnalysedPulseBranch = gAnalysedPulseTree->Branch("AnalysedPulseMapWrapper", 
-                                                    "TAnalysedPulseMapWrapper",
-                                                    &gAnalysedPulseMapWrapper,
-                                                    bufsize, split);
-  gAnalysedPulseBranch->SetAutoDelete(kFALSE);
+  //gAnalysedPulseTree = new TTree("AnalysedPulseTree", "AnalysedPulseTree");
+  //gAnalysedPulseTree->SetAutoSave(100000000);
+  //gAnalysedPulseTree->SetMaxVirtualSize(100000000);
+  //gAnalysedPulseBranch = gAnalysedPulseTree->Branch("AnalysedPulseMapWrapper", 
+  //                                                  "TAnalysedPulseMapWrapper",
+  //                                                  &gAnalysedPulseMapWrapper,
+  //                                                  bufsize, split);
+  //gAnalysedPulseBranch->SetAutoDelete(kFALSE);
   return 0;
 }
 

--- a/analyzer/rootana/src/plotters/ExportPulse.cpp
+++ b/analyzer/rootana/src/plotters/ExportPulse.cpp
@@ -28,20 +28,6 @@ using std::string;
 extern Long64_t* gTotalEntries;
 
 //----------------------------------------------------------------------
-static bool isNonCpp(char c){ 
-  bool retVal=false;
-  switch(c){
-  case '-': case '/':
-    retVal=true;
-    break;
-  default:
-    retVal=false;
-  }
-  return retVal;
-}
-
-
-//----------------------------------------------------------------------
 ExportPulse::ExportPulse(modules::options* opts)
   : BaseModule("ExportPulse",opts),fGuidanceShown(false)
   , fSetup(NULL), fOptions(opts)
@@ -212,14 +198,13 @@ int ExportPulse::DrawTPIs(){
 //----------------------------------------------------------------------
 std::string ExportPulse::PulseInfo_t::MakeTPIName()const{
   std::stringstream histname;
-  histname << "Pulse_" << bankname;
-  histname << "_" << detname;
+  histname << "Pulse_" << detname;
   histname << "_" << event;
   histname << "_" << pulseID;
   std::string hist=histname.str();
   // replace all non c++ characters with underscore so we can use the
   // histograms in root directly.
-  std::replace_if(hist.begin(),hist.end(), isNonCpp, '_');
+  modules::parser::ToCppValid(hist);
   return hist;
 }
 

--- a/analyzer/rootana/src/plotters/PlotAmplitude.cpp
+++ b/analyzer/rootana/src/plotters/PlotAmplitude.cpp
@@ -10,7 +10,7 @@
 #include <cmath>
 
 #include "TAnalysedPulse.h"
-#include "TDetectorPulse.h"
+//#include "TDetectorPulse.h"
 #include "RegisterModule.inc"
 #include "definitions.h"
 #include "SetupNavigator.h"

--- a/analyzer/rootana/src/plotters/PlotIntegral.cpp
+++ b/analyzer/rootana/src/plotters/PlotIntegral.cpp
@@ -1,0 +1,85 @@
+#include "PlotIntegral.h"
+#include "RegisterModule.inc"
+#include "TGlobalData.h"
+#include "TSetupData.h"
+#include "ModulesOptions.h"
+#include "ModulesParser.h"
+#include "definitions.h"
+#include "TAnalysedPulse.h"
+#include "IdSource.h"
+
+#include <TH1F.h>
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+extern SourceAnalPulseMap gAnalysedPulseMap;
+
+PlotIntegral::PlotIntegral(modules::options* opts):
+   BaseModule("PlotIntegral",opts){
+}
+
+PlotIntegral::~PlotIntegral(){
+}
+
+int PlotIntegral::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
+    // For each source,
+    TH1F* hist=NULL;
+    std::string name, title;
+    const IDs::source* source=NULL;
+    for(SourceAnalPulseMap::const_iterator i_source = gAnalysedPulseMap.begin();
+            i_source!=gAnalysedPulseMap.end(); ++i_source){
+        source=&i_source->first;
+
+        // setup the name and title for the histogram
+        name="h"+modules::parser::ToCppValid(source->str())+"_integrals";
+        title="Integral of pulses coming from "+source->str();
+
+        // make a histogram
+        hist=new TH1F(name.c_str(),title.c_str(),300,0,-1);
+        hist->SetXTitle("Integral of each pulse (arb. units)");
+
+        // register histogram with list
+        fPlots[*source]=hist;
+    }
+  return 0;
+}
+
+int PlotIntegral::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+
+    PlotList_t::iterator i_plot;
+    const AnalysedPulseList* pulseList;
+    const IDs::source* source;
+    for(SourceAnalPulseMap::const_iterator i_source = gAnalysedPulseMap.begin();
+            i_source!=gAnalysedPulseMap.end(); ++i_source){
+        source=&i_source->first;
+        pulseList=&i_source->second;
+
+        // Find the corresponding histogram
+        i_plot=fPlots.find(*source);
+        if(i_plot==fPlots.end()){
+            cout<<"PlotIntegral: Error: Unable to find plot for source '"<<*source<<"'"<<endl;
+            return 1;
+        }
+
+        // For each TAP 
+        for(AnalysedPulseList::const_iterator i_pulse=pulseList->begin();
+                i_pulse!=pulseList->end();++i_pulse){
+            // Fill integral histogram
+            i_plot->second->Fill((*i_pulse)->GetIntegral());
+        }
+    }
+
+  return 0;
+}
+
+int PlotIntegral::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
+    for(PlotList_t::iterator i_plot=fPlots.begin();
+            i_plot!=fPlots.end(); ++i_plot){
+        i_plot->second->Draw();
+    }
+  return 0;
+}
+
+ALCAP_REGISTER_MODULE(PlotIntegral);

--- a/analyzer/rootana/src/plotters/PlotIntegral.h
+++ b/analyzer/rootana/src/plotters/PlotIntegral.h
@@ -1,0 +1,63 @@
+#ifndef PLOTINTEGRALS_H_
+#define PLOTINTEGRALS_H_
+
+#include "BaseModule.h"
+#include <map>
+class TGlobalData;
+class TSetupData;
+class TH1F;
+namespace modules {class options;}
+namespace IDs {class source;}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \ingroup rootana_modules
+/// \author AuthorName
+///
+/// \brief
+/// A one line description of what your module does.
+///
+/// \details
+/// A longer, more descriptive block of text.
+/// Specifics like members and methods will be described later.
+/// You can add this to other groups instead of rootana_modules or in addition
+/// to rootana_modules by adding more of the ingroup tags.
+////////////////////////////////////////////////////////////////////////////////
+class PlotIntegral : public BaseModule {
+
+    public:
+        /// \brief
+        /// Constructor description. If necessary, add a details tag like above.
+        ///
+        /// \param[in] opts Describe the options this module takes.
+        PlotIntegral(modules::options* opts);
+        /// \brief
+        /// Is anything done in the destructor?
+        ~PlotIntegral();
+
+    private:
+        /// \brief
+        /// What's calculated for every entry?
+        /// Don't hesitate to repeat what was said in the class description.
+        /// 
+        /// \return Non-zero to indicate a problem.
+        virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
+        /// \brief
+        /// What needes to be done before each run?
+        /// Don't hesitate to repeat what was said in the class description.
+        ///
+        /// \return Non-zero to indicate a problem.
+        virtual int BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup);
+        /// \brief
+        /// What needs to be done after each run?
+        /// Don't hesitate to repeat what was said in the class description.
+        ///
+        /// \return Non-zero to indicate a problem.
+        virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
+
+    private:
+        typedef std::map<IDs::source,TH1F*> PlotList_t;
+        PlotList_t fPlots;
+
+};
+
+#endif //PLOTINTEGRALS_H_

--- a/analyzer/rootana/src/plotters/PlotTDPs.cpp
+++ b/analyzer/rootana/src/plotters/PlotTDPs.cpp
@@ -98,7 +98,7 @@ int PlotTDPs::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
         // Histogram amplitudes for fast pulses with a slow pulse cut
         full_title.str("");
         full_title<<"Amplitudes of fast pulses for slow pulses with amplitudes above ";
-        full_title<<fFastCut;
+        full_title<<fFastCut<<title;
         tmp.slow_amps_fast_cut=new TH1F((name+"_slow_amp_fast_cut").c_str(),
                 full_title.str().c_str(), 200,0,-1);
         tmp.slow_amps_fast_cut->SetBit(TH1::kCanRebin);
@@ -107,14 +107,27 @@ int PlotTDPs::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
         // Histogram amplitudes for slow pulses with a fast pulse cut
         full_title.str("");
         full_title<<"Amplitudes of slow pulses for fast pulses with amplitudes above ";
-        full_title<<fSlowCut;
+        full_title<<fSlowCut<<title;
         tmp.fast_amps_slow_cut=new TH1F((name+"_fast_amps_slow_cut").c_str(),
                 full_title.str().c_str(), 200,0,-1);
         tmp.fast_amps_slow_cut->SetBit(TH1::kCanRebin);
         tmp.fast_amps_slow_cut->SetXTitle("Amplitude in Fast channel");
 
         // Make a histogram of the time difference between pulses
-        tmp.time_diff=NULL;
+        full_title.str("Time difference vs. fast amplitude for pulses ");
+        full_title<<title;
+        tmp.time_diff_fast=new TH2F((name+"_fast_amp_tdiff").c_str(),full_title.str().c_str(),200,0,-1,200,0,-1);
+        tmp.time_diff_fast->SetBit(TH1::kCanRebin);
+        tmp.time_diff_fast->SetXTitle("t_{Fast} - t_{Slow}");
+        tmp.time_diff_fast->SetYTitle("Amplitude in Fast channel");
+
+        full_title.str("Time difference vs. slow amplitude for pulses ");
+        full_title<<title;
+        tmp.time_diff_slow=new TH2F((name+"_slow_amp_tdiff").c_str(),full_title.str().c_str(),200,0,-1,200,0,-1);
+        tmp.time_diff_slow->SetBit(TH1::kCanRebin);
+        tmp.time_diff_slow->SetXTitle("t_{Fast} - t_{Slow}");
+        tmp.time_diff_slow->SetYTitle("Amplitude in Slow channel");
+
 
         // Add tmp to the list of TDPs to draw
         fPlotsList[i_source->first]=tmp;
@@ -130,7 +143,8 @@ int PlotTDPs::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
     // For each TDP source of interest (defined in BeforeFirstEntry)
     const DetectorPulseList* pulseList;
     SourceDetPulseMap::const_iterator i_pulse_list;
-    double fast_amp, slow_amp;
+    double fast_amp, slow_amp, fast_time, slow_time;
+    Detector_t plots;
     for(PlotsList_t::iterator i_source=fPlotsList.begin();
             i_source!=fPlotsList.end(); ++i_source){
         // Get the desired pulse list
@@ -140,6 +154,7 @@ int PlotTDPs::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
             return 1;
         }
         pulseList=&i_pulse_list->second;
+        plots=i_source->second;
 
         // Loop over the pulse list
         for(DetectorPulseList::const_iterator i_pulse=pulseList->begin();
@@ -148,24 +163,28 @@ int PlotTDPs::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
             // get the amplitudes for each pulse
             fast_amp=(*i_pulse)->GetAmplitude(TDetectorPulse::kFast);
             slow_amp=(*i_pulse)->GetAmplitude(TDetectorPulse::kSlow);
+            fast_time=(*i_pulse)->GetTime(TDetectorPulse::kFast);
+            slow_time=(*i_pulse)->GetTime(TDetectorPulse::kSlow);
 
             // If one of the channels is the default value then fill the
             // histogram for channels that weren't matched
             if(fast_amp==definitions::DefaultValue){
-                i_source->second.slow_only_amps->Fill(slow_amp);
+                plots.slow_only_amps->Fill(slow_amp);
             }else if(slow_amp==definitions::DefaultValue){
-                i_source->second.fast_only_amps->Fill(fast_amp);
+                plots.fast_only_amps->Fill(fast_amp);
             }else {
                 // Both channels saw hits, fill the 2d plot
-                i_source->second.amplitudes->Fill(fast_amp ,slow_amp);
+                plots.amplitudes->Fill(fast_amp ,slow_amp);
+                plots.time_diff_fast->Fill(fast_amp ,slow_time - fast_time);
+                plots.time_diff_slow->Fill(slow_amp ,slow_time - fast_time);
             }
 
             // Fill the cut histograms
             if(fast_amp> fFastCut && slow_amp!=definitions::DefaultValue){
-                i_source->second.slow_amps_fast_cut->Fill(slow_amp);
+                plots.slow_amps_fast_cut->Fill(slow_amp);
             }
             if(slow_amp> fSlowCut && fast_amp!=definitions::DefaultValue){
-                i_source->second.fast_amps_slow_cut->Fill(fast_amp);
+                plots.fast_amps_slow_cut->Fill(fast_amp);
             }
 
             // Fill histogram of the time difference between pulses
@@ -184,6 +203,8 @@ int PlotTDPs::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
         i_source->second.fast_only_amps->Draw();
         i_source->second.fast_amps_slow_cut->Draw();
         i_source->second.slow_amps_fast_cut->Draw();
+        i_source->second.time_diff_fast->Draw();
+        i_source->second.time_diff_slow->Draw();
     }
 
   return 0;

--- a/analyzer/rootana/src/plotters/PlotTDPs.h
+++ b/analyzer/rootana/src/plotters/PlotTDPs.h
@@ -71,6 +71,7 @@ class PlotTDPs : public BaseModule {
     private:
         PlotsList_t fPlotsList;
         double fFastCut, fSlowCut;
+        bool fCutHists;
 };
 
 #endif //PLOTTDPS_H_

--- a/analyzer/rootana/src/plotters/PlotTDPs.h
+++ b/analyzer/rootana/src/plotters/PlotTDPs.h
@@ -25,10 +25,10 @@ namespace IDs {class source;}
 class PlotTDPs : public BaseModule {
     public:     
         struct Detector_t {
-            TH2F* amplitudes;
-            TH1F* fast_only_amps, *slow_only_amps;
-            TH1F* fast_amps_slow_cut, *slow_amps_fast_cut;
-            TH1F* time_diff;
+            TH2F *amplitudes;
+            TH1F *fast_only_amps, *slow_only_amps;
+            TH1F *fast_amps_slow_cut, *slow_amps_fast_cut;
+            TH2F *time_diff_fast, *time_diff_slow;
         };
         typedef std::map<IDs::source,Detector_t> PlotsList_t;
 

--- a/analyzer/rootana/src/plotters/PulseViewer.cpp
+++ b/analyzer/rootana/src/plotters/PulseViewer.cpp
@@ -10,6 +10,7 @@
 #include "IdSource.h"
 #include "EventNavigator.h"
 
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
 using std::cout;
@@ -139,7 +140,14 @@ int PulseViewer::SetTriggerValue(const std::string& parameter){
 int PulseViewer::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
 
     // Get the TAPs for this channel
-  AnalysedPulseList* allTAPs=&gAnalysedPulseMap[GetSource()];
+    AnalysedPulseList* allTAPs=NULL;
+    for(SourceAnalPulseMap::iterator i_source=gAnalysedPulseMap.begin();
+            i_source!=gAnalysedPulseMap.end(); ++i_source){
+        if(i_source->first.matches(GetSource())){
+            allTAPs=&i_source->second;
+            break;
+        }
+    }
 
     if(!allTAPs){
        cout<<"Problem getting TAP list for "<<GetSource()<<endl;

--- a/analyzer/rootana/src/testModule.txt
+++ b/analyzer/rootana/src/testModule.txt
@@ -31,12 +31,14 @@
 # Using aliases means we can have multiple instance of a module
 [ MODULES ]
 # Format is alias = ModuleClass
+#load_pulses = LoadPulses
 analyse_pulses = MakeAnalysedPulses 
 detector_pulses = MakeDetectorPulses
 muon_events = MakeMuonEvents
 pv_one=PulseViewer(SiR2-S , amplitude> 100 , true)
 pv_two=PulseViewer(SiR2-F , TPI_length> 155 , true)
 draw_pulses = ExportPulse
+save_pulses=SavePulses
 #### end of modules list ######
 
 ####### begin of module specific options ######
@@ -59,6 +61,17 @@ SiR2-S=MaxBin
 # then put them in brackets and comma separated like a c-style constructor
 SiR2-F=MaxBin
 #SiR2-F+=PeakFitter(0.5,0.3)
+
+[ save_pulses ]
+# This module takes no options.  It creates a tree with all TAPs contained in
+# it which can later be read back in with the LoadPulses module
+
+[ load_pulses ]
+# Loads in TAPs from a file created previously with SavePulses.  Specify the
+# file with the file_name option.
+# This modules should not be used at the same time as MakeAnalysedPulses and
+# should be one of the first modules in the list
+file_name= input.root
 
 [ detector_pulses] 
 


### PR DESCRIPTION
[ I thought I'd opened this this morning, but it seems I opened the pull request to the old repository on Nam's account]

I've added two new modules to rootana which save and load TAPs to a tree.
These should be seen as temporary kludges so we can do this without the event navigator.

The work is done by transferring the TAPs stored in gAnalysedPulseMap into a set of TClonesArrays. I'm not sure therefore how this will handle specialised TAPs therefore, but when the use case arises we can always tweak things.

@litchfld , I made some tweaks to the event navigator itself so I would like your blessing to merge this in first.  The changes were:
- TGlobalData was being cleared directly in LoopSequence::Process and in `ClearGlobalData`.  I've taken it out ClearGlobalData now.  Im nervous this could cause new memory leaks, but I think in principle it's safe.
- The Preprocess, Process and Postprocess methods only checked the return codes of the module's methods after passing over each module.  I've changed it so it checks it for each module, which I think is the more natural behaviour.

The branches made from SavePulses can be used interactively so we can do simple analysis with TTree::Draw from now on.  More complex stuff can then load the pulses back into the framework with the LoadPulses module.
