### PR TITLE
Feature/ae add pulse candidate finder to generator

### DIFF
--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
@@ -5,6 +5,8 @@
 #include "SetupNavigator.h"
 #include "EventNavigator.h"
 #include "ExportPulse.h"
+#include "ModulesParser.h"
+#include "debug_tools.h"
 
 #include <iostream>
 #include <cmath>
@@ -17,98 +19,115 @@ FirstCompleteAPGenerator::FirstCompleteAPGenerator(TAPGeneratorOptions* opts):
     TVAnalysedPulseGenerator("FirstComplete",opts), fOpts(opts){
         // Do things to set up the generator here. 
 
+    // Create a PulseCandidateFinder
+    fPulseCandidateFinder = new PulseCandidateFinder(GetChannel().str(), fOpts);
+
     }
+
+FirstCompleteAPGenerator::~FirstCompleteAPGenerator(){
+    // delete all sub-pulses
+    for(PulseIslandList::iterator i_tpi=fSubPulses.begin(); i_tpi!=fSubPulses.end(); ++i_tpi){ 
+        delete *i_tpi;
+    }
+}
 
 int FirstCompleteAPGenerator::ProcessPulses( 
         const PulseIslandList& pulseList,
         AnalysedPulseList& analysedList){
-    // Do something here that takes the TPIs in the PulseIslandList and
-    // fills the list of TAPS
-
-    // Create a PulseCandidateFinder
-    fPulseCandidateFinder = new PulseCandidateFinder(GetChannel().str(), fOpts);
 
     // The variables that this generator will be filling
     double amplitude, time, integral;
 
+
     // Get the relevant TSetupData/SetupNavigator variables for the algorithms
     std::string bankname = pulseList[0]->GetBankName();
 
-    fMaxBinAmplitude.pedestal = fConstantFractionTime.pedestal = fSimpleIntegral.pedestal = SetupNavigator::Instance()->GetPedestal(bankname);
-    fMaxBinAmplitude.trigger_polarity = fConstantFractionTime.trigger_polarity = fSimpleIntegral.trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+    fMaxBinAmplitude.pedestal 
+        = fConstantFractionTime.pedestal 
+        = fSimpleIntegral.pedestal 
+        = SetupNavigator::Instance()->GetPedestal(bankname);
+    fMaxBinAmplitude.trigger_polarity 
+        = fConstantFractionTime.trigger_polarity 
+        = fSimpleIntegral.trigger_polarity 
+        = TSetupData::Instance()->GetTriggerPolarity(bankname);
     fConstantFractionTime.max_adc_value = std::pow(2, TSetupData::Instance()->GetNBits(bankname)) - 1;
     fConstantFractionTime.clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
     fConstantFractionTime.time_shift = TSetupData::Instance()->GetTimeShift(bankname);
 
     TAnalysedPulse* tap;
-    // Loop over all the TPIs given to us
-    for (PulseIslandList::const_iterator tpi=pulseList.begin();
-            tpi!=pulseList.end(); tpi++){
+     // Loop over all the TPIs given to us
+    for (PulseIslandList::const_iterator original_tpi=pulseList.begin();
+            original_tpi!=pulseList.end(); original_tpi++){
 
         // Look for more than one pulse on the TPI
-        fPulseCandidateFinder->FindPulseCandidates(*tpi);
+        fPulseCandidateFinder->FindPulseCandidates(*original_tpi);
         int n_pulse_candidates = fPulseCandidateFinder->GetNPulseCandidates();
-        std::cout << "FirstCompleteAPGenerator: " << GetChannel().str() << ": n_pulse_candidates = " << n_pulse_candidates  << std::endl;
+        fPulseCandidateFinder->GetPulseCandidates(fSubPulses);
 
-        const std::vector<int>& pulse_samples = (*tpi)->GetSamples();
-        int n_pulse_samples = pulse_samples.size();
-        int pulse_timestamp = (*tpi)->GetTimeStamp();
+        //if(Debug())
+        //std::cout << "FirstCompleteAPGenerator: " << GetChannel().str() 
+        //    << ": n_pulse_candidates = " << n_pulse_candidates  << std::endl;
 
-        if (Debug() && n_pulse_candidates > 1 && GetChannel().str() != "muSc" && GetChannel().str() != "muScA" && GetChannel().str() != "ScL"
-                && GetChannel().str() != "ScR" && GetChannel().str() != "ScGe" && GetChannel().str() != "ScVe") {
-            ExportPulse::Instance()->AddToExportList(GetChannel().str(), tpi-pulseList.begin());
-
-            const std::vector<TPulseIsland*>& sub_pulses = fPulseCandidateFinder->GetPulseCandidates();
-            for (std::vector<TPulseIsland*>::const_iterator subPulseIter = sub_pulses.begin(); subPulseIter != sub_pulses.end(); ++subPulseIter) {
-                std::stringstream histname;
-                histname << "hSubPulse_" << GetChannel().str() << "_Event" << EventNavigator::Instance().EntryNo() <<"_Pulse" << tpi-pulseList.begin() << "_SubPulse" << subPulseIter - sub_pulses.begin();
-
-                const std::vector<int>& sub_pulse_samples = (*subPulseIter)->GetSamples();
-                int n_sub_pulse_samples = sub_pulse_samples.size();
-
-                TH1D* hPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), n_pulse_samples,0,n_pulse_samples);
-                hPulse->SetLineColor(kMagenta);
-
-                int delay = (*subPulseIter)->GetTimeStamp() - pulse_timestamp;
-                for (std::vector<int>::const_iterator subPulseSampleIter = sub_pulse_samples.begin(); subPulseSampleIter != sub_pulse_samples.end(); ++subPulseSampleIter) {
-                    hPulse->Fill( (subPulseSampleIter - sub_pulse_samples.begin()) + delay, (*subPulseSampleIter) );
-                }
-            }
+        if (Debug() && n_pulse_candidates > 10
+                && GetChannel().str() != "muSc" && GetChannel().str() != "muScA"
+                && GetChannel().str() != "ScL" && GetChannel().str() != "ScR"
+                && GetChannel().str() != "ScGe" && GetChannel().str() != "ScVe") {
+            DrawPulse(original_tpi-pulseList.begin(),
+                    (*original_tpi)->GetTimeStamp(),
+                    (*original_tpi)->GetPulseLength());
         }
 
-        // Analyse each TPI
-        amplitude=fMaxBinAmplitude(*tpi);
-        time=fConstantFractionTime(*tpi);
-        integral=fSimpleIntegral(*tpi);
+        for(PulseIslandList::const_iterator i_tpi=fSubPulses.begin(); i_tpi!=fSubPulses.end(); ++i_tpi){
+            if((*i_tpi)->GetSamples().empty()) continue;
 
-        // Now that we've found the information we were looking for make a TAP to
-        // hold it.  This method makes a TAP and sets the parent TPI info.  It needs
-        // the index of the parent TPI in the container as an argument
-        tap = MakeNewTAP(tpi-pulseList.begin());
-        tap->SetAmplitude(amplitude);
-        tap->SetTime(time);
-        tap->SetIntegral(integral);
+            // Analyse each TPI
+            amplitude=fMaxBinAmplitude(*i_tpi);
+            time=fConstantFractionTime(*i_tpi);
+            integral=fSimpleIntegral(*i_tpi);
 
-        // Finally add the new TAP to the output list
-        analysedList.push_back(tap);
-    }
+            // Now that we've found the information we were looking for make a TAP to
+            // hold it.  This method makes a TAP and sets the parent TPI info.  It needs
+            // the index of the parent TPI in the container as an argument
+            tap = MakeNewTAP(original_tpi-pulseList.begin());
+            tap->SetAmplitude(amplitude);
+            tap->SetTime(time);
+            tap->SetIntegral(integral);
 
-    // Generators have a Debug method similar to modules
-    if(Debug()){
-        // They also have a unique ID, retrievable by GetSource and
-        // a GetChannel method to get the ID of just the channel
-        cout<<"Now running source: "<<GetSource().str()<<" which looks for TAPs on "
-            "channel: "<<GetChannel().str()<<'\n';
-    }
+            // Finally add the new TAP to the output list
+            analysedList.push_back(tap);
 
-    // returning 0 tells the caller that we were successful, return non-zero if not
+        } // loop over all sub-pulses
+
+    } // loop over all original TPIs
+
     return 0;
 }
 
