### PR TITLE
Feature/bk investigate si r2 pile up

### DIFF
--- a/analyzer/rootana/Makefile
+++ b/analyzer/rootana/Makefile
@@ -93,6 +93,8 @@ ${OBJECTS}: ${OBJ_DIR}/%.o: %.cpp
 	@$(CXX) -c -Wall $(CXXFLAGS) -o $@  $<
 	@$(CXX) -MP -MM -MT $@ $(CXXFLAGS) $< > $(patsubst %.o,%.d,$@)
 
+rootcint: $(DATA_LIBRARY_SOURCE)
+
 $(DATA_LIBRARY_SOURCE): $(ROOTANA_DATALINKDEF) ${ROOT_DICT_HEADERS}
 	@$(ROOTSYS)/bin/rootcint -f $@ -c $(UIUC_CFLAGS) -p $(INCLUDE_CFLAGS) ${ROOT_DICT_HEADERS} $(ROOTANA_DATALINKDEF)
 

--- a/analyzer/rootana/src/LibraryLinkDef.h
+++ b/analyzer/rootana/src/LibraryLinkDef.h
@@ -11,27 +11,16 @@
 #pragma link C++ class std::map<std::string,IDs::Detector_t>+;
 #pragma link C++ class std::map<IDs::Detector_t,std::string>+;
 
-#pragma link C++ class TAnalysedPulse+;
+#pragma link C++ class TIntegralRatioAnalysedPulse+;
 #pragma link C++ class TGaussFitAnalysedPulse+;
+#pragma link C++ class TAnalysedPulse+;
 #pragma link C++ class TDetectorPulse+;
 #pragma link C++ class vector<TAnalysedPulse*>+;
 #pragma link C++ class vector<TAnalysedPulse*>::iterator;
 #pragma link C++ function operator!= (vector<TAnalysedPulse*>::iterator, vector<TAnalysedPulse*>::iterator);
-//#pragma link C++ class map<IDs::source, vector<TAnalysedPulse*> >+;
-//#pragma link C++ class map<IDs::source, vector<TAnalysedPulse*> >::iterator+;
-//#pragma link C++ class map<IDs::source, vector<TAnalysedPulse*> >::const_iterator+;
-//#pragma link C++ class map<IDs::source, vector<TDetectorPulse*> >+;
-//#pragma link C++ class map<IDs::source, vector<TDetectorPulse*> >::iterator+;
-//#pragma link C++ class map<IDs::source, vector<TDetectorPulse*> >::const_iterator+;
-//#pragma link C++ class map<IDs::source, vector<TMuonEvent*> >+;
-//#pragma link C++ class map<IDs::source, vector<TMuonEvent*> >::iterator+;
-//#pragma link C++ class map<IDs::source, vector<TMuonEvent*> >::const_iterator+;
 #pragma link C++ class map<string, vector<TAnalysedPulse*> >+;
 #pragma link C++ class map<string, vector<TAnalysedPulse*> >::iterator;
 #pragma link C++ class pair<string,vector<TAnalysedPulse*> >+;
-//#pragma link C++ class pair<IDs::source,vector<TAnalysedPulse*> >+;
-//#pragma link C++ class pair<IDs::source,vector<TDetectorPulse*> >+;
-//#pragma link C++ class pair<IDs::source,vector<TMuonEvent*> >+;
 #pragma link C++ class std::vector<std::string>+;
 
 #pragma link C++ class std::map<IDs::source, int>+;
@@ -42,7 +31,6 @@
 #pragma link C++ class FlyWeight<IDs::source, TAnalysedPulse::Tag>+;
 #pragma link C++ class FlyWeight<IDs::source, TDetectorPulse::Tag>+;
 
-//#pragma link C++ class vector<TPulseIsland*>+;
 #pragma link C++ class BankBranch<vector<TPulseIsland*> >+;
 #pragma link C++ class BankBranch<vector<TAnalysedPulse*> >+;
 #pragma link C++ class BankBranch<vector<TDetectorPulse*> >+;

--- a/analyzer/rootana/src/PlotIntegralRatios.cpp
+++ b/analyzer/rootana/src/PlotIntegralRatios.cpp
@@ -1,0 +1,81 @@
+#include "ExportPulse.h"
+#include "PlotIntegralRatios.h"
+#include "RegisterModule.inc"
+#include "TGlobalData.h"
+#include "TSetupData.h"
+#include "ModulesOptions.h"
+#include "definitions.h"
+#include "TIntegralRatioAnalysedPulse.h"
+
+#include "debug_tools.h"
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+extern SourceAnalPulseMap gAnalysedPulseMap;
+
+PlotIntegralRatios::PlotIntegralRatios(modules::options* opts):
+   BaseModule("PlotIntegralRatios",opts),
+    fSource(opts->GetString("source","SiR2-*#IntegralRatio#any")){
+        fThresh=opts->GetDouble("threshold",0.9);
+}
+
+PlotIntegralRatios::~PlotIntegralRatios(){
+}
+
+int PlotIntegralRatios::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
+    SourcePlots_t tmp;
+    for(SourceAnalPulseMap::const_iterator i_source = gAnalysedPulseMap.begin();
+            i_source!=gAnalysedPulseMap.end(); ++i_source){
+        if(i_source->first.matches(fSource)){
+            tmp.src=i_source->first;
+
+            tmp.ratio=new TH1F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_ratio").c_str(),
+                    ("Ratio of integrals for "+tmp.src.str()).c_str(),
+                    100,0,10);
+            tmp.ratio->SetXTitle("Ratio of total to tail integral");
+            fSourcesToPlot.push_back(tmp);
+        }
+    }
+    if(fSourcesToPlot.empty()){
+        cout<<"PlotIntegralRatios:BeforeFirstEntry: Error: No sources in gAnalysedPulseMap match "<<fSource<<endl;
+        return 1;
+    }
+  return 0;
+}
+
+int PlotIntegralRatios::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+    TIntegralRatioAnalysedPulse* pulse=0;
+    for(SourceList_t::const_iterator i_source=fSourcesToPlot.begin();
+            i_source!=fSourcesToPlot.end(); ++i_source){
+        const AnalysedPulseList& pulseList=gAnalysedPulseMap.at(i_source->src);
+        for(AnalysedPulseList::const_iterator i_pulse=pulseList.begin();
+                i_pulse!=pulseList.end(); ++i_pulse){
+            if(i_pulse==pulseList.begin()){
+                pulse=dynamic_cast<TIntegralRatioAnalysedPulse*>(*i_pulse);
+                if(!pulse) {
+                    cout<<"PlotIntegralRatios::ProcessEntry: Error: Pulses in "<<i_source->src
+                        <<" aren't of type TIntegralRatioAnalysedPulse"<<endl;
+                    return 2;
+                }
+            }else{
+                pulse=static_cast<TIntegralRatioAnalysedPulse*>(*i_pulse);
+            }
+            double ratio=pulse->GetIntegralRatio();
+            i_source->ratio->Fill(ratio);
+            if(ratio > fThresh && ExportPulse::Instance()){
+                ExportPulse::Instance()->AddToExportList(pulse);
+            }
+        }
+
+    }
+  return 0;
+}
+
+int PlotIntegralRatios::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
+  return 0;
+}
+
+ALCAP_REGISTER_MODULE(PlotIntegralRatios,source,threshold);

--- a/analyzer/rootana/src/PlotIntegralRatios.cpp
+++ b/analyzer/rootana/src/PlotIntegralRatios.cpp
@@ -35,8 +35,27 @@ int PlotIntegralRatios::BeforeFirstEntry(TGlobalData* gData,const TSetupData *se
             tmp.ratio=new TH1F(
                     modules::parser::ToCppValid("h"+tmp.src.str()+"_ratio").c_str(),
                     ("Ratio of integrals for "+tmp.src.str()).c_str(),
-                    100,0,1);
+                    1000,0,1);
             tmp.ratio->SetXTitle("Ratio of total to tail integral");
+
+            tmp.ratio_zoomed=new TH1F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_ratio_zoomed").c_str(),
+                    ("Zoomed Ratio of integrals for "+tmp.src.str()).c_str(),
+                    2000,0.1,0.25);
+            tmp.ratio_zoomed->SetXTitle("Ratio of total to tail integral");
+
+            tmp.assymetry=new TH1F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_assymetry").c_str(),
+                    ("Assymetry (first - second)/(first+second) for "+tmp.src.str()).c_str(),
+                    200,0,-1);
+            tmp.assymetry->SetXTitle("Assymetry of total to tail integral");
+
+            tmp.assymetry2d=new TH2F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_assymetry2d").c_str(),
+                    ("Assymetry (first - second) vs (first+second) for "+tmp.src.str()).c_str(),
+                    200,0,-1,200,0,-1);
+            tmp.assymetry2d->SetXTitle("Total integral");
+            tmp.assymetry2d->SetYTitle("Difference between first and tail");
 
             tmp.full_v_tail=new TH2F(
                     modules::parser::ToCppValid("h"+tmp.src.str()+"_2d").c_str(),
@@ -75,7 +94,10 @@ int PlotIntegralRatios::ProcessEntry(TGlobalData* gData,const TSetupData *setup)
             double full=pulse->GetIntegral();
             double tail=pulse->GetIntegralSmall();
             i_source->ratio->Fill(ratio);
+            i_source->ratio_zoomed->Fill(ratio);
             i_source->full_v_tail->Fill(full,tail);
+            i_source->assymetry->Fill((full-2*tail)/full);
+            i_source->assymetry2d->Fill((full-2*tail),full);
         }
 
     }

--- a/analyzer/rootana/src/PlotIntegralRatios.cpp
+++ b/analyzer/rootana/src/PlotIntegralRatios.cpp
@@ -87,6 +87,42 @@ int PlotIntegralRatios::BeforeFirstEntry(TGlobalData* gData,const TSetupData *se
             tmp.diff_v_ratio->SetYTitle("differente of tail to full integrals");
             tmp.diff_v_ratio->SetDirectory(GetDirectory("miscs"));
 
+            tmp.mean_vs_min=new TH2F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_mean_vs_min").c_str(),
+                    ("mean vs min values for "+tmp.src.str()).c_str(),
+                    200,0,-1,200,0,-1);
+            tmp.mean_vs_min->SetXTitle("minimum value");
+            tmp.mean_vs_min->SetYTitle("mean value");
+            tmp.mean_vs_min->SetDirectory(GetDirectory("min_max_mean"));
+
+            tmp.mean_vs_max=new TH2F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_mean_vs_max").c_str(),
+                    ("mean vs max values for "+tmp.src.str()).c_str(),
+                    200,0,-1,200,0,-1);
+            tmp.mean_vs_max->SetXTitle("maximum value");
+            tmp.mean_vs_max->SetYTitle("mean value");
+            tmp.mean_vs_max->SetDirectory(GetDirectory("min_max_mean"));
+
+            tmp.mean=new TH1F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_mean").c_str(),
+                    ("mean value for "+tmp.src.str()).c_str(),
+                    400,0,-1);
+            tmp.mean->SetXTitle("mean value");
+            tmp.mean->SetDirectory(GetDirectory("min_max_mean"));
+
+            tmp.max=new TH1F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_max").c_str(),
+                    ("max value for "+tmp.src.str()).c_str(),
+                    400,0,-1);
+            tmp.max->SetXTitle("max value");
+            tmp.max->SetDirectory(GetDirectory("min_max_mean"));
+
+            tmp.min=new TH1F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_min").c_str(),
+                    ("min value for "+tmp.src.str()).c_str(),
+                    400,0,-1);
+            tmp.min->SetXTitle("min value");
+            tmp.min->SetDirectory(GetDirectory("min_max_mean"));
 
             fSourcesToPlot.push_back(tmp);
         }
@@ -126,6 +162,15 @@ int PlotIntegralRatios::ProcessEntry(TGlobalData* gData,const TSetupData *setup)
             i_source->diff_v_ratio->Fill(ratio,diff);
             i_source->assymetry->Fill(diff/(full-fShiftFull));
             i_source->assymetry2d->Fill(full,(full-2*tail));
+
+            double mean=pulse->GetMean();
+            double min=pulse->GetMin();
+            double max=pulse->GetMax();
+            i_source->mean->Fill(mean);
+            i_source->max->Fill(max);
+            i_source->min->Fill(min);
+            i_source->mean_vs_min->Fill(min,mean);
+            i_source->mean_vs_max->Fill(max,mean);
         }
 
     }

--- a/analyzer/rootana/src/PlotIntegralRatios.cpp
+++ b/analyzer/rootana/src/PlotIntegralRatios.cpp
@@ -39,90 +39,97 @@ int PlotIntegralRatios::BeforeFirstEntry(TGlobalData* gData,const TSetupData *se
                     ("Ratio of integrals for "+tmp.src.str()).c_str(),
                     1000,0,1);
             tmp.ratio->SetXTitle("Ratio of total to tail integral");
-            tmp.ratio->SetDirectory(GetDirectory("ratios"));
+            //tmp.ratio->SetDirectory(GetDirectory("ratios"));
 
             tmp.ratio_zoomed=new TH1F(
                     modules::parser::ToCppValid("h"+tmp.src.str()+"_ratio_zoomed").c_str(),
                     ("Zoomed Ratio of integrals for "+tmp.src.str()).c_str(),
                     2000,0.1,0.25);
             tmp.ratio_zoomed->SetXTitle("Ratio of total to tail integral");
-            tmp.ratio_zoomed->SetDirectory(NULL);
+            //tmp.ratio_zoomed->SetDirectory(GetDirectory("ratios"));
 
-            tmp.assymetry=new TH1F(
-                    modules::parser::ToCppValid("h"+tmp.src.str()+"_assymetry").c_str(),
-                    ("Assymetry (first - second)/(first+second) for "+tmp.src.str()).c_str(),
-                    200,0,-1);
-            tmp.assymetry->SetXTitle("Assymetry of total to tail integral");
-            tmp.assymetry->SetDirectory(GetDirectory("assymetry"));
+            tmp.full_integral=new TH1F(
+                    modules::parser::ToCppValid("h"+tmp.src.str()+"_integral").c_str(),
+                    ("Integrals for "+tmp.src.str()).c_str(),
+                    1000,0,-1);
+            tmp.full_integral->SetXTitle("Total integral");
+            //tmp.full_integral->SetDirectory(GetDirectory("ratios"));
 
-            tmp.assymetry2d=new TH2F(
-                    modules::parser::ToCppValid("h"+tmp.src.str()+"_assymetry2d").c_str(),
-                    ("Assymetry (first - second) vs (first+second) for "+tmp.src.str()).c_str(),
-                    200,0,-1,200,0,-1);
-            tmp.assymetry2d->SetXTitle("Total integral");
-            tmp.assymetry2d->SetYTitle("Difference between first and tail");
-            tmp.assymetry2d->SetDirectory(GetDirectory("assymetry"));
+//            tmp.assymetry=new TH1F(
+//                    modules::parser::ToCppValid("h"+tmp.src.str()+"_assymetry").c_str(),
+//                    ("Assymetry (first - second)/(first+second) for "+tmp.src.str()).c_str(),
+//                    200,0,-1);
+//            tmp.assymetry->SetXTitle("Assymetry of total to tail integral");
+////            tmp.assymetry->SetDirectory(GetDirectory("assymetry"));
+//
+//            tmp.assymetry2d=new TH2F(
+//                    modules::parser::ToCppValid("h"+tmp.src.str()+"_assymetry2d").c_str(),
+//                    ("Assymetry (first - second) vs (first+second) for "+tmp.src.str()).c_str(),
+//                    200,0,-1,200,0,-1);
+//            tmp.assymetry2d->SetXTitle("Total integral");
+//            tmp.assymetry2d->SetYTitle("Difference between first and tail");
+////            tmp.assymetry2d->SetDirectory(GetDirectory("assymetry"));
 
             tmp.full_v_tail=new TH2F(
                     modules::parser::ToCppValid("h"+tmp.src.str()+"_2d").c_str(),
                     ("Integrals for "+tmp.src.str()).c_str(),
-                    100,0,-1,100,0,-1);
+                    400,0,-1,400,0,-1);
             tmp.full_v_tail->SetXTitle("tail integral");
             tmp.full_v_tail->SetYTitle("full integral");
-            tmp.full_v_tail->SetDirectory(GetDirectory("miscs"));
+            //tmp.full_v_tail->SetDirectory(GetDirectory("miscs"));
 
             tmp.full_v_ratio=new TH2F(
                     modules::parser::ToCppValid("h"+tmp.src.str()+"_integral_v_ratio").c_str(),
                     ("Integral vs ratio of tail to integral for "+tmp.src.str()).c_str(),
-                    300,0,-3,100,0,-1);
+                    400,0,-3,400,0,-1);
             tmp.full_v_ratio->SetXTitle("ratio of tail to full integrals");
             tmp.full_v_ratio->SetYTitle("full integral");
-            tmp.full_v_ratio->SetDirectory(GetDirectory("miscs"));
+            //tmp.full_v_ratio->SetDirectory(GetDirectory("miscs"));
 
             tmp.diff_v_ratio=new TH2F(
                     modules::parser::ToCppValid("h"+tmp.src.str()+"_diff_v_ratio").c_str(),
                     ("Difference vs ratio of tail to integral for "+tmp.src.str()).c_str(),
-                    200,0,-1,200,0,-1);
+                    400,0,-1,400,0,-1);
             tmp.diff_v_ratio->SetXTitle("ratio of tail to full integrals");
             tmp.diff_v_ratio->SetYTitle("differente of tail to full integrals");
-            tmp.diff_v_ratio->SetDirectory(GetDirectory("miscs"));
+            //tmp.diff_v_ratio->SetDirectory(GetDirectory("miscs"));
 
-            tmp.mean_vs_min=new TH2F(
-                    modules::parser::ToCppValid("h"+tmp.src.str()+"_mean_vs_min").c_str(),
-                    ("mean vs min values for "+tmp.src.str()).c_str(),
-                    200,0,-1,200,0,-1);
-            tmp.mean_vs_min->SetXTitle("minimum value");
-            tmp.mean_vs_min->SetYTitle("mean value");
-            tmp.mean_vs_min->SetDirectory(GetDirectory("min_max_mean"));
+            //tmp.mean_vs_min=new TH2F(
+            //        modules::parser::ToCppValid("h"+tmp.src.str()+"_mean_vs_min").c_str(),
+            //        ("mean vs min values for "+tmp.src.str()).c_str(),
+            //        200,0,-1,200,0,-1);
+            //tmp.mean_vs_min->SetXTitle("minimum value");
+            //tmp.mean_vs_min->SetYTitle("mean value");
+            //tmp.mean_vs_min->SetDirectory(GetDirectory("min_max_mean"));
 
-            tmp.mean_vs_max=new TH2F(
-                    modules::parser::ToCppValid("h"+tmp.src.str()+"_mean_vs_max").c_str(),
-                    ("mean vs max values for "+tmp.src.str()).c_str(),
-                    200,0,-1,200,0,-1);
-            tmp.mean_vs_max->SetXTitle("maximum value");
-            tmp.mean_vs_max->SetYTitle("mean value");
-            tmp.mean_vs_max->SetDirectory(GetDirectory("min_max_mean"));
+            //tmp.mean_vs_max=new TH2F(
+            //        modules::parser::ToCppValid("h"+tmp.src.str()+"_mean_vs_max").c_str(),
+            //        ("mean vs max values for "+tmp.src.str()).c_str(),
+            //        200,0,-1,200,0,-1);
+            //tmp.mean_vs_max->SetXTitle("maximum value");
+            //tmp.mean_vs_max->SetYTitle("mean value");
+            //tmp.mean_vs_max->SetDirectory(GetDirectory("min_max_mean"));
 