-// Similar to the modules, this macro registers the generator with
-// MakeAnalysedPulses. The first argument is compulsory and gives the name of
-// this generator. All subsequent arguments will be used as names for arguments
-// given directly within the modules file.  See the github wiki for more.
-//
-// NOTE: for TAP generators OMIT the APGenerator part of the class' name
+void FirstCompleteAPGenerator::DrawPulse(int original, int pulse_timestamp, int n_pulse_samples){
+
+    if( ExportPulse::Instance())
+        ExportPulse::Instance()->AddToExportList(GetChannel().str(), original);
+    else return;
+
+    for (std::vector<TPulseIsland*>::const_iterator subPulseIter = fSubPulses.begin();
+            subPulseIter != fSubPulses.end(); ++subPulseIter) {
+        std::stringstream histname;
+        histname << "hSubPulse_" << GetChannel() << "_Event" 
+            << EventNavigator::Instance().EntryNo() <<"_Pulse" << original
+            << "_SubPulse" << subPulseIter - fSubPulses.begin();
+
+        const std::vector<int>& sub_pulse_samples = (*subPulseIter)->GetSamples();
+
+        TH1D* hPulse = new TH1D(modules::parser::ToCppValid(histname.str()).c_str(),
+                histname.str().c_str(), n_pulse_samples,0,n_pulse_samples);
+        hPulse->SetLineColor(kMagenta);
+
+        int delay = (*subPulseIter)->GetTimeStamp() - pulse_timestamp;
+        for (std::vector<int>::const_iterator subPulseSampleIter = sub_pulse_samples.begin();
+                subPulseSampleIter != sub_pulse_samples.end(); ++subPulseSampleIter) {
+            hPulse->Fill( (subPulseSampleIter - sub_pulse_samples.begin()) + delay, (*subPulseSampleIter) );
+        }
+    }
+}
+
 ALCAP_TAP_GENERATOR(FirstComplete);

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
@@ -3,6 +3,7 @@
 #include "TPulseIsland.h"
 #include "TAnalysedPulse.h"
 #include "SetupNavigator.h"
+#include "EventNavigator.h"
 #include "ExportPulse.h"
 
 #include <iostream>