-            tmp.mean=new TH1F(
-                    modules::parser::ToCppValid("h"+tmp.src.str()+"_mean").c_str(),
-                    ("mean value for "+tmp.src.str()).c_str(),
-                    400,0,-1);
-            tmp.mean->SetXTitle("mean value");
-            tmp.mean->SetDirectory(GetDirectory("min_max_mean"));
+            //tmp.mean=new TH1F(
+            //        modules::parser::ToCppValid("h"+tmp.src.str()+"_mean").c_str(),
+            //        ("mean value for "+tmp.src.str()).c_str(),
+            //        400,0,-1);
+            //tmp.mean->SetXTitle("mean value");
+            //tmp.mean->SetDirectory(GetDirectory("min_max_mean"));
 
-            tmp.max=new TH1F(
-                    modules::parser::ToCppValid("h"+tmp.src.str()+"_max").c_str(),
-                    ("max value for "+tmp.src.str()).c_str(),
-                    400,0,-1);
-            tmp.max->SetXTitle("max value");
-            tmp.max->SetDirectory(GetDirectory("min_max_mean"));
+            //tmp.max=new TH1F(
+            //        modules::parser::ToCppValid("h"+tmp.src.str()+"_max").c_str(),
+            //        ("max value for "+tmp.src.str()).c_str(),
+            //        400,0,-1);
+            //tmp.max->SetXTitle("max value");
+            //tmp.max->SetDirectory(GetDirectory("min_max_mean"));
 
-            tmp.min=new TH1F(
-                    modules::parser::ToCppValid("h"+tmp.src.str()+"_min").c_str(),
-                    ("min value for "+tmp.src.str()).c_str(),
-                    400,0,-1);
-            tmp.min->SetXTitle("min value");
-            tmp.min->SetDirectory(GetDirectory("min_max_mean"));
+            //tmp.min=new TH1F(
+            //        modules::parser::ToCppValid("h"+tmp.src.str()+"_min").c_str(),
+            //        ("min value for "+tmp.src.str()).c_str(),
+            //        400,0,-1);
+            //tmp.min->SetXTitle("min value");
+            //tmp.min->SetDirectory(GetDirectory("min_max_mean"));
 
             fSourcesToPlot.push_back(tmp);
         }
@@ -157,20 +164,21 @@ int PlotIntegralRatios::ProcessEntry(TGlobalData* gData,const TSetupData *setup)
             double diff=full-2*tail-fShiftDifference;
             i_source->ratio->Fill(ratio);
             i_source->ratio_zoomed->Fill(ratio);
+            i_source->full_integral->Fill(full);
             i_source->full_v_tail->Fill(tail,full);
             i_source->full_v_ratio->Fill(ratio,full);
             i_source->diff_v_ratio->Fill(ratio,diff);
-            i_source->assymetry->Fill(diff/(full-fShiftFull));
-            i_source->assymetry2d->Fill(full,(full-2*tail));
+            //i_source->assymetry->Fill(diff/(full-fShiftFull));
+            //i_source->assymetry2d->Fill(full,(full-2*tail));
 
-            double mean=pulse->GetMean();
-            double min=pulse->GetMin();
-            double max=pulse->GetMax();
-            i_source->mean->Fill(mean);
-            i_source->max->Fill(max);
-            i_source->min->Fill(min);
-            i_source->mean_vs_min->Fill(min,mean);
-            i_source->mean_vs_max->Fill(max,mean);
+            //double mean=pulse->GetMean();
+            //double min=pulse->GetMin();
+            //double max=pulse->GetMax();
+            //i_source->mean->Fill(mean);
+            //i_source->max->Fill(max);
+            //i_source->min->Fill(min);
+            //i_source->mean_vs_min->Fill(min,mean);
+            //i_source->mean_vs_max->Fill(max,mean);
         }
 
     }

--- a/analyzer/rootana/src/PlotIntegralRatios.h
+++ b/analyzer/rootana/src/PlotIntegralRatios.h
@@ -4,6 +4,8 @@
 #include "BaseModule.h"
 class TGlobalData;
 class TSetupData;
+class TH1F;
+class TH2F;
 namespace modules {class options;}
 #include "IdSource.h"
 
@@ -24,6 +26,7 @@ class PlotIntegralRatios : public BaseModule {
     struct SourcePlots_t{
         IDs::source src;
         TH1F* ratio;
+        TH2F* full_v_tail;
     };
   typedef std::vector<SourcePlots_t> SourceList_t;
 
@@ -59,7 +62,6 @@ class PlotIntegralRatios : public BaseModule {
 
   SourceList_t fSourcesToPlot;
   IDs::source fSource;
-  double fThresh;
 };
 
 #endif //PLOTINTEGRALRATIOS_H_

--- a/analyzer/rootana/src/PlotIntegralRatios.h
+++ b/analyzer/rootana/src/PlotIntegralRatios.h
@@ -26,7 +26,7 @@ class PlotIntegralRatios : public BaseModule {
     struct SourcePlots_t{
         IDs::source src;
         TH1F* ratio,*ratio_zoomed,*assymetry;
-        TH2F* full_v_tail,*assymetry2d;
+        TH2F* full_v_tail,*assymetry2d, *full_v_ratio, *diff_v_ratio;
     };
   typedef std::vector<SourcePlots_t> SourceList_t;
 
@@ -62,6 +62,7 @@ class PlotIntegralRatios : public BaseModule {
 
   SourceList_t fSourcesToPlot;
   IDs::source fSource;
+  double fShiftFull, fShiftDifference;
 };
 
 #endif //PLOTINTEGRALRATIOS_H_

--- a/analyzer/rootana/src/PlotIntegralRatios.h
+++ b/analyzer/rootana/src/PlotIntegralRatios.h
@@ -25,8 +25,8 @@ namespace modules {class options;}
 class PlotIntegralRatios : public BaseModule {
     struct SourcePlots_t{
         IDs::source src;
-        TH1F* ratio;
-        TH2F* full_v_tail;
+        TH1F* ratio,*ratio_zoomed,*assymetry;
+        TH2F* full_v_tail,*assymetry2d;
     };
   typedef std::vector<SourcePlots_t> SourceList_t;
 

--- a/analyzer/rootana/src/PlotIntegralRatios.h
+++ b/analyzer/rootana/src/PlotIntegralRatios.h
@@ -27,6 +27,8 @@ class PlotIntegralRatios : public BaseModule {
         IDs::source src;
         TH1F* ratio,*ratio_zoomed,*assymetry;
         TH2F* full_v_tail,*assymetry2d, *full_v_ratio, *diff_v_ratio;
+        TH1F *min, *max, *mean;
+        TH2F *mean_vs_min, *mean_vs_max;
     };
   typedef std::vector<SourcePlots_t> SourceList_t;
 

--- a/analyzer/rootana/src/PlotIntegralRatios.h
+++ b/analyzer/rootana/src/PlotIntegralRatios.h
@@ -25,7 +25,7 @@ namespace modules {class options;}
 class PlotIntegralRatios : public BaseModule {
     struct SourcePlots_t{
         IDs::source src;
-        TH1F* ratio,*ratio_zoomed,*assymetry;
+        TH1F* ratio,*ratio_zoomed,*assymetry, *full_integral;
         TH2F* full_v_tail,*assymetry2d, *full_v_ratio, *diff_v_ratio;
         TH1F *min, *max, *mean;
         TH2F *mean_vs_min, *mean_vs_max;

--- a/analyzer/rootana/src/PlotIntegralRatios.h
+++ b/analyzer/rootana/src/PlotIntegralRatios.h
@@ -1,0 +1,65 @@
+#ifndef PLOTINTEGRALRATIOS_H_
+#define PLOTINTEGRALRATIOS_H_
+
+#include "BaseModule.h"
+class TGlobalData;
+class TSetupData;
+namespace modules {class options;}
+#include "IdSource.h"
+
+////////////////////////////////////////////////////////////////////////////////
+/// \ingroup rootana_modules
+/// \author AuthorName
+///
+/// \brief
+/// A one line description of what your module does.
+///
+/// \details
+/// A longer, more descriptive block of text.
+/// Specifics like members and methods will be described later.
+/// You can add this to other groups instead of rootana_modules or in addition
+/// to rootana_modules by adding more of the ingroup tags.
+////////////////////////////////////////////////////////////////////////////////
+class PlotIntegralRatios : public BaseModule {
+    struct SourcePlots_t{
+        IDs::source src;
+        TH1F* ratio;
+    };
+  typedef std::vector<SourcePlots_t> SourceList_t;
+
+ public:
+  /// \brief
+  /// Constructor description. If necessary, add a details tag like above.
+  ///
+  /// \param[in] opts Describe the options this module takes.
+  PlotIntegralRatios(modules::options* opts);
+  /// \brief
+  /// Is anything done in the destructor?
+  ~PlotIntegralRatios();
+
+ private:
+  /// \brief
+  /// What's calculated for every entry?
+  /// Don't hesitate to repeat what was said in the class description.
+  /// 
+  /// \return Non-zero to indicate a problem.
+  virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
+  /// \brief
+  /// What needes to be done before each run?
+  /// Don't hesitate to repeat what was said in the class description.
+  ///
+  /// \return Non-zero to indicate a problem.
+  virtual int BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup);
+  /// \brief
+  /// What needs to be done after each run?
+  /// Don't hesitate to repeat what was said in the class description.
+  ///
+  /// \return Non-zero to indicate a problem.
+  virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
+
+  SourceList_t fSourcesToPlot;
+  IDs::source fSource;
+  double fThresh;
+};
+
+#endif //PLOTINTEGRALRATIOS_H_

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
@@ -4,7 +4,9 @@
 #include "IntegralRatioAPGenerator.h"
 #include "TPulseIsland.h"
 #include "TIntegralRatioAnalysedPulse.h"
+
 #include <iostream>
+#include <algorithm>
 #include <stdexcept>
 using std::cout;
 using std::endl;
@@ -27,10 +29,14 @@ int IntegralRatioAPGenerator::ProcessPulses(
         AnalysedPulseList& analysedList){
 
     // Loop over all the TPIs given to us
-    double integral, tail;
+    double integral, tail,pedestal;
     TIntegralRatioAnalysedPulse* tap;
     for (PulseIslandList::const_iterator tpi=pulseList.begin();
             tpi!=pulseList.end(); tpi++){
+
+        pedestal=*std::min_element((*tpi)->GetSamples().begin(), (*tpi)->GetSamples().end());
+        fFullIntegrator.pedestal=pedestal;
+        fTailIntegrator.pedestal=pedestal;
 
         // Analyse each TPI
         try{

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
@@ -41,13 +41,13 @@ int IntegralRatioAPGenerator::ProcessPulses(
 
         min=*std::min_element((*tpi)->GetSamples().begin(), (*tpi)->GetSamples().end());
         max=*std::max_element((*tpi)->GetSamples().begin(), (*tpi)->GetSamples().end());
-        fHeadIntegrator.pedestal=min;
-        fTailIntegrator.pedestal=min;
+        fHeadIntegrator.SetPedestal(min);
+        fTailIntegrator.SetPedestal(min);
 
         if(fStartTailAsFraction){
            start_tail=fStartTail*(*tpi)->GetPulseLength();
-           fHeadIntegrator.stop=start_tail;
-           fTailIntegrator.start=start_tail;
+           fHeadIntegrator.SetStop(start_tail);
+           fTailIntegrator.SetStart(start_tail);
         }
 
         // Analyse each TPI

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
@@ -14,9 +14,13 @@ using std::endl;
 
 IntegralRatioAPGenerator::IntegralRatioAPGenerator(TAPGeneratorOptions* opts):
     TVAnalysedPulseGenerator("IntegralRatio",opts),
+        fStartTailAsFraction(opts->GetBool("start_tail_as_fraction",false)),
         fStartIntegral(opts->GetInt("start_int","x>=0")),
         fStopIntegral(opts->GetInt("stop_int","x>=0")),
-        fStartTail(opts->GetDouble("start_tail","x<1 && x>0")),//Form("x>%g",fStartIntegral))),
+        fStartTail(opts->GetDouble("start_tail",
+                                  fStartTailAsFraction?
+                                  "x<1 && x>0":
+                                  Form("x>%g",fStartIntegral))),
         fPedestal(GetChannel().isFast()?900:2728),
         fPolarity(GetChannel().isFast()?1:-1),
         fHeadIntegrator( fPedestal, fPolarity, fStartIntegral, fStartTail),
@@ -40,9 +44,11 @@ int IntegralRatioAPGenerator::ProcessPulses(
         fHeadIntegrator.pedestal=min;
         fTailIntegrator.pedestal=min;
 
-        start_tail=fStartTail*(*tpi)->GetPulseLength();
-        fHeadIntegrator.stop=start_tail;
-        fTailIntegrator.start=start_tail;
+        if(fStartTailAsFraction){
+           start_tail=fStartTail*(*tpi)->GetPulseLength();
+           fHeadIntegrator.stop=start_tail;
+           fTailIntegrator.start=start_tail;
+        }
 
         // Analyse each TPI
         try{
@@ -80,4 +86,4 @@ int IntegralRatioAPGenerator::ProcessPulses(
     return 0;
 }
 
-ALCAP_TAP_GENERATOR(IntegralRatio,start_int,start_tail,stop_int);
+ALCAP_TAP_GENERATOR(IntegralRatio,start_int,start_tail,stop_int,start_tail_as_fraction);

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
@@ -8,13 +8,14 @@
 #include <stdexcept>
 using std::cout;
 using std::endl;
+#include "debug_tools.h"
 
 IntegralRatioAPGenerator::IntegralRatioAPGenerator(TAPGeneratorOptions* opts):
     TVAnalysedPulseGenerator("IntegralRatio",opts),
         fStartIntegral(opts->GetInt("start_int","x>=0")),
         fStopIntegral(opts->GetInt("stop_int","x>=0")),
         fStartTail(opts->GetInt("start_tail",Form("x>%g",fStartIntegral))),
-        fPedestal(GetChannel().isFast()?1213:2680),
+        fPedestal(GetChannel().isFast()?900:2728),
         fPolarity(GetChannel().isFast()?1:-1),
         fFullIntegrator( fPedestal, fPolarity, fStartIntegral, fStopIntegral),
         fTailIntegrator( fPedestal, fPolarity, fStartTail, fStopIntegral){

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
@@ -1,0 +1,60 @@
+#include "TAPGeneratorFactory.h"
+#include "TAPAlgorithms.h"
+#include "SetupNavigator.h"
+#include "IntegralRatioAPGenerator.h"
+#include "TPulseIsland.h"
+#include "TIntegralRatioAnalysedPulse.h"
+#include <iostream>
+using std::cout;
+using std::endl;
+
+IntegralRatioAPGenerator::IntegralRatioAPGenerator(TAPGeneratorOptions* opts):
+    TVAnalysedPulseGenerator("IntegralRatio",opts),
+        fStartIntegral(opts->GetInt("start_int","x>0")),
+        fStopIntegral(opts->GetInt("stop_int","x>0")),
+        fStartTail(opts->GetInt("start_tail",Form("x>%g && x<%g",fStartIntegral,fStopIntegral))),
+        fPedestal(SetupNavigator::Instance()->GetPedestal(GetChannel())),
+        fPolarity(TSetupData::Instance()->GetTriggerPolarity(TSetupData::Instance()->GetBankName(GetChannel().str()))),
+        fFullIntegrator( fPedestal, fPolarity, fStartIntegral, fStopIntegral),
+        fTailIntegrator( fPedestal, fPolarity, fStartTail, fStopIntegral){
+    }
+IntegralRatioAPGenerator::~IntegralRatioAPGenerator(){}
+
+int IntegralRatioAPGenerator::ProcessPulses( 
+        const PulseIslandList& pulseList,
+        AnalysedPulseList& analysedList){
+
+    // Loop over all the TPIs given to us
+    double integral, tail;
+    TIntegralRatioAnalysedPulse* tap;
+    for (PulseIslandList::const_iterator tpi=pulseList.begin();
+            tpi!=pulseList.end(); tpi++){
+
+        // Analyse each TPI
+        integral=fFullIntegrator(*tpi);
+        tail=fTailIntegrator(*tpi);
+
+        // Now that we've found the information we were looking for make a TAP to
+        // hold it.  This method makes a TAP and sets the parent TPI info.  It needs
+        // the index of the parent TPI in the container as an argument
+        tap = MakeNewTAP<TIntegralRatioAnalysedPulse>(tpi-pulseList.begin());
+        tap->SetIntegral(integral);
+        tap->SetIntegralSmall(tail);
+        tap->SetIntegralRatio(tail/integral);
+        // Finally add the new TAP to the output list
+        analysedList.push_back(tap);
+    }
+
+    // Generators have a Debug method similar to modules
+    if(Debug()){
+        // They also have a unique ID, retrievable by GetSource and
+        // a GetChannel method to get the ID of just the channel
+        cout<<"Now running source: "<<GetSource().str()<<" which looks for TAPs on "
+            "channel: "<<GetChannel().str()<<'\n';
+    }
+
+    // returning 0 tells the caller that we were successful, return non-zero if not
+    return 0;
+}
+
+ALCAP_TAP_GENERATOR(IntegralRatio,start_int,start_tail,stop_int);

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
@@ -19,6 +19,7 @@ class IntegralRatioAPGenerator:public TVAnalysedPulseGenerator {
    // into more than one TAP
    virtual bool MayDivideTPIs(){return false;};
  private:
+        bool fStartTailAsFraction;
         double fStartIntegral;
         double fStopIntegral;
         double fStartTail;

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
@@ -25,8 +25,7 @@ class IntegralRatioAPGenerator:public TVAnalysedPulseGenerator {
         double fStartTail;
         double fPedestal;
         double fPolarity;
-        Algorithm::SimpleIntegral fHeadIntegrator;
-        Algorithm::SimpleIntegral fTailIntegrator;
+        Algorithm::IntegralRatio fIntegralRatioAlgo;
 
 };
 

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
@@ -1,0 +1,32 @@
+#ifndef INTEGRALRATIO_H__
+#define INTEGRALRATIO_H__
+
+#include "TSetupData.h"
+#include "TVAnalysedPulseGenerator.h"
+#include "definitions.h"
+namespace Algorithm{class SimpleIntegral ;}
+
+class IntegralRatioAPGenerator:public TVAnalysedPulseGenerator {
+
+ public:
+  IntegralRatioAPGenerator(TAPGeneratorOptions* opts);
+  virtual ~IntegralRatioAPGenerator();
+
+ public:
+   virtual int ProcessPulses( const PulseIslandList&,AnalysedPulseList&);
+
+   // This function should return true if this generator could break up a TPI
+   // into more than one TAP
+   virtual bool MayDivideTPIs(){return false;};
+ private:
+        double fStartIntegral;
+        double fStopIntegral;
+        double fStartTail;
+        double fPedestal;
+        double fPolarity;
+        Algorithm::SimpleIntegral fFullIntegrator;
+        Algorithm::SimpleIntegral fTailIntegrator;
+
+};
+
+#endif //INTEGRALRATIO_H__

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
@@ -24,7 +24,7 @@ class IntegralRatioAPGenerator:public TVAnalysedPulseGenerator {
         double fStartTail;
         double fPedestal;
         double fPolarity;
-        Algorithm::SimpleIntegral fFullIntegrator;
+        Algorithm::SimpleIntegral fHeadIntegrator;
         Algorithm::SimpleIntegral fTailIntegrator;
 
 };

--- a/analyzer/rootana/src/TAP_generators/MakeAnalysedPulses.cpp
+++ b/analyzer/rootana/src/TAP_generators/MakeAnalysedPulses.cpp
@@ -20,8 +20,11 @@ extern Long64_t* gEntryNumber;
 
 MakeAnalysedPulses::MakeAnalysedPulses(modules::options* opts):
   BaseModule("MakeAnalysedPulses",opts,false),
-  fSlowGeneratorType(opts->GetString("default_slow_generator","MaxBin")), fFastGeneratorType(opts->GetString("default_fast_generator","MaxBin")),
-  fChannelsToAnalyse(), fOptions(opts), fDefaultOpts(new TAPGeneratorOptions("default generator options")) {
+  fSlowGeneratorType(opts->GetString("default_slow_generator","MaxBin")),
+  fFastGeneratorType(opts->GetString("default_fast_generator","MaxBin")),
+  fChannelsToAnalyse(),
+  fOptions(opts),
+  fDefaultOpts(new TAPGeneratorOptions("default generator options")) {
   opts->GetVectorStringsByWhiteSpace("analyse_channels",fChannelsToAnalyse);
   if(Debug()) fDefaultOpts->SetOption("debug","true");
 }

--- a/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.cpp
@@ -4,5 +4,4 @@
 #include "Functions.h"
 
 void TIntegralRatioAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
-	}
 }

--- a/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.cpp
@@ -1,0 +1,8 @@
+#include "TIntegralRatioAnalysedPulse.h"
+#include "TF1.h"
+#include "TH1F.h"
+#include "Functions.h"
+
+void TIntegralRatioAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
+	}
+}

--- a/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.h
@@ -22,7 +22,7 @@ class TIntegralRatioAnalysedPulse:public TAnalysedPulse{
         /// @name Getters
         /// @{
         double GetIntegralSmall()const{return fIntegralSmall;}
-        double GetIntegralRato()const{return fIntegralRatio;}
+        double GetIntegralRatio()const{return fIntegralRatio;}
         /// @}
 
         /// @name Setters

--- a/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.h
@@ -1,5 +1,5 @@
-#ifndef TGAUSSFITANALYSEDPULSE_H
-#define TGAUSSFITANALYSEDPULSE_H
+#ifndef TINTEGRALRATIOAUSSFITANALYSEDPULSE_H
+#define TINTEGRALRATIOAUSSFITANALYSEDPULSE_H
 
 #include "TAnalysedPulse.h"
 #include <TObject.h>
@@ -29,7 +29,7 @@ class TIntegralRatioAnalysedPulse:public TAnalysedPulse{
         /// Set both the value and error for each field
         /// @{
         void SetIntegralSmall(const double& val){fIntegralSmall=val;}
-        void SetIntegralRato(const double& val){fIntegralRatio=val;}
+        void SetIntegralRatio(const double& val){fIntegralRatio=val;}
         /// @}
 
         /// @@brief overload the TAnalysedPulse::Draw method
@@ -42,4 +42,4 @@ class TIntegralRatioAnalysedPulse:public TAnalysedPulse{
         ClassDef(TIntegralRatioAnalysedPulse,1);
 };
 
-#endif // TIntegralRatioAnalysedPulse.h
+#endif //TINTEGRALRATIOAUSSFITANALYSEDPULSE_H

--- a/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.h
@@ -1,0 +1,45 @@
+#ifndef TGAUSSFITANALYSEDPULSE_H
+#define TGAUSSFITANALYSEDPULSE_H
+
+#include "TAnalysedPulse.h"
+#include <TObject.h>
+
+class TIntegralRatioAnalysedPulse:public TAnalysedPulse{
+    public:
+        /// Needed by ROOT but not expected to be used
+        TIntegralRatioAnalysedPulse():TAnalysedPulse(){};
+
+        /// @brief Construct a TIntegralRatioAnalysedPulse.
+        /// @details Same signature as for TAnalysedPulse so that MakeNewTAP can
+        /// create these specialised TAPs
+        TIntegralRatioAnalysedPulse(const IDs::source& sourceID,
+                const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
+            TAnalysedPulse(sourceID,parentID,parentTPI){}
+
+        // defined in .cpp file to force vtable to be built
+        virtual ~TIntegralRatioAnalysedPulse(){};
+
+        /// @name Getters
+        /// @{
+        double GetIntegralSmall()const{return fIntegralSmall;}
+        double GetIntegralRato()const{return fIntegralRatio;}
+        /// @}
+
+        /// @name Setters
+        /// Set both the value and error for each field
+        /// @{
+        void SetIntegralSmall(const double& val){fIntegralSmall=val;}
+        void SetIntegralRato(const double& val){fIntegralRatio=val;}
+        /// @}
+
+        /// @@brief overload the TAnalysedPulse::Draw method
+        virtual void Draw(const TH1F* tpi_pulse)const;
+
+    private:
+        double fIntegralSmall;
+        double fIntegralRatio;
+
+        ClassDef(TIntegralRatioAnalysedPulse,1);
+};
+
+#endif // TIntegralRatioAnalysedPulse.h

--- a/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TIntegralRatioAnalysedPulse.h
@@ -32,12 +32,24 @@ class TIntegralRatioAnalysedPulse:public TAnalysedPulse{
         void SetIntegralRatio(const double& val){fIntegralRatio=val;}
         /// @}
 
+        double GetMean()const{return fMean;}
+        double GetMin ()const{return fMin;}
+        double GetMax ()const{return fMax;}
+
+        void SetMean(double v){fMean=v;}
+        void SetMin (double v){fMin =v;}
+        void SetMax (double v){fMax =v;}
+
         /// @@brief overload the TAnalysedPulse::Draw method
         virtual void Draw(const TH1F* tpi_pulse)const;
 
     private:
         double fIntegralSmall;
         double fIntegralRatio;
+
+        double fMean;
+        double fMin;
+        double fMax;
 
         ClassDef(TIntegralRatioAnalysedPulse,1);
 };

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 #include <iostream>
 
@@ -67,10 +68,18 @@ double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
   
   double length = samples.size();
   double tempint = 0;
-  for(std::vector<int>::const_iterator sIt = samples.begin(); sIt != samples.end(); sIt++)
-    tempint += *sIt;
-  
-  double integral = trigger_polarity * (tempint - (pedestal * length));
+  typedef std::vector<int> SampleVector;
+  SampleVector::const_iterator begin=samples.begin()+start;
+  if(start > length 
+          || ( stop>0 && stop<start ) 
+          || (stop<0 && length+stop <start) ){
+      throw std::out_of_range("Algorithm::SimpleIntegral::operator() bad integral range" );
+  }
+  SampleVector::const_iterator end=stop>0?samples.begin()+stop: samples.end()+stop;
+  for(SampleVector::const_iterator sIt = begin; sIt != end; ++sIt)
+      tempint += *sIt;
+
+  double integral = trigger_polarity * (tempint - (pedestal * (end-begin)));
 
   return integral;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <numeric>
 #include <cmath>
 #include <numeric>
 #include <stdexcept>
@@ -66,7 +67,6 @@ double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
   const std::vector<int>& samples = tpi->GetSamples();
   
   double length = samples.size();
-  double tempint = 0;
   typedef std::vector<int> SampleVector;
   SampleVector::const_iterator begin=samples.begin()+start;
   if(start > length 
@@ -74,9 +74,8 @@ double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
           || (stop<0 && length+stop <start) ){
       throw std::out_of_range("Algorithm::SimpleIntegral::operator() bad integral range" );
   }
-  SampleVector::const_iterator end=stop>0?samples.begin()+stop: samples.end()+stop;
-  for(SampleVector::const_iterator sIt = begin; sIt != end; ++sIt)
-      tempint += *sIt;
+  SampleVector::const_iterator end=(stop>0?samples.begin():samples.end())+stop;
+  double tempint=std::accumulate(begin,end,0);
 
   double integral = trigger_polarity * (tempint - (pedestal * (end-begin)));
 

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -82,3 +82,11 @@ double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
 
   return integral;
 }
+
+double Algorithm::IntegralRatio::operator() (const TPulseIsland* tpi){
+     SetPedestal(*std::min_element(tpi->GetSamples().begin(), tpi->GetSamples().end()));
+     fHead=fHeadIntegrator(tpi);
+     fTail=fTailIntegrator(tpi);
+     return GetRatio();
+  }
+

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <numeric>
 #include <cmath>
 #include <stdexcept>
 
@@ -67,7 +68,6 @@ double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
   const std::vector<int>& samples = tpi->GetSamples();
   
   double length = samples.size();
-  double tempint = 0;
   typedef std::vector<int> SampleVector;
   SampleVector::const_iterator begin=samples.begin()+start;
   if(start > length 
@@ -75,9 +75,8 @@ double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
           || (stop<0 && length+stop <start) ){
       throw std::out_of_range("Algorithm::SimpleIntegral::operator() bad integral range" );
   }
-  SampleVector::const_iterator end=stop>0?samples.begin()+stop: samples.end()+stop;
-  for(SampleVector::const_iterator sIt = begin; sIt != end; ++sIt)
-      tempint += *sIt;
+  SampleVector::const_iterator end=(stop>0?samples.begin():samples.end())+stop;
+  double tempint=std::accumulate(begin,end,0);
 
   double integral = trigger_polarity * (tempint - (pedestal * (end-begin)));
 

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -81,3 +81,11 @@ double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
 
   return integral;
 }
+
+double Algorithm::IntegralRatio::operator() (const TPulseIsland* tpi){
+     SetPedestal(*std::min_element(tpi->GetSamples().begin(), tpi->GetSamples().end()));
+     fHead=fHeadIntegrator(tpi);
+     fTail=fTailIntegrator(tpi);
+     return GetRatio();
+  }
+

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -63,7 +63,7 @@ double Algorithm::ConstantFractionTime::operator() (const TPulseIsland* tpi) con
   return (dx + (double)tpi->GetTimeStamp()) * clock_tick_in_ns - time_shift;
 }
 
-double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi) {
+double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi)const {
   const std::vector<int>& samples = tpi->GetSamples();
   
   double length = samples.size();

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -53,11 +53,18 @@ struct Algorithm::ConstantFractionTime {
 struct Algorithm::SimpleIntegral {
   public:
   SimpleIntegral(double ped, int trig_pol)
-    :trigger_polarity(trig_pol), pedestal(ped){}
+    :trigger_polarity(trig_pol), pedestal(ped),start(0),stop(0){}
+  /// @param first Start integral from "samples.begin()+first" sample
+  /// @param last End integral at "samples.begin()+last" if last>0 or
+  /// "samples.end()+last" if last<=0 
+  SimpleIntegral(double ped, int trig_pol, int first, int last)
+    :trigger_polarity(trig_pol), pedestal(ped),start(first),stop(last){}
   double operator() (const TPulseIsland* tpi);
 
   const int trigger_polarity;
   const double pedestal;
+  const int start;
+  const int stop;
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -62,6 +62,16 @@ struct Algorithm::SimpleIntegral {
   double operator() (const TPulseIsland* tpi);
 
   const int trigger_polarity;
+
+  double GetPedestal()const{return pedestal;};
+  int GetStart()const{return start;};
+  int GetStop()const{return stop;};
+
+  void SetPedestal(double v){pedestal=v;};
+  void SetStart(int v){start=v;};
+  void SetStop(int v){stop=v;};
+
+private:
   double pedestal;
   int start;
   int stop;

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -62,8 +62,8 @@ struct Algorithm::SimpleIntegral {
 
   const int trigger_polarity;
   double pedestal;
-  const int start;
-  const int stop;
+  int start;
+  int stop;
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -52,11 +52,18 @@ struct Algorithm::ConstantFractionTime {
 struct Algorithm::SimpleIntegral {
   public:
   SimpleIntegral(double ped, int trig_pol)
-    :trigger_polarity(trig_pol), pedestal(ped){}
-  double operator() (const TPulseIsland* tpi) const;
+    :trigger_polarity(trig_pol), pedestal(ped),start(0),stop(0){}
+  /// @param first Start integral from "samples.begin()+first" sample
+  /// @param last End integral at "samples.begin()+last" if last>0 or
+  /// "samples.end()+last" if last<=0 
+  SimpleIntegral(double ped, int trig_pol, int first, int last)
+    :trigger_polarity(trig_pol), pedestal(ped),start(first),stop(last){}
+  double operator() (const TPulseIsland* tpi);
 
   const int trigger_polarity;
   const double pedestal;
+  const int start;
+  const int stop;
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -11,6 +11,7 @@ namespace Algorithm {
   struct MaxBinTime;
   struct ConstantFractionTime;
   struct SimpleIntegral;
+  struct IntegralRatio;
 };
 
 struct Algorithm::MaxBinAmplitude {
@@ -75,6 +76,32 @@ private:
   double pedestal;
   int start;
   int stop;
+};
+
+struct Algorithm::IntegralRatio{
+  IntegralRatio(int begin,int tail, int end, int trig_pol,double ped=0)
+    :fTailIntegrator(ped,trig_pol,tail,end)
+     ,fHeadIntegrator(ped,trig_pol,begin,tail){
+     }
+  double operator() (const TPulseIsland* tpi){
+     double head=fHeadIntegrator(tpi);
+     fTail=fTailIntegrator(tpi);
+     fTotal=head+fTail;
+     return GetRatio();
+  }
+
+  double GetRatio()const {return fTail/fTotal;}
+  double GetTotal()const{return fTotal;}
+  double GetTail()const{return fTail;}
+  
+  void SetTailStart(int v){ fTailIntegrator.SetStart(v); fHeadIntegrator.SetStop(v);}
+  void SetPedestal(double v){ fTailIntegrator.SetPedestal(v); fHeadIntegrator.SetPedestal(v);}
+
+private:
+  double fTail;
+  double fTotal;
+  Algorithm::SimpleIntegral fTailIntegrator;
+  Algorithm::SimpleIntegral fHeadIntegrator;
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -63,8 +63,8 @@ struct Algorithm::SimpleIntegral {
 
   const int trigger_polarity;
   double pedestal;
-  const int start;
-  const int stop;
+  int start;
+  int stop;
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -61,6 +61,16 @@ struct Algorithm::SimpleIntegral {
   double operator() (const TPulseIsland* tpi);
 
   const int trigger_polarity;
+
+  double GetPedestal()const{return pedestal;};
+  int GetStart()const{return start;};
+  int GetStop()const{return stop;};
+
+  void SetPedestal(double v){pedestal=v;};
+  void SetStart(int v){start=v;};
+  void SetStop(int v){stop=v;};
+
+private:
   double pedestal;
   int start;
   int stop;

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -61,7 +61,7 @@ struct Algorithm::SimpleIntegral {
   double operator() (const TPulseIsland* tpi);
 
   const int trigger_polarity;
-  const double pedestal;
+  double pedestal;
   const int start;
   const int stop;
 };

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -11,6 +11,7 @@ namespace Algorithm {
   struct MaxBinTime;
   struct ConstantFractionTime;
   struct SimpleIntegral;
+  struct IntegralRatio;
 };
 
 struct Algorithm::MaxBinAmplitude {
@@ -74,6 +75,32 @@ private:
   double pedestal;
   int start;
   int stop;
+};
+
+struct Algorithm::IntegralRatio{
+  IntegralRatio(int begin,int tail, int end, int trig_pol,double ped=0)
+    :fTailIntegrator(ped,trig_pol,tail,end)
+     ,fHeadIntegrator(ped,trig_pol,begin,tail){
+     }
+  double operator() (const TPulseIsland* tpi){
+     double head=fHeadIntegrator(tpi);
+     fTail=fTailIntegrator(tpi);
+     fTotal=head+fTail;
+     return GetRatio();
+  }
+
+  double GetRatio()const {return fTail/fTotal;}
+  double GetTotal()const{return fTotal;}
+  double GetTail()const{return fTail;}
+  
+  void SetTailStart(int v){ fTailIntegrator.SetStart(v); fHeadIntegrator.SetStop(v);}
+  void SetPedestal(double v){ fTailIntegrator.SetPedestal(v); fHeadIntegrator.SetPedestal(v);}
+
+private:
+  double fTail;
+  double fTotal;
+  Algorithm::SimpleIntegral fTailIntegrator;
+  Algorithm::SimpleIntegral fHeadIntegrator;
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -62,7 +62,7 @@ struct Algorithm::SimpleIntegral {
   double operator() (const TPulseIsland* tpi);
 
   const int trigger_polarity;
-  const double pedestal;
+  double pedestal;
   const int start;
   const int stop;
 };

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -83,15 +83,10 @@ struct Algorithm::IntegralRatio{
     :fTailIntegrator(ped,trig_pol,tail,end)
      ,fHeadIntegrator(ped,trig_pol,begin,tail){
      }
-  double operator() (const TPulseIsland* tpi){
-     double head=fHeadIntegrator(tpi);
-     fTail=fTailIntegrator(tpi);
-     fTotal=head+fTail;
-     return GetRatio();
-  }
+  double operator() (const TPulseIsland* tpi);
 
-  double GetRatio()const {return fTail/fTotal;}
-  double GetTotal()const{return fTotal;}
+  double GetRatio()const {return fTail/(fHead+fTail);}
+  double GetTotal()const{return fHead+fTail;}
   double GetTail()const{return fTail;}
   
   void SetTailStart(int v){ fTailIntegrator.SetStart(v); fHeadIntegrator.SetStop(v);}
@@ -99,7 +94,7 @@ struct Algorithm::IntegralRatio{
 
 private:
   double fTail;
-  double fTotal;
+  double fHead;
   Algorithm::SimpleIntegral fTailIntegrator;
   Algorithm::SimpleIntegral fHeadIntegrator;
 };

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -82,15 +82,10 @@ struct Algorithm::IntegralRatio{
     :fTailIntegrator(ped,trig_pol,tail,end)
      ,fHeadIntegrator(ped,trig_pol,begin,tail){
      }
-  double operator() (const TPulseIsland* tpi){
-     double head=fHeadIntegrator(tpi);
-     fTail=fTailIntegrator(tpi);
-     fTotal=head+fTail;
-     return GetRatio();
-  }
+  double operator() (const TPulseIsland* tpi);
 
-  double GetRatio()const {return fTail/fTotal;}
-  double GetTotal()const{return fTotal;}
+  double GetRatio()const {return fTail/(fHead+fTail);}
+  double GetTotal()const{return fHead+fTail;}
   double GetTail()const{return fTail;}
   
   void SetTailStart(int v){ fTailIntegrator.SetStart(v); fHeadIntegrator.SetStop(v);}
@@ -98,7 +93,7 @@ struct Algorithm::IntegralRatio{
 
 private:
   double fTail;
-  double fTotal;
+  double fHead;
   Algorithm::SimpleIntegral fTailIntegrator;
   Algorithm::SimpleIntegral fHeadIntegrator;
 };

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -59,7 +59,7 @@ struct Algorithm::SimpleIntegral {
   /// "samples.end()+last" if last<=0 
   SimpleIntegral(double ped, int trig_pol, int first, int last)
     :trigger_polarity(trig_pol), pedestal(ped),start(first),stop(last){}
-  double operator() (const TPulseIsland* tpi);
+  double operator() (const TPulseIsland* tpi)const;
 
   const int trigger_polarity;
 

--- a/analyzer/rootana/src/files.make
+++ b/analyzer/rootana/src/files.make
@@ -16,6 +16,7 @@ DIRS += src/\
 ROOT_DICT_CLASSES:=TAnalysedPulseMapWrapper\
 	TDetectorPulse\
 	TGaussFitAnalysedPulse\
+	TIntegralRatioAnalysedPulse\
 	IdChannel\
 	IdGenerator\
 	IdSource\

--- a/analyzer/rootana/src/framework/BaseModule.cpp
+++ b/analyzer/rootana/src/framework/BaseModule.cpp
@@ -73,3 +73,10 @@ int BaseModule::Postprocess(TGlobalData *gData, const TSetupData *gSetup){
 
   return ret;
 }
+
+TDirectory* BaseModule::GetDirectory(const std::string& name){
+  if(name.empty()) return fDirectory;
+  TDirectory* dir=fDirectory->GetDirectory(name.c_str());
+  if(dir) return dir;
+  return fDirectory->mkdir(name.c_str());
+}

--- a/analyzer/rootana/src/framework/BaseModule.h
+++ b/analyzer/rootana/src/framework/BaseModule.h
@@ -72,6 +72,7 @@ class BaseModule
 
   /// Get the TDirectory for this module
   TDirectory* GetDirectory()const {return fDirectory;}
+  TDirectory* GetDirectory(const std::string& name="");
 
  private:
    /// @brief The big kahuna.  Overload this in the derived class and it will be

--- a/analyzer/rootana/src/framework/IdChannel.cpp
+++ b/analyzer/rootana/src/framework/IdChannel.cpp
@@ -102,7 +102,7 @@ std::string IDs::channel::GetSlowFastString(SlowFast_t sf){
 IDs::SlowFast_t IDs::channel::GetSlowFastEnum(const std::string& type){
 	if(modules::parser::iequals(type,"-S") || type=="slow") return kSlow;
 	else if(modules::parser::iequals(type,"-F")|| type=="fast") return kFast;
-	else if(type=="*"|| type=="any") return kAnySlowFast;
+	else if(type=="-*"|| type=="any") return kAnySlowFast;
 	return kNotApplicable;
 }
 
@@ -122,3 +122,7 @@ std::ostream& operator<< (ostream& os ,const IDs::channel& id){
   return os;
 }
 
+void IDs::channel::Debug()const{
+    std::cout<<"Detector: "<<GetDetectorString(Detector())<<std::endl;
+    std::cout<<"Slow/fast: "<<GetSlowFastString(SlowFast())<<std::endl;
+}

--- a/analyzer/rootana/src/framework/IdChannel.h
+++ b/analyzer/rootana/src/framework/IdChannel.h
@@ -147,6 +147,9 @@ public:
   /// Returns kErrorSlowFast if the given string doesn't match any known value
   static SlowFast_t GetSlowFastEnum(const std::string& sf);
 
+  /// Print the individual components of the ID
+  void Debug()const;
+
 private:
   /// The detector that produced this channel
   Detector_t fDetector;

--- a/analyzer/rootana/src/framework/IdGenerator.cpp
+++ b/analyzer/rootana/src/framework/IdGenerator.cpp
@@ -26,3 +26,8 @@ IDs::generator& IDs::generator::operator=(const std::string& rhs){
     }
     return *this;
 }
+
+void IDs::generator::Debug()const{
+    std::cout<<"Generator: "<<Type()<<std::endl;
+    std::cout<<"Config: "<<Config()<<std::endl;
+}

--- a/analyzer/rootana/src/framework/IdGenerator.h
+++ b/analyzer/rootana/src/framework/IdGenerator.h
@@ -86,6 +86,9 @@ class IDs::generator:public TObject{
     /// Check if any part of the ID is a wildcard
     bool isWildCard() const { return isWildCardConfig() || isWildCardType(); }
 
+    /// Print the individual components of the ID
+    void Debug()const;
+
 	private:
 	/// Stores the type of this generator
 	Generator_t fType;

--- a/analyzer/rootana/src/framework/IdSource.cpp
+++ b/analyzer/rootana/src/framework/IdSource.cpp
@@ -1,6 +1,6 @@
 #include "IdSource.h"
 #include <iostream>
-
+#include "debug_tools.h"
 ClassImp(IDs::source);
 
 std::string IDs::source::str()const{
@@ -23,4 +23,9 @@ IDs::source& IDs::source::operator=(const std::string& rhs){
         Generator()=rhs.substr(delim+1);
     }
     return *this;
+}
+
+void IDs::source::Debug()const{
+    Channel().Debug();
+    Generator().Debug();
 }

--- a/analyzer/rootana/src/framework/IdSource.h
+++ b/analyzer/rootana/src/framework/IdSource.h
@@ -44,7 +44,7 @@ class IDs::source:public TObject{
   /// @param gen The type of generator used to analyse the channel
   /// @param cfg The generator's configuration
   source(const std::string& det, const std::string& type,
-         const std::string& gen, const std::string& cfg=IDs::kAnyConfig)
+         const std::string& gen, const std::string& cfg=IDs::kDefaultConfig)
     : fChannel(det,type), fGenerator(gen,cfg) {};
 
   /// Construct using enums for each argument of the contained generator and
@@ -54,7 +54,7 @@ class IDs::source:public TObject{
   /// @param type The type of timing filter (Slow / Fast) used in this source
   /// @param gen The type of generator used to analyse the channel
   /// @param cfg The generator's configuration
-  source(Detector_t det, SlowFast_t type,const Generator_t& t ,const Config_t& c)
+  source(Detector_t det, SlowFast_t type,const Generator_t& t ,const Config_t& c=IDs::kDefaultConfig)
   :  fChannel(det,type),fGenerator(t,c){};
   
   virtual ~source(){};
@@ -115,6 +115,9 @@ class IDs::source:public TObject{
 
   /// Check if the Channel is slow
   bool isSlow() const {return Channel().isSlow();};
+
+  /// Print the individual components of the source
+  void Debug()const;
 
  private:
   channel fChannel;

--- a/analyzer/rootana/src/plotters/ExportPulse.cpp
+++ b/analyzer/rootana/src/plotters/ExportPulse.cpp
@@ -231,10 +231,10 @@ int ExportPulse::PlotTPI(const TPulseIsland* pulse, const PulseInfo_t& info)cons
   //double max= min + num_samples * fClockTick;
   TH1F* hPulse = new TH1F(hist.c_str(), title.str().c_str(), num_samples,min,max);
   
-  double pedestal_error = SetupNavigator::Instance()->GetNoise(IDs::channel(info.detname));
+  //double pedestal_error = SetupNavigator::Instance()->GetNoise(IDs::channel(info.detname));
   for ( size_t i=0;i <num_samples; ++i) {
     hPulse->SetBinContent(i+1, pulse->GetSamples().at(i));
-    hPulse->SetBinError(i+1, pedestal_error);
+    hPulse->SetBinError(i+1, 0);//pedestal_error);
   }
   
   return 0;

--- a/analyzer/rootana/src/plotters/PulseViewer.cpp
+++ b/analyzer/rootana/src/plotters/PulseViewer.cpp
@@ -261,6 +261,7 @@ int PulseViewer::AfterLastEntry(TGlobalData* gData, const TSetupData* setup){
           cout<<prefix<<" ----- | ------------ "<<endl;
       }
       cout<<prefix<<"Total pulses plotted = "<<fTotalPlotted<<endl;
+      cout<<"Summary for pulse criteria: ("<<fTriggerCondition <<") on channel "<<fSource<<endl;
 
   }
 

--- a/analyzer/rootana/src/plotters/PulseViewer.cpp
+++ b/analyzer/rootana/src/plotters/PulseViewer.cpp
@@ -9,6 +9,7 @@
 #include "debug_tools.h"
 #include "IdSource.h"
 #include "EventNavigator.h"
+#include "TIntegralRatioAnalysedPulse.h"
 
 #include <TFormula.h>
 
@@ -20,16 +21,26 @@ using std::endl;
 using modules::parser::GetOneWord;
 using modules::parser::GetDouble;
 
+#define GetVals(array,pulse)\
+            for(ParameterKeys::const_iterator i_key=fAvailableParams.begin(); \
+              i_key!=fAvailableParams.end();++i_key){\
+               array[i_key->second]=GetParameterValue(pulse,i_key->second);\
+            }
+
 extern SourceAnalPulseMap gAnalysedPulseMap;
+
 PulseViewer::ParameterKeys PulseViewer::fAvailableParams;
+PulseViewer::PulseKeys PulseViewer::fAvailablePulseTypes;
 
 PulseViewer::PulseViewer(modules::options* opts):
-    BaseModule("PulseViewer",opts),fTotalPlotted(0),fFormula(NULL){
+    BaseModule("PulseViewer",opts),fTotalPlotted(0),fFormula(NULL),fEvent(0){
         fRequestedSource=opts->GetString("source"); 
+        fRequestedPulseType=opts->GetString("pulse_type","TAnalysedPulse"); 
         fSource.Channel()=fRequestedSource;
         fTriggerCondition=opts->GetString("trigger"); 
-        fSummarize=opts->GetBool("summarize"); 
+        fSummarize=opts->GetFlag("summarize"); 
         fMaxToPlot=opts->GetInt("max_plots",-1);
+        fMaxToPlotPerEvent=opts->GetInt("max_plots_event",-1);
         fStopAtMax=opts->GetBool("stop_at_max_plots",true);
     }
 
@@ -60,10 +71,40 @@ int PulseViewer::BeforeFirstEntry(TGlobalData* gData, const TSetupData* setup){
      fAvailableParams["energy"]=kEnergy;
      fAvailableParams["pedestal"]=kPedestal;
      fAvailableParams["trigger_time"]=kTriggerTime;
+     fAvailableParams["event_no"]=kEventNo;
    }
+
+   if(fAvailablePulseTypes.empty()){
+     fAvailablePulseTypes["TAnalysedPulse"]=kTAP;
+     fAvailablePulseTypes["IntegralRatioAP"]=kIntegralRatioAP;
+   }
+
+   int ret_val= CheckPulseType(fRequestedPulseType);
+   if(ret_val) return ret_val;
 
    // Parse the trigger string
    return ParseTriggerString(fTriggerCondition);
+}
+
+int PulseViewer::CheckPulseType(const std::string& pulse_type){
+   PulseKeys::const_iterator i_type=fAvailablePulseTypes.find(pulse_type);
+   if(i_type==fAvailablePulseTypes.end()) {
+      cout<<"PulseViewer::CheckPulseType: Error: Bad pulse_type: "<<pulse_type<<endl;
+     for(PulseKeys::const_iterator it=fAvailablePulseTypes.begin();
+             it!=fAvailablePulseTypes.end(); it++){
+         cout<<"    |-"<<it->first<<endl;
+     }
+     return 1;
+   }
+   fPulseType=i_type->second;
+   switch(fPulseType){
+      case kTAP: break;
+      case kIntegralRatioAP:
+         fAvailableParams["Integral_ratio"]=kIntegralRatio;
+         fAvailableParams["Integral_tail"]=kIntegralTail;
+      break;
+   }
+   return 0;
 }
 
 int PulseViewer::ParseTriggerString(const std::string& trigger_condition){
@@ -122,37 +163,49 @@ int PulseViewer::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
     for(AnalysedPulseList::iterator i_pulse=allTAPs->begin();
 		i_pulse!=allTAPs->end() && retVal==0;
 		i_pulse++){
+            if(fEvent==0){
+                retVal=TestPulseType(*i_pulse);
+            }
 	    retVal=ConsiderDrawing((*i_pulse)->GetParentID() ,*i_pulse);
     }
     if(retVal!=0) return retVal;
 
+    fEvent++;
+
   return 0;
 }
 
-double PulseViewer::GetParameterValue(const TAnalysedPulse& pulse,const ParameterType& parameter){
-	double retVal=0;
-	switch (parameter){
-  	case kAmplitude:
-		retVal=pulse.GetAmplitude();
-		break;
-  	case kTime:
-		retVal=pulse.GetTime();
-		break;
-  	case kIntegral:
-		retVal=pulse.GetIntegral();
-		break;
-  	case kTPILength:
-        retVal=pulse.GetTPILength();
-        break;
-    case kEnergy:
-        retVal=pulse.GetEnergy();
-        break;
-    case kPedestal:
-        retVal=pulse.GetPedestal();
-        break;
-    case kTriggerTime:
-        retVal=pulse.GetTriggerTime();
-        break;
+bool PulseViewer::TestPulseType(const TAnalysedPulse* pulse){
+  switch(fPulseType){
+    case kTAP: return false;
+    case kIntegralRatioAP: return dynamic_cast<const TIntegralRatioAnalysedPulse*>(pulse);
+  }
+  return false;
+}
+
+double PulseViewer::GetParameterValue(const TAnalysedPulse* pulse,const ParameterType& parameter){
+   double retVal=0;
+   switch (parameter){
+       case kAmplitude: retVal=pulse->GetAmplitude(); break;
+       case kTime: retVal=pulse->GetTime(); break;
+       case kIntegral: retVal=pulse->GetIntegral(); break;
+       case kTPILength: retVal=pulse->GetTPILength(); break;
+       case kEnergy: retVal=pulse->GetEnergy(); break;
+       case kPedestal: retVal=pulse->GetPedestal(); break;
+       case kTriggerTime: retVal=pulse->GetTriggerTime(); break;
+       case kEventNo: retVal=fEvent; break;
+       default: retVal=definitions::DefaultValue;
+           cout<<"PulseViewer::GetParameterValue: Error: Cannot get param: "<<parameter<<" from a TAnalysedPulse"<<endl;
+    }
+    return retVal;
+}
+
+double PulseViewer::GetParameterValue(const TIntegralRatioAnalysedPulse* pulse,const ParameterType& parameter){
+   double retVal=0;
+   switch (parameter){
+       case kIntegralTail: retVal=pulse->GetIntegralSmall(); break;
+       case kIntegralRatio: retVal=pulse->GetIntegralRatio(); break;
+       default: retVal=GetParameterValue( static_cast<const TAnalysedPulse*>(pulse),parameter);
     }
     return retVal;
 }
@@ -160,9 +213,13 @@ double PulseViewer::GetParameterValue(const TAnalysedPulse& pulse,const Paramete
 int PulseViewer::ConsiderDrawing(const TAnalysedPulseID& id, const TAnalysedPulse* pulse){
   // Check pulse passes trigger condition
     double vals[fAvailableParams.size()];
-    for(ParameterKeys::const_iterator i_key=fAvailableParams.begin();
-            i_key!=fAvailableParams.end();++i_key){
-        vals[i_key->second]=GetParameterValue(*pulse,i_key->second);
+    switch (fPulseType){
+       case kTAP: GetVals(vals,pulse); break;
+       case kIntegralRatioAP: 
+            const TIntegralRatioAnalysedPulse* ir_pulse
+              =static_cast<const TIntegralRatioAnalysedPulse*>(pulse);
+            GetVals(vals,ir_pulse);
+            break;
     }
     fFormula->SetParameters(vals);
     double value=fFormula->Eval(0);
@@ -190,14 +247,14 @@ int PulseViewer::AfterLastEntry(TGlobalData* gData, const TSetupData* setup){
       const std::string prefix="     ";
       cout<<"Summary for pulse criteria: ("<<fTriggerCondition <<") on channel "<<fSource<<endl;
       if(!fPulsesPlotted.empty()){
-          cout<<prefix<<" Event | Pulses drawn (times requested)"<<endl;
+          cout<<prefix<<" Event | Pulse IDs drawn (sub_pulse ID)"<<endl;
           cout<<prefix<<" ----- | ------------ "<<endl;
           for(EventPulseIDList_t::const_iterator i_event=fPulsesPlotted.begin();
                   i_event!=fPulsesPlotted.end();i_event++){
               cout<<prefix<<std::setw(6)<< i_event->first<<" | ";
               for(PulseIDList_t::const_iterator i_pulse=i_event->second.begin();
                       i_pulse!=i_event->second.end();i_pulse++){
-                  cout<<std::setw(2)<< i_pulse->first<<"("<< i_pulse->second<<")"<<", ";
+                  cout<<std::setw(2)<< i_pulse->first <<"("<< i_pulse->second<<")" <<", ";
               }
               cout<<endl;
           }
@@ -210,4 +267,4 @@ int PulseViewer::AfterLastEntry(TGlobalData* gData, const TSetupData* setup){
   return 0;
 }
 
-ALCAP_REGISTER_MODULE(PulseViewer,source,trigger,summarize);
+ALCAP_REGISTER_MODULE(PulseViewer,source,trigger,pulse_type,summarize);

--- a/analyzer/rootana/src/plotters/PulseViewer.h
+++ b/analyzer/rootana/src/plotters/PulseViewer.h
@@ -7,6 +7,7 @@ class TGlobalData;
 class TSetupData;
 namespace modules {class options;}
 class TFormula;
+class TIntegralRatioAnalysedPulse;
 
 /// @brief Module to plot pulses meeting a certain criteria
 /// @see https://github.com/alcap-org/AlcapDAQ/wiki/rootana-module-PulseViewer
@@ -17,8 +18,6 @@ class PulseViewer : public BaseModule{
     typedef std::map<TPulseIslandID,int> PulseIDList_t;
     typedef std::map<EventID_t,PulseIDList_t> EventPulseIDList_t;
 
-    enum  TriggerType {kE, kG, kL, kGE, kLE};
-
     enum  ParameterType {
         kAmplitude,
         kTime,
@@ -26,7 +25,15 @@ class PulseViewer : public BaseModule{
         kTPILength,
         kEnergy,
         kPedestal,
-        kTriggerTime
+        kTriggerTime,
+        kEventNo,
+        kIntegralRatio,
+        kIntegralTail
+    };
+
+    enum PulseType{
+        kTAP,
+        kIntegralRatioAP
     };
 
     public:
@@ -46,27 +53,36 @@ class PulseViewer : public BaseModule{
     int ConsiderDrawing(const TAnalysedPulseID& id, const TAnalysedPulse* i_pulse);
 
     /// Get the value of interest from pulse
-    double GetParameterValue(const TAnalysedPulse& pulse,const ParameterType& parameter);
+    double GetParameterValue(const TAnalysedPulse* pulse,const ParameterType& parameter);
+    double GetParameterValue(const TIntegralRatioAnalysedPulse* pulse,const ParameterType& parameter);
 
     /// Parse a trigger condition and set up the values needed to handle it
     /// @return 0 on success, non-zero otherwise
     int ParseTriggerString(const std::string& trigger_condition);
+    int CheckPulseType(const std::string& pulse_type);
+    bool TestPulseType(const TAnalysedPulse* pulse_type);
 
     /// Dump a summary of what was done
     bool SummarisePlots(){return fSummarize;};
 
     private:
     IDs::source fSource;
-    std::string fTriggerCondition;
     std::string fRequestedSource;
+    std::string fTriggerCondition;
+    PulseType fPulseType;
+    std::string fRequestedPulseType;
     long int fTotalPlotted;
-    long int fMaxToPlot;
+    long int fMaxToPlot, fMaxToPlotPerEvent;
     bool fSummarize, fStopAtMax;
     EventPulseIDList_t fPulsesPlotted;
     TFormula* fFormula;
+    int fEvent;
 
     typedef std::map<std::string,ParameterType> ParameterKeys;
     static ParameterKeys fAvailableParams;
+
+    typedef std::map<std::string,PulseType> PulseKeys;
+    static PulseKeys fAvailablePulseTypes;
 };
 
 #endif //PULSEVIEWER_H_


### PR DESCRIPTION
This is to merge in the code I added to get the integral ratio working for pile-up.   I had to make some changes to common files so I'm going to merge through a pull request, including in the I(nfamous)D classes.

Here's my summary of changes:
- New files: TIntegralRatioAnalysedPulse, IntegralRatioAPGenerator,  PlotIntegralRatios.
- Changes to PulseViewer to allow plotting from IntegralRatioAPs.  The approach is reasonably extendable, though could be improved.
- Makefile: new rootcint target
  -`Algorithm::SimpInt` - add integral limits, defaults use full waveform range as before.  Also changed implementation to use `std::accumulate`.  Pedestal is not a constant, but can only be accessed through getters and setters.
- New `Algorithm::IntegralRatio` - Implements the integral ratio algorithm using the SimpInt algorithm behind the scenes.
- Added a `GetDirectory(const char*)` method to `BaseModule`.  It gets or else creates a sub-directory of the modules' directory, in case a module makes many plots and wants to provide better structure (such as a directory per source for example) in the output file.
- `IDs::source` constructors with 4 arguments was changed so that if no value for the 4th argument is specified (giving the configuration of a generator) the generator is created with the `kDefaultConfig` value.  This is the same as for generators but may break existing code since it was previously giving `kAnyConfig`.
- `IDs::channel` the two possible strings to specify channels that are either fast or slow is now either `-*` or `any` as opposed to `*` or `any`.  This matches the string used for assignment from a string.
- New debug method for all IDs to print each sub-field of the ID.