@@ -53,13 +54,13 @@ int FirstCompleteAPGenerator::ProcessPulses(
     int n_pulse_samples = pulse_samples.size();
     int pulse_timestamp = (*tpi)->GetTimeStamp();
 
-    if (Debug() && n_pulse_candidates > 1 ) {
+    if (Debug() && n_pulse_candidates == 1 ) {
       ExportPulse::Instance()->AddToExportList(GetChannel().str(), tpi-pulseList.begin());
 
       const std::vector<TPulseIsland*>& sub_pulses = fPulseCandidateFinder->GetPulseCandidates();
       for (std::vector<TPulseIsland*>::const_iterator subPulseIter = sub_pulses.begin(); subPulseIter != sub_pulses.end(); ++subPulseIter) {
 	std::stringstream histname;
-	histname << "hSubPulse_" << GetChannel().str() << "_Pulse" << tpi-pulseList.begin() << "_SubPulse" << subPulseIter - sub_pulses.begin();
+	histname << "hSubPulse_" << GetChannel().str() << "_Event" << EventNavigator::Instance().EntryNo() <<"_Pulse" << tpi-pulseList.begin() << "_SubPulse" << subPulseIter - sub_pulses.begin();
 
 	const std::vector<int>& sub_pulse_samples = (*subPulseIter)->GetSamples();
 	int n_sub_pulse_samples = sub_pulse_samples.size();

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
@@ -14,95 +14,95 @@ using std::cout;
 using std::endl;
 
 FirstCompleteAPGenerator::FirstCompleteAPGenerator(TAPGeneratorOptions* opts):
-  TVAnalysedPulseGenerator("FirstComplete",opts), fOpts(opts){
-	// Do things to set up the generator here. 
+    TVAnalysedPulseGenerator("FirstComplete",opts), fOpts(opts){
+        // Do things to set up the generator here. 
 
-}
+    }
 
 int FirstCompleteAPGenerator::ProcessPulses( 
-		const PulseIslandList& pulseList,
-		AnalysedPulseList& analysedList){
+        const PulseIslandList& pulseList,
+        AnalysedPulseList& analysedList){
     // Do something here that takes the TPIs in the PulseIslandList and
     // fills the list of TAPS
 
-  // Create a PulseCandidateFinder
-  fPulseCandidateFinder = new PulseCandidateFinder(GetChannel().str(), fOpts);
+    // Create a PulseCandidateFinder
+    fPulseCandidateFinder = new PulseCandidateFinder(GetChannel().str(), fOpts);
 
-  // The variables that this generator will be filling
-  double amplitude, time, integral;
+    // The variables that this generator will be filling
+    double amplitude, time, integral;
 
-  // Get the relevant TSetupData/SetupNavigator variables for the algorithms
-  std::string bankname = pulseList[0]->GetBankName();
+    // Get the relevant TSetupData/SetupNavigator variables for the algorithms
+    std::string bankname = pulseList[0]->GetBankName();
 
-  fMaxBinAmplitude.pedestal = fConstantFractionTime.pedestal = fSimpleIntegral.pedestal = SetupNavigator::Instance()->GetPedestal(bankname);
-  fMaxBinAmplitude.trigger_polarity = fConstantFractionTime.trigger_polarity = fSimpleIntegral.trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
-  fConstantFractionTime.max_adc_value = std::pow(2, TSetupData::Instance()->GetNBits(bankname)) - 1;
-  fConstantFractionTime.clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
-  fConstantFractionTime.time_shift = TSetupData::Instance()->GetTimeShift(bankname);
+    fMaxBinAmplitude.pedestal = fConstantFractionTime.pedestal = fSimpleIntegral.pedestal = SetupNavigator::Instance()->GetPedestal(bankname);
+    fMaxBinAmplitude.trigger_polarity = fConstantFractionTime.trigger_polarity = fSimpleIntegral.trigger_polarity = TSetupData::Instance()->GetTriggerPolarity(bankname);
+    fConstantFractionTime.max_adc_value = std::pow(2, TSetupData::Instance()->GetNBits(bankname)) - 1;
+    fConstantFractionTime.clock_tick_in_ns = TSetupData::Instance()->GetClockTick(bankname);
+    fConstantFractionTime.time_shift = TSetupData::Instance()->GetTimeShift(bankname);
 
-  TAnalysedPulse* tap;
-  // Loop over all the TPIs given to us
-  for (PulseIslandList::const_iterator tpi=pulseList.begin();
-       tpi!=pulseList.end(); tpi++){
+    TAnalysedPulse* tap;
+    // Loop over all the TPIs given to us
+    for (PulseIslandList::const_iterator tpi=pulseList.begin();
+            tpi!=pulseList.end(); tpi++){
 
-    // Look for more than one pulse on the TPI
-    fPulseCandidateFinder->FindPulseCandidates(*tpi);
-    int n_pulse_candidates = fPulseCandidateFinder->GetNPulseCandidates();
-    std::cout << "FirstCompleteAPGenerator: " << GetChannel().str() << ": n_pulse_candidates = " << n_pulse_candidates  << std::endl;
+        // Look for more than one pulse on the TPI
+        fPulseCandidateFinder->FindPulseCandidates(*tpi);
+        int n_pulse_candidates = fPulseCandidateFinder->GetNPulseCandidates();
+        std::cout << "FirstCompleteAPGenerator: " << GetChannel().str() << ": n_pulse_candidates = " << n_pulse_candidates  << std::endl;
 
-    const std::vector<int>& pulse_samples = (*tpi)->GetSamples();
-    int n_pulse_samples = pulse_samples.size();
-    int pulse_timestamp = (*tpi)->GetTimeStamp();
+        const std::vector<int>& pulse_samples = (*tpi)->GetSamples();
+        int n_pulse_samples = pulse_samples.size();
+        int pulse_timestamp = (*tpi)->GetTimeStamp();
 
-    if (Debug() && n_pulse_candidates > 1 && GetChannel().str() != "muSc" && GetChannel().str() != "muScA" && GetChannel().str() != "ScL"
-	&& GetChannel().str() != "ScR" && GetChannel().str() != "ScGe" && GetChannel().str() != "ScVe") {
-      ExportPulse::Instance()->AddToExportList(GetChannel().str(), tpi-pulseList.begin());
+        if (Debug() && n_pulse_candidates > 1 && GetChannel().str() != "muSc" && GetChannel().str() != "muScA" && GetChannel().str() != "ScL"
+                && GetChannel().str() != "ScR" && GetChannel().str() != "ScGe" && GetChannel().str() != "ScVe") {
+            ExportPulse::Instance()->AddToExportList(GetChannel().str(), tpi-pulseList.begin());
 
-      const std::vector<TPulseIsland*>& sub_pulses = fPulseCandidateFinder->GetPulseCandidates();
-      for (std::vector<TPulseIsland*>::const_iterator subPulseIter = sub_pulses.begin(); subPulseIter != sub_pulses.end(); ++subPulseIter) {
-	std::stringstream histname;
-	histname << "hSubPulse_" << GetChannel().str() << "_Event" << EventNavigator::Instance().EntryNo() <<"_Pulse" << tpi-pulseList.begin() << "_SubPulse" << subPulseIter - sub_pulses.begin();
+            const std::vector<TPulseIsland*>& sub_pulses = fPulseCandidateFinder->GetPulseCandidates();
+            for (std::vector<TPulseIsland*>::const_iterator subPulseIter = sub_pulses.begin(); subPulseIter != sub_pulses.end(); ++subPulseIter) {
+                std::stringstream histname;
+                histname << "hSubPulse_" << GetChannel().str() << "_Event" << EventNavigator::Instance().EntryNo() <<"_Pulse" << tpi-pulseList.begin() << "_SubPulse" << subPulseIter - sub_pulses.begin();
 
-	const std::vector<int>& sub_pulse_samples = (*subPulseIter)->GetSamples();
-	int n_sub_pulse_samples = sub_pulse_samples.size();
+                const std::vector<int>& sub_pulse_samples = (*subPulseIter)->GetSamples();
+                int n_sub_pulse_samples = sub_pulse_samples.size();
 
-	TH1D* hPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), n_pulse_samples,0,n_pulse_samples);
-	hPulse->SetLineColor(kMagenta);
+                TH1D* hPulse = new TH1D(histname.str().c_str(), histname.str().c_str(), n_pulse_samples,0,n_pulse_samples);
+                hPulse->SetLineColor(kMagenta);
 
-	int delay = (*subPulseIter)->GetTimeStamp() - pulse_timestamp;
-	for (std::vector<int>::const_iterator subPulseSampleIter = sub_pulse_samples.begin(); subPulseSampleIter != sub_pulse_samples.end(); ++subPulseSampleIter) {
-	  hPulse->Fill( (subPulseSampleIter - sub_pulse_samples.begin()) + delay, (*subPulseSampleIter) );
-	}
-      }
+                int delay = (*subPulseIter)->GetTimeStamp() - pulse_timestamp;
+                for (std::vector<int>::const_iterator subPulseSampleIter = sub_pulse_samples.begin(); subPulseSampleIter != sub_pulse_samples.end(); ++subPulseSampleIter) {
+                    hPulse->Fill( (subPulseSampleIter - sub_pulse_samples.begin()) + delay, (*subPulseSampleIter) );
+                }
+            }
+        }
+
+        // Analyse each TPI
+        amplitude=fMaxBinAmplitude(*tpi);
+        time=fConstantFractionTime(*tpi);
+        integral=fSimpleIntegral(*tpi);
+
+        // Now that we've found the information we were looking for make a TAP to
+        // hold it.  This method makes a TAP and sets the parent TPI info.  It needs
+        // the index of the parent TPI in the container as an argument
+        tap = MakeNewTAP(tpi-pulseList.begin());
+        tap->SetAmplitude(amplitude);
+        tap->SetTime(time);
+        tap->SetIntegral(integral);
+
+        // Finally add the new TAP to the output list
+        analysedList.push_back(tap);
     }
 
-    // Analyse each TPI
-    amplitude=fMaxBinAmplitude(*tpi);
-    time=fConstantFractionTime(*tpi);
-    integral=fSimpleIntegral(*tpi);
+    // Generators have a Debug method similar to modules
+    if(Debug()){
+        // They also have a unique ID, retrievable by GetSource and
+        // a GetChannel method to get the ID of just the channel
+        cout<<"Now running source: "<<GetSource().str()<<" which looks for TAPs on "
+            "channel: "<<GetChannel().str()<<'\n';
+    }
 
-    // Now that we've found the information we were looking for make a TAP to
-    // hold it.  This method makes a TAP and sets the parent TPI info.  It needs
-    // the index of the parent TPI in the container as an argument
-    tap = MakeNewTAP(tpi-pulseList.begin());
-    tap->SetAmplitude(amplitude);
-    tap->SetTime(time);
-    tap->SetIntegral(integral);
-
-    // Finally add the new TAP to the output list
-    analysedList.push_back(tap);
-   }
-	
-	// Generators have a Debug method similar to modules
-	if(Debug()){
-    // They also have a unique ID, retrievable by GetSource and
-		// a GetChannel method to get the ID of just the channel
-    cout<<"Now running source: "<<GetSource().str()<<" which looks for TAPs on "
-        "channel: "<<GetChannel().str()<<'\n';
-	}
-
-	// returning 0 tells the caller that we were successful, return non-zero if not
-	return 0;
+    // returning 0 tells the caller that we were successful, return non-zero if not
+    return 0;
 }
 
 // Similar to the modules, this macro registers the generator with

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
@@ -59,7 +59,7 @@ int FirstCompleteAPGenerator::ProcessPulses(
       const std::vector<TPulseIsland*>& sub_pulses = fPulseCandidateFinder->GetPulseCandidates();
       for (std::vector<TPulseIsland*>::const_iterator subPulseIter = sub_pulses.begin(); subPulseIter != sub_pulses.end(); ++subPulseIter) {
 	std::stringstream histname;
-	histname << "hSubPulse_ " << GetChannel().str() << "_Pulse" << tpi-pulseList.begin() << "_SubPulse" << subPulseIter - sub_pulses.begin();
+	histname << "hSubPulse_" << GetChannel().str() << "_Pulse" << tpi-pulseList.begin() << "_SubPulse" << subPulseIter - sub_pulses.begin();
 
 	const std::vector<int>& sub_pulse_samples = (*subPulseIter)->GetSamples();
 	int n_sub_pulse_samples = sub_pulse_samples.size();

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
@@ -54,7 +54,8 @@ int FirstCompleteAPGenerator::ProcessPulses(
     int n_pulse_samples = pulse_samples.size();
     int pulse_timestamp = (*tpi)->GetTimeStamp();
 
-    if (Debug() && n_pulse_candidates == 1 ) {
+    if (Debug() && n_pulse_candidates > 1 && GetChannel().str() != "muSc" && GetChannel().str() != "muScA" && GetChannel().str() != "ScL"
+	&& GetChannel().str() != "ScR" && GetChannel().str() != "ScGe" && GetChannel().str() != "ScVe") {
       ExportPulse::Instance()->AddToExportList(GetChannel().str(), tpi-pulseList.begin());
 
       const std::vector<TPulseIsland*>& sub_pulses = fPulseCandidateFinder->GetPulseCandidates();

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.h
@@ -6,6 +6,7 @@
 #include "definitions.h"
 
 #include "TAPAlgorithms.h"
+#include "PulseCandidateFinder.h"
 
 class FirstCompleteAPGenerator:public TVAnalysedPulseGenerator {
 
@@ -25,6 +26,12 @@ class FirstCompleteAPGenerator:public TVAnalysedPulseGenerator {
    Algorithm::MaxBinAmplitude fMaxBinAmplitude;
    Algorithm::ConstantFractionTime fConstantFractionTime;
    Algorithm::SimpleIntegral fSimpleIntegral;
+
+   // The pulse candidate finder that we will use
+   PulseCandidateFinder* fPulseCandidateFinder;
+
+   // The module options
+   TAPGeneratorOptions* fOpts;
 };
 
 #endif //FIRSTCOMPLETE_H__

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.h
@@ -12,7 +12,7 @@ class FirstCompleteAPGenerator:public TVAnalysedPulseGenerator {
 
  public:
   FirstCompleteAPGenerator(TAPGeneratorOptions* opts);
-  virtual ~FirstCompleteAPGenerator(){};
+  virtual ~FirstCompleteAPGenerator();
 
  public:
    virtual int ProcessPulses( const PulseIslandList&,AnalysedPulseList&);
@@ -22,6 +22,8 @@ class FirstCompleteAPGenerator:public TVAnalysedPulseGenerator {
    virtual bool MayDivideTPIs(){return true;};
 
  private:
+   void DrawPulse(int original, int pulse_timestamp, int n_pulse_samples);
+
    // The algorithms that this generator will use
    Algorithm::MaxBinAmplitude fMaxBinAmplitude;
    Algorithm::ConstantFractionTime fConstantFractionTime;
@@ -32,6 +34,10 @@ class FirstCompleteAPGenerator:public TVAnalysedPulseGenerator {
 
    // The module options
    TAPGeneratorOptions* fOpts;
+
+   // A vector of sub-pulses so we don't need to declare each time we call
+   // ProcessPulses
+   PulseIslandList fSubPulses;
 };
 
 #endif //FIRSTCOMPLETE_H__

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -285,7 +285,7 @@ void PulseCandidateFinder::SetDefaultParameterValues() {
 
   fDefaultParameterValues[IDs::channel("Ge-F")] = 40;
 
-  fDefaultParameterValues[IDs::channel("ScL")] = 20;
+  fDefaultParameterValues[IDs::channel("ScL")] = 15;
   fDefaultParameterValues[IDs::channel("ScR")] = 20;
   fDefaultParameterValues[IDs::channel("ScGe")] = 20;
   fDefaultParameterValues[IDs::channel("ScVe")] = 30;

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -169,31 +169,42 @@ void PulseCandidateFinder::FindCandidatePulses_Slow(int threshold) {
   // Loop through the samples
   for (unsigned int i = 0; i < n_samples; ++i) {
     sample_height = polarity * (samples[i] - pedestal);
-
+    std::cout << "i = " << i << ", sample_height = " << sample_height << std::endl;
     if (found) {
       if (sample_height < noise) { // stop if the sample goes below pedestal
 	location.stop = (int)i;
 	if (location.stop >= samples.size()) {
 	  location.stop = samples.size() - 1;
 	}
-
+	std::cout << "Stop: location = " << location.stop << ", sample_height = " << sample_height << std::endl;
 	start = stop = 0;
 	fPulseCandidateLocations.push_back(location);
 	found = false;
       }
       else if (i == n_samples-1) { // Also stop if we are at the last sample (only do this check if we failed the above one)
 	location.stop = (int) i;
-
+	std::cout << "Stop: location = " << location.stop << ", sample_height = " << sample_height << std::endl;
 	fPulseCandidateLocations.push_back(location);
 	found = false;
       }
     } else {
       if (sample_height > threshold) {
 	found = true;
+
+	// Track back until we get to the pedestal again so that we get the whole pulse (Ge-S pulses were being cut-off at the start)
 	location.start = (int)(i);
+	for (int j = i; j > 0; --j) {
+	  std::cout << "j = " << j << std::endl;
+	  sample_height = polarity * (samples[j] - pedestal);
+	  if (sample_height <= 0) {
+	    location.start = (int)(j);
+	    break;
+	  }
+	}
 	if (location.start < 0) {
 	  location.start = 0;
 	}
+	std::cout << "Start: location = " << location.start << ", sample_height = " << sample_height << std::endl;
       }
     }
   }

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -129,9 +129,7 @@ void PulseCandidateFinder::FindCandidatePulses_Fast(int rise) {
 	fPulseCandidateLocations.push_back(location);
 	found = false;
       }
-      
-      // Also stop if we are at the last sample
-      if (i == n_samples-1) {
+      else if (i == n_samples-1) { // Also stop if we are at the last sample (only do this check if we failed the above one)
 	location.stop = (int) i;
 
 	fPulseCandidateLocations.push_back(location);
@@ -179,6 +177,12 @@ void PulseCandidateFinder::FindCandidatePulses_Slow(int threshold) {
 	}
 
 	start = stop = 0;
+	fPulseCandidateLocations.push_back(location);
+	found = false;
+      }
+      else if (i == n_samples-1) { // Also stop if we are at the last sample (only do this check if we failed the above one)
+	location.stop = (int) i;
+
 	fPulseCandidateLocations.push_back(location);
 	found = false;
       }

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -1,7 +1,5 @@
 #include "PulseCandidateFinder.h"
-
 #include "SetupNavigator.h"
-
 #include "definitions.h"
 
 #include <iostream>
@@ -86,7 +84,7 @@ void PulseCandidateFinder::GetPulseCandidates(std::vector<TPulseIsland*>& pulse_
 
     // Make the new TPI
     int index=locationIter-fPulseCandidateLocations.begin();
-    if((int)pulse_candidates.size() < index || !pulse_candidates.at(index)){
+    if((int)pulse_candidates.size() <= index || !pulse_candidates.at(index)){
         TPulseIsland* pulse_island = new TPulseIsland(new_timestamp, start_new, stop_new, bankname);
         pulse_candidates.push_back(pulse_island);
     }else{

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -113,6 +113,7 @@ void PulseCandidateFinder::FindCandidatePulses_Fast(int rise) {
   Location location;
 
   // Loop through the samples
+  int n_before_start_samples = 2; // take a few samples from before the official start
   for (unsigned int i = 1; i < n_samples; ++i) {
     s1 = polarity * (samples[i-1] - pedestal);
     s2 = polarity * (samples[i] - pedestal);
@@ -138,7 +139,7 @@ void PulseCandidateFinder::FindCandidatePulses_Fast(int rise) {
     } else {
       if (ds > rise) {
 	found = true;
-	location.start = (int)(i - 1);
+	location.start = (int)(i - 1) - n_before_start_samples;
 
 	if (location.start < 0) {
 	  location.start = 0;

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -113,7 +113,6 @@ void PulseCandidateFinder::FindCandidatePulses_Fast(int rise) {
   Location location;
 
   // Loop through the samples
-  int n_border_samples = 10; // take some samples before and after the candidate officially stops
   for (unsigned int i = 1; i < n_samples; ++i) {
     s1 = polarity * (samples[i-1] - pedestal);
     s2 = polarity * (samples[i] - pedestal);
@@ -122,7 +121,7 @@ void PulseCandidateFinder::FindCandidatePulses_Fast(int rise) {
     if (found) {
 
       if (s2 < noise) { // stop if the sample goes below pedestal
-	location.stop = (int)i + n_border_samples;
+	location.stop = (int)i;
 	if (location.stop >= samples.size()) {
 	  location.stop = samples.size() - 1;
 	}
@@ -141,7 +140,7 @@ void PulseCandidateFinder::FindCandidatePulses_Fast(int rise) {
     } else {
       if (ds > rise) {
 	found = true;
-	location.start = (int)(i - 1) - n_border_samples;
+	location.start = (int)(i - 1);
 
 	if (location.start < 0) {
 	  location.start = 0;
@@ -169,13 +168,12 @@ void PulseCandidateFinder::FindCandidatePulses_Slow(int threshold) {
   Location location;
 
   // Loop through the samples
-  int n_border_samples = 10; // take some samples before and after the candidate officially stops
   for (unsigned int i = 0; i < n_samples; ++i) {
     sample_height = polarity * (samples[i] - pedestal);
 
     if (found) {
       if (sample_height < noise) { // stop if the sample goes below pedestal
-	location.stop = (int)i + n_border_samples;
+	location.stop = (int)i;
 	if (location.stop >= samples.size()) {
 	  location.stop = samples.size() - 1;
 	}
@@ -187,7 +185,7 @@ void PulseCandidateFinder::FindCandidatePulses_Slow(int threshold) {
     } else {
       if (sample_height > threshold) {
 	found = true;
-	location.start = (int)(i) - n_border_samples;
+	location.start = (int)(i);
 	if (location.start < 0) {
 	  location.start = 0;
 	}

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.cpp
@@ -1,6 +1,7 @@
 #include "PulseCandidateFinder.h"
 #include "SetupNavigator.h"
 #include "definitions.h"
+#include "debug_tools.h"
 
 #include <iostream>
 #include <iterator>
@@ -93,6 +94,9 @@ void PulseCandidateFinder::GetPulseCandidates(std::vector<TPulseIsland*>& pulse_
         pulse_island->SetTimeStamp(new_timestamp);
         pulse_island->SetBankName(bankname);
     }
+  }
+  for(unsigned int i=fPulseCandidateLocations.size();i< pulse_candidates.size();++i){
+      pulse_candidates.at(i)->Reset();
   }
 }
 

--- a/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.h
+++ b/analyzer/rootana/src/TAP_generators/utils/PulseCandidateFinder.h
@@ -66,7 +66,9 @@ class PulseCandidateFinder {
   int GetNPulseCandidates() { return fPulseCandidateLocations.size(); }
   /// \brief
   /// Returns the actual TPulseIsland of each candidate
-  std::vector<TPulseIsland*> GetPulseCandidates();
+  //std::vector<TPulseIsland*> GetPulseCandidates();
+
+  void GetPulseCandidates(std::vector<TPulseIsland*>&)const;
 
  private:
   /// \brief

--- a/analyzer/rootana/src/plotters/ExportPulse.cpp
+++ b/analyzer/rootana/src/plotters/ExportPulse.cpp
@@ -240,8 +240,10 @@ int ExportPulse::PlotTPI(const TPulseIsland* pulse, const PulseInfo_t& info)cons
   }
   
   size_t num_samples = pulse->GetPulseLength();
-  double min= (pulse->GetTimeStamp() * fClockTick) - fTimeShift;
-  double max= min + num_samples * fClockTick;
+  double min=0;
+  double max= num_samples;
+  //double min= (pulse->GetTimeStamp() * fClockTick) - fTimeShift;
+  //double max= min + num_samples * fClockTick;
   TH1F* hPulse = new TH1F(hist.c_str(), title.str().c_str(), num_samples,min,max);
   
   double pedestal_error = SetupNavigator::Instance()->GetPedestalError(info.bankname);

--- a/analyzer/rootana/src/plotters/PlotPedestalAndNoise.cpp
+++ b/analyzer/rootana/src/plotters/PlotPedestalAndNoise.cpp
@@ -18,6 +18,7 @@ using std::endl;
 #include <TSQLiteResult.h>
 #include <TSQLiteRow.h>
 
+
 PlotPedestalAndNoise::PlotPedestalAndNoise(modules::options* opts):
    BaseModule("PlotPedestalAndNoise",opts){
 
@@ -52,6 +53,7 @@ int PlotPedestalAndNoise::ProcessEntry(TGlobalData* gData,const TSetupData *setu
   PulseIslandList thePulseIslands;
   StringPulseIslandMap::const_iterator it;
 
+
   // Loop over each detector
   for(it = gData->fPulseIslandToChannelMap.begin(); it != gData->fPulseIslandToChannelMap.end(); ++it){
     
@@ -68,11 +70,11 @@ int PlotPedestalAndNoise::ProcessEntry(TGlobalData* gData,const TSetupData *setu
       int n_bits = TSetupData::Instance()->GetNBits(bankname);
       int x_min = 0;
       int x_max = std::pow(2, n_bits);
-      int n_bins_x = (x_max - x_min)/10;
+      int n_bins_x = 100;
 
       int y_min = 0;
       int y_max = 200;
-      int n_bins_y = (y_max - y_min)*10;
+      int n_bins_y = (y_max - y_min)*5;
 
       std::string histname = "fPedestalVsNoiseHistogram_" + detname;
       std::stringstream histtitle;
@@ -84,24 +86,28 @@ int PlotPedestalAndNoise::ProcessEntry(TGlobalData* gData,const TSetupData *setu
       fPedestalVsNoiseHistograms[detname] = histogram;
     }
 
+
+
     TH2D* pedestal_vs_noise_histogram = fPedestalVsNoiseHistograms[detname];
 
     // Loop through all the pulses
     for (PulseIslandList::iterator pulseIter = thePulseIslands.begin(); pulseIter != thePulseIslands.end(); ++pulseIter) {
 
       const std::vector<int>& theSamples = (*pulseIter)->GetSamples();
+      int limit=fNSamples;
+      if((int)theSamples.size() < fNSamples) limit=theSamples.size();
 
       double sum = 0;
-      for (int iSample = 0; iSample < fNSamples; ++iSample) {
-	sum += theSamples.at(iSample);
+      for (int iSample = 0; iSample < limit; ++iSample) {
+          sum += theSamples.at(iSample);
       }
-      double mean = sum / fNSamples;
+      double mean = sum / limit;
       
       double sum_of_deviations_squared = 0;
-      for (int iSample = 0; iSample < fNSamples; ++iSample) {
-	sum_of_deviations_squared += (theSamples.at(iSample) - mean)*(theSamples.at(iSample) - mean);
+      for (int iSample = 0; iSample < limit; ++iSample) {
+          sum_of_deviations_squared += (theSamples.at(iSample) - mean)*(theSamples.at(iSample) - mean);
       }
-      double RMS = std::sqrt(sum_of_deviations_squared / fNSamples);
+      double RMS = std::sqrt(sum_of_deviations_squared / limit);
 
       pedestal_vs_noise_histogram->Fill(mean, RMS);
     } // end loop through pulses

--- a/analyzer/src/common/TPulseIsland.cpp
+++ b/analyzer/src/common/TPulseIsland.cpp
@@ -13,6 +13,11 @@ using std::string;
 TPulseIsland::TPulseIsland() : fSamples(), fTimeStamp(0), fBankName("") {
 }
 
+TPulseIsland::TPulseIsland(int timestamp, const vector<int>::const_iterator& first,
+        const vector<int>::const_iterator& last, string bank_name) :
+  fSamples(first,last), fTimeStamp(timestamp), fBankName(bank_name) {
+}
+
 TPulseIsland::TPulseIsland(int timestamp, const vector<int>& samples_vector, string bank_name) :
   fSamples(samples_vector), fTimeStamp(timestamp), fBankName(bank_name) {
 }

--- a/analyzer/src/common/TPulseIsland.h
+++ b/analyzer/src/common/TPulseIsland.h
@@ -41,13 +41,24 @@ class TPulseIsland : public TObject {
   TPulseIsland(int timestamp, const std::vector<int>& samples_vector, 
                std::string bank_name);
 
+  /// @brief Construct a TPI from a sub-range of an existing vector of ints
+  /// @details Copies all samples in the range [first,last[
+  ///
+  /// @param[in] timestamp The time in units of clock ticks of the first sample in the pulse
+  /// @param[in] first Iterator to the first sample of the input waveform
+  /// @param[in] first Iterator to the last sample of the input waveform
+  /// @param[in] bank_name The (4 character long) name identifying the digitizer channel
+  /// the pulse originated.
+  TPulseIsland(int timestamp, const std::vector<int>::const_iterator& first,
+          const std::vector<int>::const_iterator& last, std::string bank_name);
+
   /// The TPI goes to the state the default constructor would set it to. Not generally used.
   void Reset(Option_t* o = "");
 
   /// \name Getters
   /// Return copies of all fields in the TPI and TSD.
   //@{
-  std::vector<int> GetSamples() const { return fSamples; }
+  const std::vector<int>& GetSamples() const { return fSamples; }
   int GetTimeStamp() const { return fTimeStamp; }
   std::string GetBankName() const { return fBankName; }
 
@@ -76,13 +87,18 @@ class TPulseIsland : public TObject {
   double GetPedestal(int nPedSamples) const;
   //@}
 
+  void SetBankName(const std::string& name ){fBankName=name;}
+  void SetTimeStamp(int t ){fTimeStamp=t;}
+  void SetSamples( const std::vector<int>::const_iterator& first,
+          const std::vector<int>::const_iterator& last){fSamples.assign(first,last);}
+
  private:
   /// Copying is made explicitly private since we do not need it yet.
   TPulseIsland(const TPulseIsland& src);
   /// Assignment is made explicitly private since we do not need it yet.
   TPulseIsland operator=(const TPulseIsland& rhs); 
 
-  ClassDef(TPulseIsland, 1);
+  ClassDef(TPulseIsland, 2);
 };
 
 #endif


### PR DESCRIPTION
So I've added the PulseCandidateFinder to FirstCompleteAPGenerator and made a couple of tweaks:
- for fast pulses we take 2 bins before the "detected" start so that we get the whole pulse (muSc pulses were looking a little odd)
- for slow pulses we track back from the "detected" start until we hit the pedestal to get the whole pulse (I could also do this for fast pulses)
- tweaked a parameter value:
  - ScL: rise 20 --> 15 because run 2808, event 0, pulse 2 had obviously missed a 4th candidate pulse

I think there are still a few channels to tweak the parameter values for (Run 2808, SiL2-S, event 8, pulse 1 has two candidates when there should only be one) but I will leave this till tomorrow since it would be nice to run with this today.

Also, for the Ge-F pulses, there are some overflows which mean we are detecting pulses when we shouldn't (just a heads up):
![ge-f_overflowedpulse](https://cloud.githubusercontent.com/assets/1848575/3799815/82d3a32c-1bf1-11e4-934a-7ae940a5f60f.png)

Note, there are 5 candidates here.

(I've got to dash off home now so can't do any more work on it - I should be able to reply to comments with my GitHub smartphone app :) but can't do any coding because my laptop is broken :( ).
