### PR TITLE
Feature/bk template ap generator

### DIFF
--- a/analyzer/rootana/src/LibraryLinkDef.h
+++ b/analyzer/rootana/src/LibraryLinkDef.h
@@ -13,6 +13,7 @@
 
 #pragma link C++ class TIntegralRatioAnalysedPulse+;
 #pragma link C++ class TGaussFitAnalysedPulse+;
+#pragma link C++ class TTemplateConvolveAnalysedPulse+;
 #pragma link C++ class TTemplateFitAnalysedPulse+;
 #pragma link C++ class TAnalysedPulse+;
 #pragma link C++ class TDetectorPulse+;

--- a/analyzer/rootana/src/LibraryLinkDef.h
+++ b/analyzer/rootana/src/LibraryLinkDef.h
@@ -13,6 +13,7 @@
 
 #pragma link C++ class TIntegralRatioAnalysedPulse+;
 #pragma link C++ class TGaussFitAnalysedPulse+;
+#pragma link C++ class TTemplateFitAnalysedPulse+;
 #pragma link C++ class TAnalysedPulse+;
 #pragma link C++ class TDetectorPulse+;
 #pragma link C++ class vector<TAnalysedPulse*>+;

--- a/analyzer/rootana/src/SavePulses.cpp
+++ b/analyzer/rootana/src/SavePulses.cpp
@@ -54,15 +54,15 @@ int SavePulses::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
 int SavePulses::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
     const AnalysedPulseList* pulseList;
     TClonesArray* array;
-    TAnalysedPulse* tap;
+    TObject* tap;
     for (SourceAnalPulseMap::const_iterator i_source = gAnalysedPulseMap.begin();
             i_source != gAnalysedPulseMap.end(); ++i_source) {
         pulseList=&i_source->second;
         array=fArrays[i_source->first];
         for (AnalysedPulseList::const_iterator i_pulse = pulseList->begin();
                 i_pulse != pulseList->end(); ++i_pulse) {
-            tap=(TAnalysedPulse*) array->ConstructedAt(i_pulse-pulseList->begin());
-            *tap=**i_pulse;
+            tap= array->ConstructedAt(i_pulse-pulseList->begin());
+            (*i_pulse)->Copy(*tap);
         }
     }
     fTree->Fill();

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.cpp
@@ -50,7 +50,6 @@ int FirstCompleteAPGenerator::ProcessPulses(
 void FirstCompleteAPGenerator::MakeTAPsWithPCF(int tpi_ID, const TPulseIsland* original_tpi, AnalysedPulseList& analysedList){
     // Look for more than one pulse on the TPI
     fPulseCandidateFinder->FindPulseCandidates(original_tpi);
-    int n_pulse_candidates = fPulseCandidateFinder->GetNPulseCandidates();
     fPulseCandidateFinder->GetPulseCandidates(fSubPulses);
 
     // now loop over all sub-pulses

--- a/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/FirstCompleteAPGenerator.h
@@ -23,6 +23,8 @@ class FirstCompleteAPGenerator:public TVAnalysedPulseGenerator {
 
  private:
    void DrawPulse(int original, int pulse_timestamp, int n_pulse_samples);
+   void MakeTAPsWithPCF(int tpi_ID,const TPulseIsland* tpi, AnalysedPulseList& analysedList);
+   void AnalyseOneTpi(int tpi_ID,const TPulseIsland* tpi, AnalysedPulseList& analysedList);
 
    // The algorithms that this generator will use
    const Algorithm::MaxBinAmplitude fMaxBinAmplitude;

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
@@ -49,6 +49,7 @@ int IntegralRatioAPGenerator::ProcessPulses(
 
         // Analyse each TPI
         try{
+            fIntegralRatioAlgo.SetPedestalToMinimum(*tpi);
             fIntegralRatioAlgo(*tpi);
         }catch(std::out_of_range& e){
             continue;

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.cpp
@@ -63,8 +63,8 @@ int IntegralRatioAPGenerator::ProcessPulses(
         tap->SetIntegral(fIntegralRatioAlgo.GetTotal());
         tap->SetIntegralSmall(fIntegralRatioAlgo.GetTail());
         tap->SetIntegralRatio(fIntegralRatioAlgo.GetRatio());
-        tap->SetAmplitude(fMaxBinAmplitude.amplitude);
-        tap->SetTime(fMaxBinAmplitude.time);
+        tap->SetAmplitude(fMaxBinAmplitude.GetAmplitude());
+        tap->SetTime(fMaxBinAmplitude.GetTime());
 
         // Finally add the new TAP to the output list
         analysedList.push_back(tap);

--- a/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/IntegralRatioAPGenerator.h
@@ -28,6 +28,7 @@ class IntegralRatioAPGenerator:public TVAnalysedPulseGenerator {
         double fPedestal;
         double fPolarity;
         Algorithm::IntegralRatio fIntegralRatioAlgo;
+        const Algorithm::MaxBinAmplitude fMaxBinAmplitude;
 
 };
 

--- a/analyzer/rootana/src/TAP_generators/MakeAnalysedPulses.cpp
+++ b/analyzer/rootana/src/TAP_generators/MakeAnalysedPulses.cpp
@@ -206,7 +206,7 @@ bool MakeAnalysedPulses::AddGenerator(const string& detector,string generatorTyp
 
     // Get the requested generator
     TVAnalysedPulseGenerator* generator=
-        TAPGeneratorFactory::Instance()->createModule(generatorType+"APGenerator",opts);
+        TAPGeneratorFactory::Instance()->createModule(generatorType,opts);
     if(!generator) return false;
 
     // print something

--- a/analyzer/rootana/src/TAP_generators/MakeAnalysedPulses.cpp
+++ b/analyzer/rootana/src/TAP_generators/MakeAnalysedPulses.cpp
@@ -206,7 +206,7 @@ bool MakeAnalysedPulses::AddGenerator(const string& detector,string generatorTyp
 
     // Get the requested generator
     TVAnalysedPulseGenerator* generator=
-        TAPGeneratorFactory::Instance()->createModule(generatorType,opts);
+        TAPGeneratorFactory::Instance()->createModule(generatorType+"APGenerator",opts);
     if(!generator) return false;
 
     // print something

--- a/analyzer/rootana/src/TAP_generators/TAPGeneratorFactory.h
+++ b/analyzer/rootana/src/TAP_generators/TAPGeneratorFactory.h
@@ -20,7 +20,11 @@ class TAPGeneratorFactory:public TemplateFactory<TVAnalysedPulseGenerator,TAPGen
         }
 
     	std::string GetTAPType(const IDs::generator& g){ 
-            return GetProduct(g.Type());
+            std::string gen=g.Type();
+            size_t n_subtract=gen.find("APGenerator");
+            if(n_subtract!=std::string::npos)
+               gen.erase(n_subtract); //remove APGenerator part
+            return GetProduct(gen);
         }
 
 		// Get the single instance of this class

--- a/analyzer/rootana/src/TAP_generators/TAPGeneratorFactory.h
+++ b/analyzer/rootana/src/TAP_generators/TAPGeneratorFactory.h
@@ -35,12 +35,12 @@ inline TAPGeneratorFactory* TAPGeneratorFactory::Instance(){
     return instance;
 }
 
-#define ALCAP_TAP_GENERATOR__(NAME, CLASS, ARGUMENTS) \
+#define ALCAP_TAP_GENERATOR__( CLASS, ARGUMENTS) \
 RegistryProxy<CLASS,TVAnalysedPulseGenerator,TAPGeneratorOptions,TAPGeneratorFactory> \
-   p_##CLASS(NAME, ARGUMENTS, CLASS::TapType() );
+   p_##CLASS(#CLASS, ARGUMENTS, CLASS::TapType() );
 
 #define ALCAP_TAP_GENERATOR( NAME , ... ) \
-    ALCAP_TAP_GENERATOR__(#NAME, NAME##APGenerator, #__VA_ARGS__)
+    ALCAP_TAP_GENERATOR__( NAME##APGenerator, #__VA_ARGS__)
 
 
 #endif // TAPGENERATORFACTORY__HH_

--- a/analyzer/rootana/src/TAP_generators/TAPGeneratorFactory.h
+++ b/analyzer/rootana/src/TAP_generators/TAPGeneratorFactory.h
@@ -35,12 +35,12 @@ inline TAPGeneratorFactory* TAPGeneratorFactory::Instance(){
     return instance;
 }
 
-#define ALCAP_TAP_GENERATOR__( CLASS, ARGUMENTS) \
+#define ALCAP_TAP_GENERATOR__( NAME, CLASS, ARGUMENTS) \
 RegistryProxy<CLASS,TVAnalysedPulseGenerator,TAPGeneratorOptions,TAPGeneratorFactory> \
-   p_##CLASS(#CLASS, ARGUMENTS, CLASS::TapType() );
+   p_##CLASS(NAME, ARGUMENTS, CLASS::TapType() );
 
-#define ALCAP_TAP_GENERATOR( NAME , ... ) \
-    ALCAP_TAP_GENERATOR__( NAME##APGenerator, #__VA_ARGS__)
+#define ALCAP_TAP_GENERATOR( CLASS , ... ) \
+    ALCAP_TAP_GENERATOR__( #CLASS, CLASS##APGenerator, #__VA_ARGS__)
 
 
 #endif // TAPGENERATORFACTORY__HH_

--- a/analyzer/rootana/src/TAP_generators/TAPGeneratorOptions.cpp
+++ b/analyzer/rootana/src/TAP_generators/TAPGeneratorOptions.cpp
@@ -3,7 +3,7 @@
 
 void TAPGeneratorOptions::AddArgument(const int& number, const std::string& option) {
   // Get the name of this argument
-  std::string name = TAPGeneratorFactory::Instance()->GetArgumentName(fModuleName,number);
+  std::string name = TAPGeneratorFactory::Instance()->GetArgumentName(fModuleName+"APGenerator",number);
   // Set the value of the corresponding option
   SetOption(name,option);
 }

--- a/analyzer/rootana/src/TAP_generators/TAPGeneratorOptions.cpp
+++ b/analyzer/rootana/src/TAP_generators/TAPGeneratorOptions.cpp
@@ -3,7 +3,7 @@
 
 void TAPGeneratorOptions::AddArgument(const int& number, const std::string& option) {
   // Get the name of this argument
-  std::string name = TAPGeneratorFactory::Instance()->GetArgumentName(fModuleName+"APGenerator",number);
+  std::string name = TAPGeneratorFactory::Instance()->GetArgumentName(fModuleName,number);
   // Set the value of the corresponding option
   SetOption(name,option);
 }

--- a/analyzer/rootana/src/TAP_generators/TAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TAnalysedPulse.h
@@ -37,6 +37,22 @@ class TAnalysedPulse : public TObject {
   /// you cannot set the source outside of the constructor.
   TAnalysedPulse();
 
+  virtual void Copy(TObject& rhs)const{
+    TObject::Copy(rhs);
+    if(rhs.InheritsFrom(Class())){
+      TAnalysedPulse* tap=static_cast<TAnalysedPulse*>(&rhs);
+      tap->fParentID=fParentID;
+      tap->fTPILength=fTPILength;
+      tap->fAmplitude=fAmplitude;
+      tap->fTime=fTime;
+      tap->fIntegral=fIntegral;
+      tap->fEnergy=fEnergy;
+      tap->fPedestal=fPedestal;
+      tap->fTriggerTime=fTriggerTime;
+      tap->fSource=fSource;
+    }
+  }
+
   public:
   /// \brief
   /// The constructor one should use if we need use one.

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
@@ -3,6 +3,7 @@
 #include "InterpolatePulse.h"
 #include <algorithm>
 #include "debug_tools.h"
+#include <TF1.h>
 
 TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse():TAnalysedPulse(),
       fNPeaks(0), fPeakRank(0), fIntegralRatio(0){}
@@ -30,11 +31,24 @@ void TTemplateConvolveAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
    TH1F* time_hist=functions::VectorToHist(fTimeSamples,name+"_time","First derivative of convolution with template");
     
    //TMarker* marker=new TMarker(GetTime(), GetAmplitude()+10, 23);
-   TLine* line=new TLine(GetTime(), 0, GetTime(), GetAmplitude()+10);
+   TLine* line=new TLine(GetTime(), GetPedestal(), GetTime(), GetAmplitude()+GetPedestal());
    line->SetLineColor(kRed);
+   tpi_pulse->GetListOfFunctions()->Add(line->Clone());
+
+   line->SetX1(fTimeOffset);
+   line->SetX2(fTimeOffset);
+   line->SetY1(0);
+   line->SetY2(fAmplitudeScale);
+
    energy_hist->GetListOfFunctions()->Add(line);
    time_hist->GetListOfFunctions()->Add(line->Clone());
-   tpi_pulse->GetListOfFunctions()->Add(line->Clone());
+
+   TF1* fit=new TF1("Fit","[0]*(x-[3])**2+[1]*(x-[3])+[2]", 0 , energy_hist->GetNbinsX());
+   fit->SetParameter(0,fQuad);
+   fit->SetParameter(1,fLinear);
+   fit->SetParameter(2,fConstant);
+   fit->SetParameter(3,fTimeOffset );
+   energy_hist->GetListOfFunctions()->Add(fit);
 
    //tap_pulse->Write();
    

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
@@ -60,6 +60,8 @@ void TTemplateConvolveAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
    fit->SetParameter(2,fConstant);
    fit->SetParameter(3,fTimeOffset );
    energy_hist->GetListOfFunctions()->Add(fit);
+   energy_hist->Write();
+   time_hist->Write();
 
    //tap_pulse->Write();
    

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include "debug_tools.h"
 #include <TF1.h>
+#include <TPaveText.h>
 
 TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse():TAnalysedPulse(),
       fNPeaks(0), fPeakRank(0), fIntegralRatio(0){}
@@ -42,6 +43,16 @@ void TTemplateConvolveAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
 
    energy_hist->GetListOfFunctions()->Add(line);
    time_hist->GetListOfFunctions()->Add(line->Clone());
+
+   TPaveText* text_b=new TPaveText(0.7,0.60,0.9,0.9,"NB NDC");
+   text_b->AddText(Form("A = %g",GetAmplitude()));
+   text_b->AddText(Form("t = %g",GetTime()));
+   text_b->AddText(Form("a = %g",fQuad));
+   text_b->AddText(Form("b = %g",fLinear));
+   text_b->AddText(Form("c = %g",fConstant));
+   text_b->SetFillColor(kWhite);
+   text_b->SetBorderSize(1);
+   energy_hist->GetListOfFunctions()->Add(text_b);
 
    TF1* fit=new TF1("Fit","[0]*(x-[3])**2+[1]*(x-[3])+[2]", 0 , energy_hist->GetNbinsX());
    fit->SetParameter(0,fQuad);

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
@@ -5,6 +5,7 @@
 #include "debug_tools.h"
 #include <TF1.h>
 #include <TPaveText.h>
+#include "EventNavigator.h"
 
 TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse():TAnalysedPulse(),
       fNPeaks(0), fPeakRank(0), fIntegralRatio(0){}
@@ -32,7 +33,10 @@ void TTemplateConvolveAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
    TH1F* time_hist=functions::VectorToHist(fTimeSamples,name+"_time","First derivative of convolution with template");
     
    //TMarker* marker=new TMarker(GetTime(), GetAmplitude()+10, 23);
-   TLine* line=new TLine(GetTime(), GetPedestal(), GetTime(), GetAmplitude()+GetPedestal());
+   int polarity=EventNavigator::GetSetupRecord().GetPolarity(GetSource().Channel());
+   double bottom= GetPedestal() - (polarity>0?0:GetAmplitude());
+   double top= GetPedestal() + (polarity>0?GetAmplitude():0);
+   TLine* line=new TLine(GetTime(), bottom, GetTime(), top);
    line->SetLineColor(kRed);
    tpi_pulse->GetListOfFunctions()->Add(line->Clone());
 

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
@@ -1,4 +1,15 @@
 #include "TTemplateConvolveAnalysedPulse.h"
+#include "InterpolatePulse.h"
+#include <algorithm>
+#include "debug_tools.h"
+
+namespace{
+  struct unique_n{
+    int operator() () { return ++current; }
+    int current;
+    unique_n():current(-1){}
+  };
+}
 
 TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse(
        const IDs::source& sourceID, const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
@@ -7,3 +18,32 @@ TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse(
 TTemplateConvolveAnalysedPulse::~TTemplateConvolveAnalysedPulse(){
 }
 
+void TTemplateConvolveAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
+   if(!tpi_pulse) return;
+
+   // prepare labels for histoagrams
+   const int n_samples=fEnergySamples.size();
+   unique_n uniq;
+   double labels[n_samples];
+   std::generate_n(labels,n_samples, uniq);
+
+   std::string name(tpi_pulse->GetName());
+   /// make the energy (template convolution) waveform
+   TH1F* energy_hist=new TH1F((name+"_energy").c_str(),
+                               "Convolution with template",
+                               fEnergySamples.size(),0,fEnergySamples.size());
+   energy_hist->FillN(n_samples,labels,fEnergySamples.data());
+
+   /// make the time (second derivative of the energy) waveform
+   TH1F* time_hist=new TH1F((name+"_time").c_str(),
+                               "Second derivative of convolution with template",
+                               fTimeSamples.size(),0,fTimeSamples.size());
+   time_hist->FillN(fTimeSamples.size(),labels,fTimeSamples.data());
+    
+   //TMarker* marker=new TMarker(GetTime(), GetAmplitude()+GetPedestal()+10, 23);
+   //marker->SetMarkerColor(kRed);
+   //tap_pulse->GetListOfFunctions()->Add(marker);
+
+   //tap_pulse->Write();
+   
+}

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
@@ -1,4 +1,5 @@
 #include "TTemplateConvolveAnalysedPulse.h"
+#include "TMarker.h"
 #include "InterpolatePulse.h"
 #include <algorithm>
 #include "debug_tools.h"
@@ -13,7 +14,9 @@ namespace{
 
 TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse(
        const IDs::source& sourceID, const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
-            TAnalysedPulse(sourceID,parentID,parentTPI){}
+            TAnalysedPulse(sourceID,parentID,parentTPI),
+      fNPeaks(0), fPeakRank(0), fIntegralRatio(0)
+{}
 
 TTemplateConvolveAnalysedPulse::~TTemplateConvolveAnalysedPulse(){
 }
@@ -36,13 +39,14 @@ void TTemplateConvolveAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
 
    /// make the time (second derivative of the energy) waveform
    TH1F* time_hist=new TH1F((name+"_time").c_str(),
-                               "Second derivative of convolution with template",
+                               "Derivative of convolution with template",
                                fTimeSamples.size(),0,fTimeSamples.size());
    time_hist->FillN(fTimeSamples.size(),labels,fTimeSamples.data());
     
-   //TMarker* marker=new TMarker(GetTime(), GetAmplitude()+GetPedestal()+10, 23);
-   //marker->SetMarkerColor(kRed);
-   //tap_pulse->GetListOfFunctions()->Add(marker);
+   TMarker* marker=new TMarker(GetTime(), GetAmplitude()+10, 23);
+   marker->SetMarkerColor(kRed);
+   energy_hist->GetListOfFunctions()->Add(marker);
+   time_hist->GetListOfFunctions()->Add(marker->Clone());
 
    //tap_pulse->Write();
    

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
@@ -4,6 +4,9 @@
 #include <algorithm>
 #include "debug_tools.h"
 
+TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse():TAnalysedPulse(),
+      fNPeaks(0), fPeakRank(0), fIntegralRatio(0){}
+
 TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse(
        const IDs::source& sourceID, const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
             TAnalysedPulse(sourceID,parentID,parentTPI),

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.cpp
@@ -1,0 +1,9 @@
+#include "TTemplateConvolveAnalysedPulse.h"
+
+TTemplateConvolveAnalysedPulse::TTemplateConvolveAnalysedPulse(
+       const IDs::source& sourceID, const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
+            TAnalysedPulse(sourceID,parentID,parentTPI){}
+
+TTemplateConvolveAnalysedPulse::~TTemplateConvolveAnalysedPulse(){
+}
+

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
@@ -5,6 +5,10 @@
 #include "TTemplate.h"
 #include <TRef.h>
 #include <TObject.h>
+#ifndef __CINT__
+#include "debug_tools.h"
+#include <iostream>
+#endif// __CINT__
 
 class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
 
@@ -31,7 +35,11 @@ class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
 
       /// @name Setters
       /// @{
-      void SetNPeaks(double val){fNPeaks=val;}
+      void SetNPeaks(int val){fNPeaks=val;}
+      void SetPeakRank(int val){
+fPeakRank=val;
+//if(val>1) DEBUG_VALUE(val,fPeakRank);
+}
       void SetIntegralRatio(double val){fIntegralRatio=val;}
       void SetEnergyConvolve(const SamplesVector& r){fEnergySamples=r;};
       void SetTimeConvolve(const SamplesVector& r){fTimeSamples=r;};
@@ -42,6 +50,7 @@ class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
 
     private:
       int fNPeaks;
+      int fPeakRank;
       double fIntegralRatio;
       SamplesVector fEnergySamples; //!
       SamplesVector fTimeSamples; //!

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
@@ -35,6 +35,11 @@ class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
             tap->fNPeaks       =fNPeaks;
             tap->fPeakRank     =fPeakRank;
             tap->fIntegralRatio=fIntegralRatio;
+            tap->fQuad=fQuad;
+            tap->fLinear=fLinear;
+            tap->fConstant=fConstant;
+            tap->fTimeOffset=fTimeOffset;
+            tap->fAmplitudeScale=fAmplitudeScale;
          }
       }
 
@@ -43,18 +48,20 @@ class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
       double GetIntegralRatio()const{return fIntegralRatio;}
       int GetNPeaks()const{return fNPeaks;}
       int GetPeakRank()const{return fPeakRank;}
+      const TTemplate* GetTemplate()const{return (const TTemplate*) fTemplate.GetObject();}
       /// @}
 
       /// @name Setters
       /// @{
       void SetNPeaks(int val){fNPeaks=val;}
-      void SetPeakRank(int val){
-fPeakRank=val;
-//if(val>1) DEBUG_VALUE(val,fPeakRank);
-}
+      void SetPeakRank(int val){ fPeakRank=val; }
+      void SetTimeOffset(double val){ fTimeOffset=val; }
+      void SetAmplitudeScale(double val){ fAmplitudeScale=val; }
       void SetIntegralRatio(double val){fIntegralRatio=val;}
+      void SetQuadraticFit(double a, double b, double c){fQuad=a; fLinear=b; fConstant=c;};
       void SetEnergyConvolve(const SamplesVector& r){fEnergySamples=r;};
       void SetTimeConvolve(const SamplesVector& r){fTimeSamples=r;};
+      void SetTemplate(TTemplate* val){fTemplate=val;}
       /// @}
 
       /// @@brief overload the TAnalysedPulse::Draw method
@@ -64,6 +71,9 @@ fPeakRank=val;
       int fNPeaks;
       int fPeakRank;
       double fIntegralRatio;
+      double fQuad, fLinear, fConstant;
+      double fTimeOffset, fAmplitudeScale;
+        TRef fTemplate;//!
       SamplesVector fEnergySamples; //!
       SamplesVector fTimeSamples; //!
 

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
@@ -28,6 +28,16 @@ class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
       // defined in .cpp file to force vtable to be built
       virtual ~TTemplateConvolveAnalysedPulse();
 
+      virtual void Copy(TObject& rhs)const{
+         TAnalysedPulse::Copy(rhs);
+         if(rhs.InheritsFrom(Class())){
+           TTemplateConvolveAnalysedPulse* tap=static_cast<TTemplateConvolveAnalysedPulse*>(&rhs);
+            tap->fNPeaks       =fNPeaks;
+            tap->fPeakRank     =fPeakRank;
+            tap->fIntegralRatio=fIntegralRatio;
+         }
+      }
+
       /// @name Getters
       /// @{
       double GetIntegralRatio()const{return fIntegralRatio;}
@@ -57,7 +67,7 @@ fPeakRank=val;
       SamplesVector fEnergySamples; //!
       SamplesVector fTimeSamples; //!
 
-      ClassDef(TTemplateConvolveAnalysedPulse,1);
+      ClassDef(TTemplateConvolveAnalysedPulse,2);
 };
 
 #endif // TTEMPLATECONVOLVEANALYSEDPULSE_H

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
@@ -33,15 +33,18 @@ class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
       /// @{
       void SetNPeaks(double val){fNPeaks=val;}
       void SetIntegralRatio(double val){fIntegralRatio=val;}
-      void SetEnergyConvolve(const SamplesVector& r){fEnergyConvolve=r;};
-      void SetTimeConvolve(const SamplesVector& r){fTimeConvolve=r;};
+      void SetEnergyConvolve(const SamplesVector& r){fEnergySamples=r;};
+      void SetTimeConvolve(const SamplesVector& r){fTimeSamples=r;};
       /// @}
+
+      /// @@brief overload the TAnalysedPulse::Draw method
+      virtual void Draw(const TH1F* tpi_pulse)const;
 
     private:
       int fNPeaks;
       double fIntegralRatio;
-      SamplesVector fEnergyConvolve; //!
-      SamplesVector fTimeConvolve; //!
+      SamplesVector fEnergySamples; //!
+      SamplesVector fTimeSamples; //!
 
       ClassDef(TTemplateConvolveAnalysedPulse,1);
 };

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
@@ -1,0 +1,49 @@
+#ifndef TTEMPLATECONVOLVEANALYSEDPULSE_H
+#define TTEMPLATECONVOLVEANALYSEDPULSE_H
+
+#include "TAnalysedPulse.h"
+#include "TTemplate.h"
+#include <TRef.h>
+#include <TObject.h>
+
+class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
+
+    public:
+      typedef std::vector<double> SamplesVector;
+
+    public:
+      /// Needed by ROOT but not expected to be used
+      TTemplateConvolveAnalysedPulse():TAnalysedPulse(){};
+
+      /// @brief Construct a TTemplateConvolveAnalysedPulse.
+      /// @details Same signature as for TAnalysedPulse so that MakeNewTAP can
+      /// create these specialised TAPs
+      TTemplateConvolveAnalysedPulse(const IDs::source& sourceID,
+              const TPulseIslandID& parentID, const TPulseIsland* parentTPI);
+
+      // defined in .cpp file to force vtable to be built
+      virtual ~TTemplateConvolveAnalysedPulse();
+
+      /// @name Getters
+      /// @{
+      double GetIntegralRatio()const{return fIntegralRatio;}
+      /// @}
+
+      /// @name Setters
+      /// @{
+      void SetNPeaks(double val){fNPeaks=val;}
+      void SetIntegralRatio(double val){fIntegralRatio=val;}
+      void SetEnergyConvolve(const SamplesVector& r){fEnergyConvolve=r;};
+      void SetTimeConvolve(const SamplesVector& r){fTimeConvolve=r;};
+      /// @}
+
+    private:
+      int fNPeaks;
+      double fIntegralRatio;
+      SamplesVector fEnergyConvolve; //!
+      SamplesVector fTimeConvolve; //!
+
+      ClassDef(TTemplateConvolveAnalysedPulse,1);
+};
+
+#endif // TTEMPLATECONVOLVEANALYSEDPULSE_H

--- a/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateConvolveAnalysedPulse.h
@@ -17,7 +17,7 @@ class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
 
     public:
       /// Needed by ROOT but not expected to be used
-      TTemplateConvolveAnalysedPulse():TAnalysedPulse(){};
+      TTemplateConvolveAnalysedPulse();
 
       /// @brief Construct a TTemplateConvolveAnalysedPulse.
       /// @details Same signature as for TAnalysedPulse so that MakeNewTAP can
@@ -31,6 +31,8 @@ class TTemplateConvolveAnalysedPulse:public TAnalysedPulse{
       /// @name Getters
       /// @{
       double GetIntegralRatio()const{return fIntegralRatio;}
+      int GetNPeaks()const{return fNPeaks;}
+      int GetPeakRank()const{return fPeakRank;}
       /// @}
 
       /// @name Setters

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -8,7 +8,8 @@ void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
       std::string name=tpi_pulse->GetName();
       name+="_templateAP";
       const TH1* tpl = GetTemplate()->GetHisto();
-      TH1F* tap_pulse=(TH1F*) tpi_pulse->Clone(name.c_str());
+      int num_samples=tpi_pulse->GetNbinsX()*GetTemplate()->GetRefineFactor();
+      TH1F* tap_pulse=new TH1F(name.c_str(), name.c_str(),num_samples,0,tpi_pulse->GetNbinsX());
       for ( int i=0; i<tap_pulse->GetNbinsX(); i++){
          // deduce right bin to look in
          int tpl_bin=i+ GetTime();

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -22,7 +22,7 @@ void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
       TH1F* tap_pulse=(TH1F*)GetHisto()->Clone(name.c_str());
       tap_pulse->SetDirectory(TDirectory::CurrentDirectory());
 
-      TPaveText* text_b=new TPaveText(0.7,0.60,0.9,0.8,"NB NDC");
+      TPaveText* text_b=new TPaveText(0.7,0.60,0.9,0.9,"NB NDC");
       text_b->AddText(Form("#chi^2 = %3.2g",GetChi2()));
       text_b->AddText(Form("Status = %d",GetFitStatus()));
       text_b->AddText(Form("Time = %g",GetTime()));
@@ -87,3 +87,4 @@ double TTemplateFitAnalysedPulse::GetBinContent(int bin)const{
       // Set sample in histogram that's to be saved
       return sample*GetAmplitude() + GetPedestal();
 }
+

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -12,7 +12,7 @@ TTemplateFitAnalysedPulse::TTemplateFitAnalysedPulse(
              fResidual(NULL), fHisto(NULL),fIsPileUpPulse(false),fOtherPulse(NULL){}
 
 TTemplateFitAnalysedPulse::~TTemplateFitAnalysedPulse(){
-   if(fHisto) delete fHisto;
+   //if(fHisto) delete fHisto;
 }
 
 void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -15,9 +15,11 @@ void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
       name+="_templateAP";
       TH1F* tap_pulse=(TH1F*)GetHisto()->Clone(name.c_str());
 
-      TPaveText* text_b=new TPaveText(0.5,0.75,0.7,0.9,"NB NDC");
-      text_b->AddText(Form("#chi^2 = %g",GetChi2()));
+      TPaveText* text_b=new TPaveText(0.7,0.60,0.9,0.8,"NB NDC");
+      text_b->AddText(Form("#chi^2 = %3.2g",GetChi2()));
       text_b->AddText(Form("Status = %d",GetFitStatus()));
+      text_b->AddText(Form("Time = %g",GetTime()));
+      text_b->AddText(Form("NDoF = %d",GetNDoF()));
       text_b->SetFillColor(kWhite);
       text_b->SetBorderSize(1);
       tap_pulse->GetListOfFunctions()->Add(text_b);
@@ -42,19 +44,23 @@ const TH1F* TTemplateFitAnalysedPulse::GetHisto()const{
                                 GetSource().Channel().str().c_str(),
                                 EventNavigator::Instance().EntryNo(),
                                 GetParentID());
-      const TH1* tpl = GetTemplate()->GetHisto();
       int num_samples=GetTPILength()*GetTemplate()->GetRefineFactor();
       TH1F* tap_pulse=new TH1F(name.c_str(), name.c_str(),num_samples,0,GetTPILength());
       for ( int i=0; i<num_samples; i++){
-         // deduce right bin to look in
-         int tpl_bin=i+ GetTime();
-         // get bin sample
-         double sample=tpl->GetBinContent(tpl_bin);
-         // Set sample in histogram that's to be saved
-         tap_pulse->SetBinContent(i,sample*GetAmplitude() + GetPedestal());
+         double height=GetBinContent(i);
+         tap_pulse->SetBinContent(i,height);
       }
       tap_pulse->SetDirectory(0);
 
       fHisto=tap_pulse;
       return fHisto;
+}
+
+double TTemplateFitAnalysedPulse::GetBinContent(int bin)const{
+         // deduce right bin to look in
+         int tpl_bin=bin+ GetTime();
+         // get bin sample
+         double sample=GetTemplate()->GetHisto()->GetBinContent(tpl_bin);
+         // Set sample in histogram that's to be saved
+         return sample*GetAmplitude() + GetPedestal();
 }

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -1,0 +1,20 @@
+#include "TTemplateFitAnalysedPulse.h"
+#include "TF1.h"
+#include "TH1F.h"
+#include "Functions.h"
+
+void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
+	if(tpi_pulse) {
+	  std::string name=tpi_pulse->GetName();
+	  TF1* tap_pulse=new TF1((name+"_AP").c_str(),functions::gauss_lin,0,1000,5);
+    // parameters:
+    // 0: constant (pedestal)
+    // 1: gradient
+    // 2: Gauss amplitude
+    // 3: Gauss mean
+    // 4: Gauss width
+      tap_pulse->SetParameters(GetPedestal(),fGradient,GetAmplitude(),GetTime(),fWidth);
+      tap_pulse->Draw();
+      tap_pulse->Write();
+	}
+}

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -8,36 +8,54 @@
 
 TTemplateFitAnalysedPulse::TTemplateFitAnalysedPulse(
        const IDs::source& sourceID, const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
-            TAnalysedPulse(sourceID,parentID,parentTPI), fResidual(NULL), fHisto(NULL){}
+            TAnalysedPulse(sourceID,parentID,parentTPI),
+             fResidual(NULL), fHisto(NULL),fIsPileUpPulse(false),fOtherPulse(NULL){}
+
+TTemplateFitAnalysedPulse::~TTemplateFitAnalysedPulse(){
+   if(fHisto) delete fHisto;
+}
 
 void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
    if(tpi_pulse) {
       std::string name=tpi_pulse->GetName();
       name+="_templateAP";
       TH1F* tap_pulse=(TH1F*)GetHisto()->Clone(name.c_str());
+      tap_pulse->SetDirectory(TDirectory::CurrentDirectory());
 
       TPaveText* text_b=new TPaveText(0.7,0.60,0.9,0.8,"NB NDC");
       text_b->AddText(Form("#chi^2 = %3.2g",GetChi2()));
       text_b->AddText(Form("Status = %d",GetFitStatus()));
       text_b->AddText(Form("Time = %g",GetTime()));
+      text_b->AddText(Form("Ampl. = %g",GetAmplitude()));
       text_b->AddText(Form("NDoF = %d",GetNDoF()));
       text_b->SetFillColor(kWhite);
       text_b->SetBorderSize(1);
       tap_pulse->GetListOfFunctions()->Add(text_b);
+
+      TH1F* tap_pulse2=NULL;
+      if(fOtherPulse && !fIsPileUpPulse){
+        name+="2";
+        tap_pulse2=(TH1F*)fOtherPulse->GetHisto()->Clone(name.c_str());
+        tap_pulse2->SetDirectory(TDirectory::CurrentDirectory());
+      }
        
       //TMarker* marker=new TMarker(GetTime(), GetAmplitude()+GetPedestal()+10, 23);
       //marker->SetMarkerColor(kRed);
       //tap_pulse->GetListOfFunctions()->Add(marker);
 
-      tap_pulse->SetDirectory(TDirectory::CurrentDirectory());
       //tap_pulse->Write();
 
       TH1F* residual=(TH1F*) tpi_pulse->Clone(Form("%s_residual",tpi_pulse->GetName()));
       TH1F* tap_rebinned=(TH1F*) tap_pulse->Rebin(GetTemplate()->GetRefineFactor(),Form("%s_rebin",tap_pulse->GetName()));
       residual->Add(tap_rebinned, -1./GetTemplate()->GetRefineFactor());
+      if(tap_pulse2) {
+        delete tap_rebinned;
+        tap_rebinned=(TH1F*) tap_pulse2->Rebin(GetTemplate()->GetRefineFactor(),Form("%s_rebin",tap_pulse->GetName()));
+        residual->Add(tap_rebinned, -1./GetTemplate()->GetRefineFactor());
+      }
       double integral=residual->Integral(5,residual->GetNbinsX()-5);
       text_b->AddText(Form("Total residue = %g",integral));
-       delete tap_rebinned;
+      delete tap_rebinned;
       //residual->Write();
    } 
 }

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -1,16 +1,51 @@
+#include "EventNavigator.h"
 #include "TTemplateFitAnalysedPulse.h"
-#include "TF1.h"
+#include "TPaveText.h"
 #include "TH1F.h"
 #include "Functions.h"
+#include "debug_tools.h"
+
+TTemplateFitAnalysedPulse::TTemplateFitAnalysedPulse(
+       const IDs::source& sourceID, const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
+            TAnalysedPulse(sourceID,parentID,parentTPI), fResidual(NULL), fHisto(NULL){}
 
 void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
    if(tpi_pulse) {
       std::string name=tpi_pulse->GetName();
       name+="_templateAP";
+      TH1F* tap_pulse=(TH1F*)GetHisto()->Clone(name.c_str());
+
+      TPaveText* text_b=new TPaveText(0.5,0.75,0.7,0.9,"NB NDC");
+      text_b->AddText(Form("#chi^2 = %g",GetChi2()));
+      text_b->AddText(Form("Status = %d",GetFitStatus()));
+      text_b->SetFillColor(kWhite);
+      text_b->SetBorderSize(1);
+      tap_pulse->GetListOfFunctions()->Add(text_b);
+
+      tap_pulse->SetDirectory(TDirectory::CurrentDirectory());
+      //tap_pulse->Write();
+
+      TH1F* residual=(TH1F*) tpi_pulse->Clone(Form("%s_residual",tpi_pulse->GetName()));
+      TH1F* tap_rebinned=(TH1F*) tap_pulse->Rebin(GetTemplate()->GetRefineFactor(),Form("%s_rebin",tap_pulse->GetName()));
+      residual->Add(tap_rebinned, -1./GetTemplate()->GetRefineFactor());
+      double integral=residual->Integral(5,residual->GetNbinsX()-5);
+      text_b->AddText(Form("Total residue = %g",integral));
+       delete tap_rebinned;
+      //residual->Write();
+   } 
+}
+
+const TH1F* TTemplateFitAnalysedPulse::GetHisto()const{
+      if(fHisto) return fHisto;
+
+      std::string name=Form("Pulse_%s_%4lld_%3d_templateAP",
+                                GetSource().Channel().str().c_str(),
+                                EventNavigator::Instance().EntryNo(),
+                                GetParentID());
       const TH1* tpl = GetTemplate()->GetHisto();
-      int num_samples=tpi_pulse->GetNbinsX()*GetTemplate()->GetRefineFactor();
-      TH1F* tap_pulse=new TH1F(name.c_str(), name.c_str(),num_samples,0,tpi_pulse->GetNbinsX());
-      for ( int i=0; i<tap_pulse->GetNbinsX(); i++){
+      int num_samples=GetTPILength()*GetTemplate()->GetRefineFactor();
+      TH1F* tap_pulse=new TH1F(name.c_str(), name.c_str(),num_samples,0,GetTPILength());
+      for ( int i=0; i<num_samples; i++){
          // deduce right bin to look in
          int tpl_bin=i+ GetTime();
          // get bin sample
@@ -18,6 +53,8 @@ void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
          // Set sample in histogram that's to be saved
          tap_pulse->SetBinContent(i,sample*GetAmplitude() + GetPedestal());
       }
-      tap_pulse->Write();
-   }
+      tap_pulse->SetDirectory(0);
+
+      fHisto=tap_pulse;
+      return fHisto;
 }

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -1,6 +1,7 @@
 #include "EventNavigator.h"
 #include "TTemplateFitAnalysedPulse.h"
 #include "TPaveText.h"
+#include "TMarker.h"
 #include "TH1F.h"
 #include "Functions.h"
 #include "debug_tools.h"
@@ -23,6 +24,10 @@ void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
       text_b->SetFillColor(kWhite);
       text_b->SetBorderSize(1);
       tap_pulse->GetListOfFunctions()->Add(text_b);
+       
+      //TMarker* marker=new TMarker(GetTime(), GetAmplitude()+GetPedestal()+10, 23);
+      //marker->SetMarkerColor(kRed);
+      //tap_pulse->GetListOfFunctions()->Add(marker);
 
       tap_pulse->SetDirectory(TDirectory::CurrentDirectory());
       //tap_pulse->Write();
@@ -57,10 +62,10 @@ const TH1F* TTemplateFitAnalysedPulse::GetHisto()const{
 }
 
 double TTemplateFitAnalysedPulse::GetBinContent(int bin)const{
-         // deduce right bin to look in
-         int tpl_bin=bin+ GetTime();
-         // get bin sample
-         double sample=GetTemplate()->GetHisto()->GetBinContent(tpl_bin);
-         // Set sample in histogram that's to be saved
-         return sample*GetAmplitude() + GetPedestal();
+      // deduce right bin to look in
+      int tpl_bin=GetTime()-GetTemplate()->GetTime()/GetTemplate()->GetRefineFactor()+bin;
+      // get bin sample
+      double sample=GetTemplate()->GetHisto()->GetBinContent(tpl_bin);
+      // Set sample in histogram that's to be saved
+      return sample*GetAmplitude() + GetPedestal();
 }

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.cpp
@@ -4,17 +4,19 @@
 #include "Functions.h"
 
 void TTemplateFitAnalysedPulse::Draw(const TH1F* tpi_pulse)const{
-	if(tpi_pulse) {
-	  std::string name=tpi_pulse->GetName();
-	  TF1* tap_pulse=new TF1((name+"_AP").c_str(),functions::gauss_lin,0,1000,5);
-    // parameters:
-    // 0: constant (pedestal)
-    // 1: gradient
-    // 2: Gauss amplitude
-    // 3: Gauss mean
-    // 4: Gauss width
-      tap_pulse->SetParameters(GetPedestal(),fGradient,GetAmplitude(),GetTime(),fWidth);
-      tap_pulse->Draw();
+   if(tpi_pulse) {
+      std::string name=tpi_pulse->GetName();
+      name+="_templateAP";
+      const TH1* tpl = GetTemplate()->GetHisto();
+      TH1F* tap_pulse=(TH1F*) tpi_pulse->Clone(name.c_str());
+      for ( int i=0; i<tap_pulse->GetNbinsX(); i++){
+         // deduce right bin to look in
+         int tpl_bin=i+ GetTime();
+         // get bin sample
+         double sample=tpl->GetBinContent(tpl_bin);
+         // Set sample in histogram that's to be saved
+         tap_pulse->SetBinContent(i,sample*GetAmplitude() + GetPedestal());
+      }
       tap_pulse->Write();
-	}
+   }
 }

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
@@ -35,7 +35,7 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         const TH1F* GetHisto()const;
         const TH1F* GetResidual()const{return fResidual;}
         double GetResidualIntegral()const{return fResidualTotal;}
-
+        double GetIntegralRatio()const{return fIntegralRatio;}
         /// @}
 
         /// @name Setters
@@ -50,6 +50,7 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         void SetTemplate(TTemplate* val){fTemplate=val;}
         void SetResidual(const TH1F* val){fResidual=val;}
         void SetResidualIntegral(double val){fResidualTotal=val;}
+        void SetIntegralRatio(double val){fIntegralRatio=val;}
         /// @}
         
         using TAnalysedPulse::SetAmplitude;
@@ -62,6 +63,7 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
     private:
         int fStatus;
         double fChi2, fNDoF;
+        double fIntegralRatio;
         double fTimeErr, fAmplitudeErr, fPedestalErr; 
         TRef fTemplate;
         const TH1F* fResidual; //!

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
@@ -24,23 +24,27 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         /// @{
         int GetFitStatus()const{return fStatus;}
         double GetChi2()const{return fChi2;}
-        /// @}
-
-        /// @name Error_Getters
-        /// @{
+        double GetNDoF()const{return fNDoF;}
         double GetTimeErr()const{return fTimeErr;}
         double GetPedestalErr()const{return fPedestalErr;}
         double GetAmplitudeErr()const{return fAmplitudeErr;}
         const TTemplate* GetTemplate()const{return (const TTemplate*) fTemplate.GetObject();}
-        const TH1F* GetHisto()const;
-        const TH1F* GetResidual()const{return fResidual;}
         double GetResidualIntegral()const{return fResidualTotal;}
         double GetIntegralRatio()const{return fIntegralRatio;}
+        /// @}
+
+        /// @name Histogram_getters
+        /// @{
+        double GetBinContent(int i)const;
+        const TH1F* GetHisto()const;
+        const TH1F* GetResidual()const{return fResidual;}
         /// @}
 
         /// @name Setters
         /// Set both the value and error for each field
         /// @{
+        void SetTimeOffset(const double& val){TAnalysedPulse::SetTime(GetTemplate()->GetTime()-val);}
+        void SetAmplitudeScaleFactor(const double& val){TAnalysedPulse::SetTime(GetTemplate()->GetAmplitude()*val);}
         void SetTime(const double& val, const double& err){TAnalysedPulse::SetTime(val); fTimeErr=err;}
         void SetAmplitude(const double& val, const double& err){TAnalysedPulse::SetAmplitude(val); fAmplitudeErr=err;}
         void SetPedestal(const double& val, const double& err){TAnalysedPulse::SetPedestal(val); fPedestalErr=err;}

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
@@ -1,0 +1,62 @@
+#ifndef TTEMPLATEFITANALYSEDPULSE_H
+#define TTEMPLATEFITANALYSEDPULSE_H
+
+#include "TAnalysedPulse.h"
+#include <TObject.h>
+
+class TTemplateFitAnalysedPulse:public TAnalysedPulse{
+    public:
+        /// Needed by ROOT but not expected to be used
+        TTemplateFitAnalysedPulse():TAnalysedPulse(){};
+
+        /// @brief Construct a TTemplateFitAnalysedPulse.
+        /// @details Same signature as for TAnalysedPulse so that MakeNewTAP can
+        /// create these specialised TAPs
+        TTemplateFitAnalysedPulse(const IDs::source& sourceID,
+                const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
+            TAnalysedPulse(sourceID,parentID,parentTPI){}
+
+        // defined in .cpp file to force vtable to be built
+        virtual ~TTemplateFitAnalysedPulse(){};
+
+        /// @name Getters
+        /// @{
+        int GetFitStatus()const{return fStatus;}
+        double GetChi2()const{return fChi2;}
+        double GetGradient()const{return fGradient;}
+        double GetWidth()const{return fWidth;}
+        /// @}
+
+        /// @name Error_Getters
+        /// @{
+        double GetGradientErr()const{return fGradientErr;}
+        double GetWidthErr()const{return fWidthErr;}
+        double GetTimeErr()const{return fTimeErr;}
+        double GetPedestalErr()const{return fPedestalErr;}
+        double GetAmplitudeErr()const{return fAmplitudeErr;}
+        /// @}
+
+        /// @name Setters
+        /// Set both the value and error for each field
+        /// @{
+        void SetTime(const double& val, const double& err){TAnalysedPulse::SetTime(val); fTimeErr=err;}
+        void SetAmplitude(const double& val, const double& err){TAnalysedPulse::SetAmplitude(val); fAmplitudeErr=err;}
+        void SetPedestal(const double& val, const double& err){TAnalysedPulse::SetPedestal(val); fPedestalErr=err;}
+        void SetGradient(const double& val, const double& err){fGradient=val; fGradientErr=err;}
+        void SetWidth(const double& val, const double& err){fWidth=val; fWidthErr=err;}
+        void SetChi2(const double& val){fChi2=val;}
+        void SetFitStatus(const double& val){fStatus=val;}
+        /// @}
+
+        /// @@brief overload the TAnalysedPulse::Draw method
+        virtual void Draw(const TH1F* tpi_pulse)const;
+
+    private:
+        int fStatus;
+        double fChi2, fWidth,fGradient;
+        double fTimeErr, fWidthErr, fAmplitudeErr, fPedestalErr, fGradientErr; 
+
+        ClassDef(TTemplateFitAnalysedPulse,1);
+};
+
+#endif // TTEMPLATEFITANALYSEDPULSE_H

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
@@ -18,7 +18,7 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
                 const TPulseIslandID& parentID, const TPulseIsland* parentTPI);
 
         // defined in .cpp file to force vtable to be built
-        virtual ~TTemplateFitAnalysedPulse(){};
+        virtual ~TTemplateFitAnalysedPulse();
 
         /// @name Getters
         /// @{
@@ -31,6 +31,7 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         const TTemplate* GetTemplate()const{return (const TTemplate*) fTemplate.GetObject();}
         double GetResidualIntegral()const{return fResidualTotal;}
         double GetIntegralRatio()const{return fIntegralRatio;}
+        bool WasFirstOfDouble()const{return fOtherPulse && !fIsPileUpPulse;}
         /// @}
 
         /// @name Histogram_getters
@@ -57,6 +58,9 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         void SetIntegralRatio(double val){fIntegralRatio=val;}
         /// @}
         
+        void SetOtherPulse(TTemplateFitAnalysedPulse* pulse){fOtherPulse=pulse;}
+        void IsPileUpPulse(bool is=true){fIsPileUpPulse=is;}
+        
         using TAnalysedPulse::SetAmplitude;
         using TAnalysedPulse::SetPedestal;
         using TAnalysedPulse::SetTime;
@@ -73,6 +77,9 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         const TH1F* fResidual; //!
         mutable const TH1F* fHisto; //!
         double fResidualTotal;
+
+        bool fIsPileUpPulse;
+        TTemplateFitAnalysedPulse* fOtherPulse; //!
 
         ClassDef(TTemplateFitAnalysedPulse,1);
 };

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
@@ -43,16 +43,21 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         void SetAmplitude(const double& val, const double& err){TAnalysedPulse::SetAmplitude(val); fAmplitudeErr=err;}
         void SetPedestal(const double& val, const double& err){TAnalysedPulse::SetPedestal(val); fPedestalErr=err;}
         void SetChi2(const double& val){fChi2=val;}
+        void SetNDoF(const double& val){fNDoF=val;}
         void SetFitStatus(const double& val){fStatus=val;}
         void SetTemplate(TTemplate* val){fTemplate=val;}
         /// @}
+        
+        using TAnalysedPulse::SetAmplitude;
+        using TAnalysedPulse::SetPedestal;
+        using TAnalysedPulse::SetTime;
 
         /// @@brief overload the TAnalysedPulse::Draw method
         virtual void Draw(const TH1F* tpi_pulse)const;
 
     private:
         int fStatus;
-        double fChi2;
+        double fChi2, fNDoF;
         double fTimeErr, fAmplitudeErr, fPedestalErr; 
         TRef fTemplate;
 

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
@@ -24,7 +24,7 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         /// @{
         int GetFitStatus()const{return fStatus;}
         double GetChi2()const{return fChi2;}
-        double GetNDoF()const{return fNDoF;}
+        int GetNDoF()const{return fNDoF;}
         double GetTimeErr()const{return fTimeErr;}
         double GetPedestalErr()const{return fPedestalErr;}
         double GetAmplitudeErr()const{return fAmplitudeErr;}
@@ -43,8 +43,8 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         /// @name Setters
         /// Set both the value and error for each field
         /// @{
-        void SetTimeOffset(const double& val){TAnalysedPulse::SetTime(GetTemplate()->GetTime()-val);}
-        void SetAmplitudeScaleFactor(const double& val){TAnalysedPulse::SetTime(GetTemplate()->GetAmplitude()*val);}
+        void SetTimeOffset(const double& val){TAnalysedPulse::SetTime(GetTemplate()->GetTime()/GetTemplate()->GetRefineFactor()+val);}
+        void SetAmplitudeScaleFactor(const double& val){TAnalysedPulse::SetAmplitude(GetTemplate()->GetAmplitude()*val);}
         void SetTime(const double& val, const double& err){TAnalysedPulse::SetTime(val); fTimeErr=err;}
         void SetAmplitude(const double& val, const double& err){TAnalysedPulse::SetAmplitude(val); fAmplitudeErr=err;}
         void SetPedestal(const double& val, const double& err){TAnalysedPulse::SetPedestal(val); fPedestalErr=err;}

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
@@ -2,6 +2,8 @@
 #define TTEMPLATEFITANALYSEDPULSE_H
 
 #include "TAnalysedPulse.h"
+#include "TTemplate.h"
+#include <TRef.h>
 #include <TObject.h>
 
 class TTemplateFitAnalysedPulse:public TAnalysedPulse{
@@ -23,17 +25,15 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         /// @{
         int GetFitStatus()const{return fStatus;}
         double GetChi2()const{return fChi2;}
-        double GetGradient()const{return fGradient;}
-        double GetWidth()const{return fWidth;}
         /// @}
 
         /// @name Error_Getters
         /// @{
-        double GetGradientErr()const{return fGradientErr;}
-        double GetWidthErr()const{return fWidthErr;}
         double GetTimeErr()const{return fTimeErr;}
         double GetPedestalErr()const{return fPedestalErr;}
         double GetAmplitudeErr()const{return fAmplitudeErr;}
+        const TTemplate* GetTemplate()const{return (const TTemplate*) fTemplate.GetObject();}
+
         /// @}
 
         /// @name Setters
@@ -42,10 +42,9 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         void SetTime(const double& val, const double& err){TAnalysedPulse::SetTime(val); fTimeErr=err;}
         void SetAmplitude(const double& val, const double& err){TAnalysedPulse::SetAmplitude(val); fAmplitudeErr=err;}
         void SetPedestal(const double& val, const double& err){TAnalysedPulse::SetPedestal(val); fPedestalErr=err;}
-        void SetGradient(const double& val, const double& err){fGradient=val; fGradientErr=err;}
-        void SetWidth(const double& val, const double& err){fWidth=val; fWidthErr=err;}
         void SetChi2(const double& val){fChi2=val;}
         void SetFitStatus(const double& val){fStatus=val;}
+        void SetTemplate(TTemplate* val){fTemplate=val;}
         /// @}
 
         /// @@brief overload the TAnalysedPulse::Draw method
@@ -53,8 +52,9 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
 
     private:
         int fStatus;
-        double fChi2, fWidth,fGradient;
-        double fTimeErr, fWidthErr, fAmplitudeErr, fPedestalErr, fGradientErr; 
+        double fChi2;
+        double fTimeErr, fAmplitudeErr, fPedestalErr; 
+        TRef fTemplate;
 
         ClassDef(TTemplateFitAnalysedPulse,1);
 };

--- a/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
+++ b/analyzer/rootana/src/TAP_generators/TTemplateFitAnalysedPulse.h
@@ -15,8 +15,7 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         /// @details Same signature as for TAnalysedPulse so that MakeNewTAP can
         /// create these specialised TAPs
         TTemplateFitAnalysedPulse(const IDs::source& sourceID,
-                const TPulseIslandID& parentID, const TPulseIsland* parentTPI):
-            TAnalysedPulse(sourceID,parentID,parentTPI){}
+                const TPulseIslandID& parentID, const TPulseIsland* parentTPI);
 
         // defined in .cpp file to force vtable to be built
         virtual ~TTemplateFitAnalysedPulse(){};
@@ -33,6 +32,9 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         double GetPedestalErr()const{return fPedestalErr;}
         double GetAmplitudeErr()const{return fAmplitudeErr;}
         const TTemplate* GetTemplate()const{return (const TTemplate*) fTemplate.GetObject();}
+        const TH1F* GetHisto()const;
+        const TH1F* GetResidual()const{return fResidual;}
+        double GetResidualIntegral()const{return fResidualTotal;}
 
         /// @}
 
@@ -46,6 +48,8 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         void SetNDoF(const double& val){fNDoF=val;}
         void SetFitStatus(const double& val){fStatus=val;}
         void SetTemplate(TTemplate* val){fTemplate=val;}
+        void SetResidual(const TH1F* val){fResidual=val;}
+        void SetResidualIntegral(double val){fResidualTotal=val;}
         /// @}
         
         using TAnalysedPulse::SetAmplitude;
@@ -60,6 +64,9 @@ class TTemplateFitAnalysedPulse:public TAnalysedPulse{
         double fChi2, fNDoF;
         double fTimeErr, fAmplitudeErr, fPedestalErr; 
         TRef fTemplate;
+        const TH1F* fResidual; //!
+        mutable const TH1F* fHisto; //!
+        double fResidualTotal;
 
         ClassDef(TTemplateFitAnalysedPulse,1);
 };

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
@@ -59,9 +59,11 @@ int TemplateConvolveAPGenerator::ProcessPulses(
     if(fIntegralRatio && !PassesIntegralRatio(*tpi, integral,ratio)){
        continue;
     }
+    Algorithm::TpiMinusPedestal_iterator waveform((*tpi)->GetSamples().begin(),fPedestal);
+    Algorithm::TpiMinusPedestal_iterator end((*tpi)->GetSamples().end());
 
     // convolve with the template
-    int n_peaks= fConvolver->Convolve(*tpi , fPedestal);
+    int n_peaks= fConvolver->Convolve(waveform,end );
     if(n_peaks<0) {
       if(Debug())cout<<"Waveform too small to analyze"<<endl;
       continue;
@@ -70,6 +72,9 @@ int TemplateConvolveAPGenerator::ProcessPulses(
     int count=0;
     for(TemplateConvolver::PeaksVector::const_iterator i_tap=peaks.begin();
           i_tap!=peaks.end(); ++i_tap){
+    //for(int i_peak=0; i_peak<3 || fConvolver->GetPeaks().size()==0 ; ++i_peak){
+    //   // get the first pulse to be found
+    //   const TemplateConvolver::FoundPeaks& i_tap=*fConvolver->GetPeaks().begin();
     
        // Make a new TAP to store the data.  This method makes a TAP and sets the parent TPI info.  It needs
        // the index of the parent TPI in the container as an argument
@@ -92,7 +97,12 @@ int TemplateConvolveAPGenerator::ProcessPulses(
 
        // Finally add the new TAP to the output list
        analysedList.push_back(tap);
-       ++count;
+
+       //// subtract template from first peak and convolve again
+       //waveform.AddHistogram(fConvolver->GetTemplateACF(), i_tap.amplitude, -i_tap.time+fConvolver->GetLeftSafety());
+       //n_peaks= fConvolver->Convolve(waveform,end );
+       //if(n_peaks==0) break;
+       count++;
     }
   }
 

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
@@ -95,4 +95,4 @@ bool TemplateConvolveAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse,
 }
 
 
-ALCAP_TAP_GENERATOR(TemplateConvolve);
+ALCAP_TAP_GENERATOR(TemplateConvolve, template_archive, peak_cut, use_IR_cut, min_integral, max_integral, min_ratio, max_ratio );

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
@@ -122,6 +122,7 @@ int TemplateConvolveAPGenerator::ProcessPulses(
 bool TemplateConvolveAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse, double& integral, double& ratio)const{
    if(!fIntegralRatio) return true;
    try{
+     fIntegralRatio->SetPedestalToMinimum(pulse);
      (*fIntegralRatio)(pulse);
    }catch(std::out_of_range& e){
      return false;

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
@@ -27,6 +27,7 @@ TemplateConvolveAPGenerator::TemplateConvolveAPGenerator(TAPGeneratorOptions* op
    fTemplate->NormaliseToSumSquares();
 
    fConvolver=new TemplateConvolver(GetChannel(), fTemplate, opts->GetDouble("pulse_cut",1e6));
+   fConvolver->AutoCorrelateTemplate();
 
    // prepare the integral ratio cuts
    if(opts->GetFlag("use_IR_cut")){

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
@@ -26,7 +26,10 @@ TemplateConvolveAPGenerator::TemplateConvolveAPGenerator(TAPGeneratorOptions* op
    fTemplate->RebinToOriginalSampling();
    fTemplate->NormaliseToSumSquares();
 
-   fConvolver=new TemplateConvolver(GetChannel(), fTemplate, opts->GetDouble("n_quad_fit",5));
+   int fit_peak= opts->GetInt("n_quad_fit",5);
+   int left= opts->GetInt("left",20);
+   int right= opts->GetInt("right",120);
+   fConvolver=new TemplateConvolver(GetChannel(), fTemplate, fit_peak, left, right);
    TH1* tpl=(TH1*)fTemplate->GetHisto()->Clone("Template");
    tpl->SetDirectory(gDirectory);
    fConvolver->CharacteriseTemplate();
@@ -126,4 +129,4 @@ bool TemplateConvolveAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse,
 }
 
 
-ALCAP_TAP_GENERATOR(TemplateConvolve, template_archive, n_quad_fit, use_IR_cut, min_integral, max_integral, min_ratio, max_ratio );
+ALCAP_TAP_GENERATOR(TemplateConvolve, template_archive, n_quad_fit, left, right, use_IR_cut, min_integral, max_integral, min_ratio, max_ratio );

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
@@ -27,6 +27,8 @@ TemplateConvolveAPGenerator::TemplateConvolveAPGenerator(TAPGeneratorOptions* op
    fTemplate->NormaliseToSumSquares();
 
    fConvolver=new TemplateConvolver(GetChannel(), fTemplate, opts->GetDouble("pulse_cut",1e6));
+   TH1* tpl=(TH1*)fTemplate->GetHisto()->Clone("Template");
+   tpl->SetDirectory(gDirectory);
    fConvolver->AutoCorrelateTemplate();
 
    // prepare the integral ratio cuts

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
@@ -1,0 +1,98 @@
+#include "TemplateConvolveAPGenerator.h"
+
+#include "EventNavigator.h"
+#include "TAPGeneratorFactory.h"
+#include "TemplateConvolver.h"
+#include "TPulseIsland.h"
+#include "TAnalysedPulse.h"
+#include "debug_tools.h"
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+TemplateArchive* TemplateConvolveAPGenerator::fTemplateArchive=NULL;
+
+TemplateConvolveAPGenerator::TemplateConvolveAPGenerator(TAPGeneratorOptions* opts):
+   TVAnalysedPulseGenerator("TemplateConvolve",opts),
+    fPedestal(EventNavigator::Instance().GetSetupRecord().GetPedestal(GetChannel())),
+    fIntegralRatio(NULL)
+{
+   // get the templates from the archive
+   if(!fTemplateArchive){
+     fTemplateArchive=new TemplateArchive(opts->GetString("template_archive").c_str(),"READ");
+   }
+   fTemplate=fTemplateArchive->GetTemplate(GetChannel());
+
+   fConvolver=new TemplateConvolver(GetChannel(), fTemplate, opts->GetDouble("pulse_cut",1e6));
+
+   // prepare the integral ratio cuts
+   if(opts->GetFlag("use_IR_cut")){
+      fIntegralRatio=new Algorithm::IntegralRatio(
+                      opts->GetInt("start_integral",10),
+                      opts->GetInt("start_tail",60),
+                      opts->GetInt("stop_integral",0),
+                      EventNavigator::Instance().GetSetupRecord().GetPolarity(GetChannel()));
+      fIntegralMax=opts->GetDouble("max_integral");
+      fIntegralMin=opts->GetDouble("min_integral");
+      fIntegralRatioMax=opts->GetDouble("max_ratio");
+      fIntegralRatioMin=opts->GetDouble("min_ratio");
+  }
+}
+
+int TemplateConvolveAPGenerator::ProcessPulses( 
+    const PulseIslandList& pulseList,
+    AnalysedPulseList& analysedList){
+
+  // Loop over all the TPIs given to us
+  double integral, ratio;
+  TTemplateConvolveAnalysedPulse* tap;
+  for (PulseIslandList::const_iterator tpi=pulseList.begin();
+       tpi!=pulseList.end(); tpi++){
+
+    // Check integral ratio if we're supposed to
+    if(fIntegralRatio && !PassesIntegralRatio(*tpi, integral,ratio)){
+       continue;
+    }
+
+    // convolve with the template
+    int n_peaks= fConvolver->Convolve(*tpi);
+
+    // Make a new TAP to store the data.  This method makes a TAP and sets the parent TPI info.  It needs
+    // the index of the parent TPI in the container as an argument
+    tap = MakeNewTAP<TTemplateConvolveAnalysedPulse>(tpi-pulseList.begin());
+    if(fIntegralRatio){
+      tap->SetIntegral(integral);
+      tap->SetIntegralRatio(ratio);
+    }
+    tap->SetNPeaks(n_peaks);
+    tap->SetEnergyConvolve(fConvolver->GetEnergyConvolution());
+    tap->SetTimeConvolve(fConvolver->GetTimeConvolution());
+    tap->SetTime(fConvolver->GetTime());
+    tap->SetAmplitude(fConvolver->GetAmplitude());
+
+    // Finally add the new TAP to the output list
+    analysedList.push_back(tap);
+  }
+
+  return 0;
+}
+
+bool TemplateConvolveAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse, double& integral, double& ratio)const{
+   if(!fIntegralRatio) return true;
+   try{
+     (*fIntegralRatio)(pulse);
+   }catch(std::out_of_range& e){
+     return false;
+   }
+   integral=fIntegralRatio->GetTotal();
+   ratio=fIntegralRatio->GetRatio();
+   if( fIntegralMax < integral || fIntegralMin > integral
+       || fIntegralRatioMax < ratio || fIntegralRatioMin > ratio) {
+       return false;
+   }
+   return true;
+}
+
+
+ALCAP_TAP_GENERATOR(TemplateConvolve);

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.cpp
@@ -23,6 +23,7 @@ TemplateConvolveAPGenerator::TemplateConvolveAPGenerator(TAPGeneratorOptions* op
      fTemplateArchive=new TemplateArchive(opts->GetString("template_archive").c_str(),"READ");
    }
    fTemplate=fTemplateArchive->GetTemplate(GetChannel());
+   fTemplate->RebinToOriginalSampling();
 
    fConvolver=new TemplateConvolver(GetChannel(), fTemplate, opts->GetDouble("pulse_cut",1e6));
 
@@ -57,6 +58,10 @@ int TemplateConvolveAPGenerator::ProcessPulses(
 
     // convolve with the template
     int n_peaks= fConvolver->Convolve(*tpi);
+    if(n_peaks<0) {
+      cout<<"Waveform too small to analyze"<<endl;
+      continue;
+    }
 
     // Make a new TAP to store the data.  This method makes a TAP and sets the parent TPI info.  It needs
     // the index of the parent TPI in the container as an argument

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.h
@@ -1,0 +1,46 @@
+#ifndef TEMPLATECONVOLVE_H__
+#define TEMPLATECONVOLVE_H__
+
+#include "TSetupData.h"
+#include "TVAnalysedPulseGenerator.h"
+#include "definitions.h"
+#include "TTemplate.h"
+#include "TemplateArchive.h"
+#include "TTemplateConvolveAnalysedPulse.h"
+#include "TAPAlgorithms.h"
+
+class TemplateConvolver;
+
+class TemplateConvolveAPGenerator:public TVAnalysedPulseGenerator {
+
+ public:
+  TemplateConvolveAPGenerator(TAPGeneratorOptions* opts);
+  virtual ~TemplateConvolveAPGenerator(){};
+
+ public:
+   virtual int ProcessPulses( const PulseIslandList&,AnalysedPulseList&);
+
+   virtual bool MayDivideTPIs(){return true;};
+
+   static const char* TapType() {
+       return TTemplateConvolveAnalysedPulse::Class()->GetName();
+   }
+
+  private:
+    bool PassesIntegralRatio(const TPulseIsland* pulse,double& integral, double& ratio)const;
+
+  private:
+    static TemplateArchive* fTemplateArchive;
+    TTemplate* fTemplate;
+    TemplateConvolver* fConvolver;
+
+    double fIntegralMax, fIntegralMin;
+    double fIntegralRatioMax, fIntegralRatioMin;
+    double fTemplateAmp, fTemplatePed, fTemplateTime;
+    double fPedestal;
+
+    Algorithm::IntegralRatio* fIntegralRatio;
+
+};
+
+#endif //TEMPLATECONVOLVE_H__

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.h
@@ -8,6 +8,7 @@
 #include "TemplateArchive.h"
 #include "TTemplateConvolveAnalysedPulse.h"
 #include "TAPAlgorithms.h"
+#include <vector>
 
 class TemplateConvolver;
 

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.h
@@ -1,5 +1,5 @@
-#ifndef TEMPLATECONVOLVE_H__
-#define TEMPLATECONVOLVE_H__
+#ifndef TEMPLATECONVOLVEAPGENERATOR_H__
+#define TEMPLATECONVOLVEAPGENERATOR_H__
 
 #include "TSetupData.h"
 #include "TVAnalysedPulseGenerator.h"
@@ -39,9 +39,10 @@ class TemplateConvolveAPGenerator:public TVAnalysedPulseGenerator {
     double fIntegralRatioMax, fIntegralRatioMin;
     double fTemplateAmp, fTemplatePed, fTemplateTime;
     double fPedestal;
+    bool fExpectPileUp; // Do we expect this generator to have to deal with pile-up waveforms?
 
     Algorithm::IntegralRatio* fIntegralRatio;
 
 };
 
-#endif //TEMPLATECONVOLVE_H__
+#endif //TEMPLATECONVOLVEAPGENERATOR_H__

--- a/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateConvolveAPGenerator.h
@@ -29,6 +29,8 @@ class TemplateConvolveAPGenerator:public TVAnalysedPulseGenerator {
 
   private:
     bool PassesIntegralRatio(const TPulseIsland* pulse,double& integral, double& ratio)const;
+    /// Convert time from clock time within the TPI to real time
+    double CalibrateTime(double clockTime, const TPulseIsland* tpi)const;
 
   private:
     static TemplateArchive* fTemplateArchive;
@@ -39,6 +41,7 @@ class TemplateConvolveAPGenerator:public TVAnalysedPulseGenerator {
     double fIntegralRatioMax, fIntegralRatioMin;
     double fTemplateAmp, fTemplatePed, fTemplateTime;
     double fPedestal;
+    double fTicksPerNs, fMuScTimeOffset;
     bool fExpectPileUp; // Do we expect this generator to have to deal with pile-up waveforms?
 
     Algorithm::IntegralRatio* fIntegralRatio;

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
@@ -149,6 +149,7 @@ int TemplateFitAPGenerator::ProcessPulses(
 bool TemplateFitAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse, double& integral, double& ratio)const{
    if(!fIntegralRatio) return true;
    try{
+     fIntegralRatio->SetPedestalToMinimum(pulse);
      (*fIntegralRatio)(pulse);
    }catch(std::out_of_range& e){
      return false;

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
@@ -11,6 +11,7 @@ using std::cout;
 using std::endl;
 
 TemplateArchive* TemplateFitAPGenerator::fTemplateArchive=NULL;
+TemplateArchive* TemplateFitAPGenerator::fTemplateArchive2=NULL;
 
 TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
    TVAnalysedPulseGenerator("TemplateFitAPGenerator",opts),
@@ -18,11 +19,25 @@ TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
     fIntegralRatio(NULL),
     fMaxBin(fInitPedestal, EventNavigator::Instance().GetSetupRecord().GetPolarity(GetChannel()))
 {
+   // get the templates from the archive
    if(!fTemplateArchive){
      fTemplateArchive=new TemplateArchive(opts->GetString("template_archive").c_str(),"READ");
    }
+   if(opts->HasOption("template_archive_2") && opts->GetString("template_archive_2")!=fTemplateArchive->GetName()){
+     std::string template_2_src=opts->GetString("template_archive_2");
+     if(!fTemplateArchive2)
+     fTemplateArchive2=new TemplateArchive(opts->GetString("template_archive_2").c_str(),"READ");
+   } else if(!fTemplateArchive2){
+     fTemplateArchive2=fTemplateArchive;
+   }
    fTemplate=fTemplateArchive->GetTemplate(GetChannel());
+   fTemplate2=fTemplateArchive2->GetTemplate(GetChannel());
+
+   // make the fitters
    fFitter = new TemplateFitter(GetChannel().str(), fTemplate->GetRefineFactor());
+   fDoubleFitter = new TemplateMultiFitter(GetChannel().str(), fTemplate->GetRefineFactor());
+
+   // prepare the integral ratio cuts
    if(opts->GetFlag("use_IR_cut")){
       fIntegralRatio=new Algorithm::IntegralRatio(
                       opts->GetInt("start_integral",10),
@@ -35,9 +50,31 @@ TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
       fIntegralRatioMin=opts->GetDouble("min_ratio");
   }
 
+  // cache the template parameters so we dont need to look them up
   fTemplateAmp=fTemplate->GetAmplitude();
   fTemplateTime=fTemplate->GetTime();
   fTemplatePed=fTemplate->GetPedestal();
+
+  fTemplate2Amp=fTemplate2->GetAmplitude();
+  fTemplate2Time=fTemplate2->GetTime();
+  fTemplate2Ped=fTemplate2->GetPedestal();
+
+  // chi2 to determine when we refit with 2 pulses
+  fChi2MinToRefit=opts->GetDouble("min_chi2_to_refit",2e8);
+}
+
+TemplateFitAPGenerator::~TemplateFitAPGenerator(){
+  delete fFitter;
+  delete fDoubleFitter;
+  if(fIntegralRatio) delete fIntegralRatio;
+  if(fTemplateArchive) {
+    delete fTemplateArchive;
+    fTemplateArchive=NULL;
+  }
+  if(fTemplateArchive2) {
+    delete fTemplateArchive2;
+    fTemplateArchive2=NULL;
+  }
 }
 
 int TemplateFitAPGenerator::ProcessPulses( 
@@ -54,7 +91,7 @@ int TemplateFitAPGenerator::ProcessPulses(
        continue;
     }
     double init_amp=fMaxBin(*tpi)/fTemplateAmp;
-    double init_time= fTemplateTime-fMaxBin.time*fTemplate->GetRefineFactor();
+    double init_time= fTemplateTime - fMaxBin.time * fTemplate->GetRefineFactor();
     fFitter->SetInitialParameterEstimates(fInitPedestal, init_amp, init_time);
 
     // Analyse each TPI
@@ -67,26 +104,29 @@ int TemplateFitAPGenerator::ProcessPulses(
     // the index of the parent TPI in the container as an argument
     tap = MakeNewTAP<TTemplateFitAnalysedPulse>(tpi-pulseList.begin());
     tap->SetTemplate(fTemplate);
-    tap->SetAmplitude(fFitter->GetAmplitudeScaleFactor());
     tap->SetPedestal(fFitter->GetPedestalOffset());
-    tap->SetTime(fFitter->GetTimeOffset());
+    tap->SetAmplitudeScaleFactor(fFitter->GetAmplitudeScaleFactor());
+    tap->SetTimeOffset(fFitter->GetTimeOffset());
     tap->SetChi2(fFitter->GetChi2());
     tap->SetNDoF(fFitter->GetNDoF());
     tap->SetFitStatus(fit_status);
     tap->SetIntegral(integral);
     tap->SetIntegralRatio(ratio);
 
-    // Histogram the residual
-      TH1F* residual=(TH1F*) hPulseToFit->Clone("residual");
-      const TH1F* tap_pulse=tap->GetHisto();
-      residual->Add(tap_pulse, -1);
+    if(fFitter->GetChi2() > fChi2MinToRefit){
+        TTemplateFitAnalysedPulse* second_tap=NULL;
+        bool better_with_2 = RefitWithTwo(hPulseToFit, tap, second_tap);
+        if(better_with_2){
+           analysedList.push_back(tap);
+           analysedList.push_back(second_tap);
+        } else{
+           analysedList.push_back(tap);
+           if(second_tap) delete second_tap;
+        }
+    } else {
+       analysedList.push_back(tap);
+    }
 
-    tap->SetResidualIntegral(residual->Integral());
-    delete residual;
-    //tap->SetResidual(residual);
-
-    // Finally add the new TAP to the output list
-    analysedList.push_back(tap);
    }
 
    // returning 0 tells the caller that we were successful, return non-zero if not
@@ -108,6 +148,60 @@ bool TemplateFitAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse, doub
    }
    return true;
 }
+
+bool TemplateFitAPGenerator::RefitWithTwo(TH1D* tpi, TTemplateFitAnalysedPulse*& tap_one, TTemplateFitAnalysedPulse*& tap_two)const{
+
+  // find the max bin after the current fitted tap
+  tpi->GetXaxis()->SetRange(tap_one->GetTime());
+  int second_time=tpi->GetMaximumBin();
+  tpi->GetXaxis()->UnZoom();
+  double second_scale=tpi->GetBinContent(second_time) - tap_one->GetBinContent(second_time);
+  second_scale /=fTemplate2->GetHisto()->GetMaximum();
+
+  // fit the second template around the second peak
+  fDoubleFitter->SetPulseEstimates( 0, tap_one->GetAmplitude(), tap_one->GetTime());
+  fDoubleFitter->SetPulseEstimates( 1, second_scale, second_time);
+  fDoubleFitter->FixTimeForAllBut(1);
+  int fit_status = fDoubleFitter->FitToPulse(tpi);
+
+  // fit the first pulse again
+  fDoubleFitter->FixTimeForAllBut(0);
+  fit_status = fDoubleFitter->FitToPulse(tpi);
+
+  // fit the second pulse again
+  fDoubleFitter->FixTimeForAll();
+  fit_status = fDoubleFitter->FitToPulse(tpi);
+
+  if(fit_status==0){
+    // Has the double fit improved the chi-2 per NDoF
+    double old_chi2=tap_one->GetChi2()/tap_one->GetNDoF();
+    double new_chi2=fDoubleFitter->GetChi2()/fDoubleFitter->GetNDoF();
+    if( (old_chi2 - new_chi2) < 0){
+      // refill tap_one's values
+      tap_one->SetPedestal(fDoubleFitter->GetPedestalOffset());
+      tap_one->SetAmplitude(fDoubleFitter->GetAmplitude(2));
+      tap_one->SetTime(fDoubleFitter->GetTime(2));
+      tap_one->SetChi2(fDoubleFitter->GetChi2());
+      tap_one->SetNDoF(fDoubleFitter->GetNDoF());
+      tap_one->SetFitStatus(fit_status);
+
+      // make the second tap
+      tap_two = MakeNewTAP<TTemplateFitAnalysedPulse>(tap_one->GetParentID());
+      tap_two->SetTemplate(fTemplate2);
+      tap_two->SetPedestal(fDoubleFitter->GetPedestalOffset());
+      tap_two->SetAmplitudeScaleFactor(fDoubleFitter->GetAmplitudeScaleFactor(1));
+      tap_two->SetTimeOffset(fDoubleFitter->GetTimeOffset());
+      tap_two->SetChi2(fDoubleFitter->GetChi2());
+      tap_two->SetNDoF(fDoubleFitter->GetNDoF());
+      tap_two->SetFitStatus(fit_status);
+
+      return true;
+    }
+  } 
+
+  return false;
+}
+
 // Similar to the modules, this macro registers the generator with
 // MakeAnalysedPulses. The first argument is compulsory and gives the name of
 // this generator. All subsequent arguments will be used as names for arguments

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
@@ -4,6 +4,7 @@
 #include "TAnalysedPulse.h"
 #include "TTemplateFitAnalysedPulse.h"
 #include "InterpolatePulse.h"
+#include "EventNavigator.h"
 #include <iostream>
 using std::cout;
 using std::endl;
@@ -11,12 +12,25 @@ using std::endl;
 TemplateArchive* TemplateFitAPGenerator::fTemplateArchive=NULL;
 
 TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
-   TVAnalysedPulseGenerator("TemplateFitAPGenerator",opts){
+   TVAnalysedPulseGenerator("TemplateFitAPGenerator",opts),
+    fIntegralRatio(NULL)
+{
    if(!fTemplateArchive){
      fTemplateArchive=new TemplateArchive(opts->GetString("template_archive").c_str(),"READ");
    }
    fTemplate=fTemplateArchive->GetTemplate(GetChannel());
    fFitter = new TemplateFitter(GetChannel().str(), fTemplate->GetRefineFactor());
+   if(opts->GetFlag("use_IR_cut")){
+      fIntegralRatio=new Algorithm::IntegralRatio(
+                      opts->GetInt("start_integral",10),
+                      opts->GetInt("start_tail",60),
+                      opts->GetInt("stop_integral",0),
+                      EventNavigator::Instance().GetSetupRecord().GetPolarity(GetChannel()));
+      fIntegralMax=opts->GetDouble("max_integral");
+      fIntegralMin=opts->GetDouble("min_integral");
+      fIntegralRatioMax=opts->GetDouble("max_ratio");
+      fIntegralRatioMin=opts->GetDouble("min_ratio");
+  }
 }
 
 int TemplateFitAPGenerator::ProcessPulses( 
@@ -27,6 +41,10 @@ int TemplateFitAPGenerator::ProcessPulses(
   TTemplateFitAnalysedPulse* tap;
   for (PulseIslandList::const_iterator tpi=pulseList.begin();
        tpi!=pulseList.end(); tpi++){
+
+    if(fIntegralRatio && !PassesIntegralRatio(*tpi)){
+       continue;
+    }
 
     // Analyse each TPI
     TH1D* hPulseToFit=InterpolatePulse(*tpi,"hPulseToFit","hPulseToFit",false,fTemplate->GetRefineFactor());
@@ -47,23 +65,29 @@ int TemplateFitAPGenerator::ProcessPulses(
     // Finally add the new TAP to the output list
     analysedList.push_back(tap);
    }
-   
-   // Generators have a Debug method similar to modules
-   if(Debug()){
-    // They also have a unique ID, retrievable by GetSource and
-      // a GetChannel method to get the ID of just the channel
-    cout<<"Now running source: "<<GetSource().str()<<" which looks for TAPs on "
-        "channel: "<<GetChannel().str()<<'\n';
-   }
 
    // returning 0 tells the caller that we were successful, return non-zero if not
    return 0;
 }
-
+bool TemplateFitAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse)const{
+   if(!fIntegralRatio) return true;
+   try{
+     (*fIntegralRatio)(pulse);
+   }catch(std::out_of_range& e){
+     return false;
+   }
+   const double& integral=fIntegralRatio->GetTotal();
+   const double& ratio=fIntegralRatio->GetRatio();
+   if( fIntegralMax < integral || fIntegralMin > integral
+       || fIntegralRatioMax < ratio || fIntegralRatioMin > ratio) {
+       return false;
+   }
+   return true;
+}
 // Similar to the modules, this macro registers the generator with
 // MakeAnalysedPulses. The first argument is compulsory and gives the name of
 // this generator. All subsequent arguments will be used as names for arguments
 // given directly within the modules file.  See the github wiki for more.
 //
 // NOTE: for TAP generators OMIT the APGenerator part of the class' name
-ALCAP_TAP_GENERATOR(TemplateFit,template_archive);
+ALCAP_TAP_GENERATOR(TemplateFit,template_archive,use_IR_cut, min_integral, max_integral, min_ratio, max_ratio);

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
@@ -69,7 +69,7 @@ TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
   }
 
   // chi2 to determine when we refit with 2 pulses
-  fChi2MinToRefit=opts->GetDouble("min_chi2_to_refit",2e8);
+  fChi2MinToRefit=opts->GetDouble("min_chi2_to_refit",2e5);
 }
 
 TemplateFitAPGenerator::~TemplateFitAPGenerator(){
@@ -201,6 +201,11 @@ bool TemplateFitAPGenerator::RefitWithTwo(TH1D* tpi, TTemplateFitAnalysedPulse*&
       tap_two->SetChi2(fDoubleFitter->GetChi2());
       tap_two->SetNDoF(fDoubleFitter->GetNDoF());
       tap_two->SetFitStatus(fit_status);
+
+      // link the two pulses together
+      tap_one->SetOtherPulse(tap_two);
+      tap_two->SetOtherPulse(tap_one);
+      tap_two->IsPileUpPulse();
 
       return true;
     }

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
@@ -16,6 +16,7 @@ TemplateArchive* TemplateFitAPGenerator::fTemplateArchive2=NULL;
 TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
    TVAnalysedPulseGenerator("TemplateFitAPGenerator",opts),
     fInitPedestal(EventNavigator::Instance().GetSetupRecord().GetPedestal(GetChannel())),
+    fTemplate2(NULL),
     fIntegralRatio(NULL),
     fMaxBin(fInitPedestal, EventNavigator::Instance().GetSetupRecord().GetPolarity(GetChannel()))
 {
@@ -23,22 +24,25 @@ TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
    if(!fTemplateArchive){
      fTemplateArchive=new TemplateArchive(opts->GetString("template_archive").c_str(),"READ");
    }
-   if(opts->HasOption("template_archive_2") && opts->GetString("template_archive_2")!=fTemplateArchive->GetName()){
+   if(opts->HasOption("template_archive_2")){
      std::string template_2_src=opts->GetString("template_archive_2");
-     if(!fTemplateArchive2)
-     fTemplateArchive2=new TemplateArchive(opts->GetString("template_archive_2").c_str(),"READ");
-   } else if(!fTemplateArchive2){
-     fTemplateArchive2=fTemplateArchive;
+     if (template_2_src!=fTemplateArchive->GetName() && !fTemplateArchive2)
+        fTemplateArchive2=new TemplateArchive(opts->GetString("template_archive_2").c_str(),"READ");
+     else if(!fTemplateArchive2){
+        fTemplateArchive2=fTemplateArchive;
+     }
    }
    fTemplate=fTemplateArchive->GetTemplate(GetChannel());
-   fTemplate2=fTemplateArchive2->GetTemplate(GetChannel());
+   if(fTemplateArchive2) fTemplate2=fTemplateArchive2->GetTemplate(GetChannel());
 
    // make the fitters
    fFitter = new TemplateFitter(GetChannel().str(), fTemplate->GetRefineFactor());
-   fDoubleFitter = new TemplateMultiFitter(GetChannel().str());
-   fDoubleFitter->AddTemplate(fTemplate);
-   fDoubleFitter->AddTemplate(fTemplate2);
-   fDoubleFitter->Init();
+   if(fTemplate2){
+     fDoubleFitter = new TemplateMultiFitter(GetChannel().str());
+     fDoubleFitter->AddTemplate(fTemplate);
+     fDoubleFitter->AddTemplate(fTemplate2);
+     fDoubleFitter->Init();
+   }
 
    // prepare the integral ratio cuts
    if(opts->GetFlag("use_IR_cut")){
@@ -58,9 +62,11 @@ TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
   fTemplateTime=fTemplate->GetTime();
   fTemplatePed=fTemplate->GetPedestal();
 
-  fTemplate2Amp=fTemplate2->GetAmplitude();
-  fTemplate2Time=fTemplate2->GetTime();
-  fTemplate2Ped=fTemplate2->GetPedestal();
+  if(fTemplate2){
+     fTemplate2Amp=fTemplate2->GetAmplitude();
+     fTemplate2Time=fTemplate2->GetTime();
+     fTemplate2Ped=fTemplate2->GetPedestal();
+  }
 
   // chi2 to determine when we refit with 2 pulses
   fChi2MinToRefit=opts->GetDouble("min_chi2_to_refit",2e8);
@@ -98,7 +104,7 @@ int TemplateFitAPGenerator::ProcessPulses(
     double init_time= fTemplateTime - fMaxBin.time * fTemplate->GetRefineFactor();
     fFitter->SetInitialParameterEstimates(fInitPedestal, init_amp, init_time);
 
-    // Analyse each TPI
+    // Make histo for TPI
     TH1D* hPulseToFit=InterpolatePulse(*tpi,"hPulseToFit","hPulseToFit",false,fTemplate->GetRefineFactor());
     
     int fit_status = fFitter->FitPulseToTemplate(fTemplate, hPulseToFit, (*tpi)->GetBankName());
@@ -110,14 +116,14 @@ int TemplateFitAPGenerator::ProcessPulses(
     tap->SetTemplate(fTemplate);
     tap->SetPedestal(fFitter->GetPedestalOffset());
     tap->SetAmplitudeScaleFactor(fFitter->GetAmplitudeScaleFactor());
-    tap->SetTimeOffset(fFitter->GetTimeOffset());
+    tap->SetTimeOffset(-fFitter->GetTimeOffset());
     tap->SetChi2(fFitter->GetChi2());
     tap->SetNDoF(fFitter->GetNDoF());
     tap->SetFitStatus(fit_status);
     tap->SetIntegral(integral);
     tap->SetIntegralRatio(ratio);
 
-    if(fFitter->GetChi2() > fChi2MinToRefit){
+    if(fTemplate2 && fFitter->GetChi2() > fChi2MinToRefit){
         TTemplateFitAnalysedPulse* second_tap=NULL;
         bool better_with_2 = RefitWithTwo(hPulseToFit, tap, second_tap);
         if(better_with_2){
@@ -190,8 +196,8 @@ bool TemplateFitAPGenerator::RefitWithTwo(TH1D* tpi, TTemplateFitAnalysedPulse*&
       tap_two = MakeNewTAP<TTemplateFitAnalysedPulse>(tap_one->GetParentID());
       tap_two->SetTemplate(fTemplate2);
       tap_two->SetPedestal(fDoubleFitter->GetPedestal());
-      tap_two->SetAmplitudeScaleFactor(fDoubleFitter->GetAmplitude(1));
-      tap_two->SetTimeOffset(fDoubleFitter->GetTime(1));
+      tap_two->SetAmplitude(fDoubleFitter->GetAmplitude(1));
+      tap_two->SetTime(fDoubleFitter->GetTime(1));
       tap_two->SetChi2(fDoubleFitter->GetChi2());
       tap_two->SetNDoF(fDoubleFitter->GetNDoF());
       tap_two->SetFitStatus(fit_status);
@@ -203,10 +209,4 @@ bool TemplateFitAPGenerator::RefitWithTwo(TH1D* tpi, TTemplateFitAnalysedPulse*&
   return false;
 }
 
-// Similar to the modules, this macro registers the generator with
-// MakeAnalysedPulses. The first argument is compulsory and gives the name of
-// this generator. All subsequent arguments will be used as names for arguments
-// given directly within the modules file.  See the github wiki for more.
-//
-// NOTE: for TAP generators OMIT the APGenerator part of the class' name
-ALCAP_TAP_GENERATOR(TemplateFit,template_archive,use_IR_cut, min_integral, max_integral, min_ratio, max_ratio);
+ALCAP_TAP_GENERATOR(TemplateFit,template_archive,use_IR_cut, min_integral, max_integral, min_ratio, max_ratio, template_archive_2);

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
@@ -1,0 +1,69 @@
+#include "TAPGeneratorFactory.h"
+#include "TemplateFitAPGenerator.h"
+#include "TPulseIsland.h"
+#include "TAnalysedPulse.h"
+#include "TTemplateFitAnalysedPulse.h"
+#include "InterpolatePulse.h"
+#include <iostream>
+using std::cout;
+using std::endl;
+
+TemplateArchive* TemplateFitAPGenerator::fTemplateArchive=NULL;
+
+TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
+   TVAnalysedPulseGenerator("TemplateFitAPGenerator",opts){
+   if(!fTemplateArchive){
+     fTemplateArchive=new TemplateArchive(opts->GetString("template_archive").c_str(),"READ");
+   }
+   fTemplate=fTemplateArchive->GetTemplate(GetChannel());
+   fFitter = new TemplateFitter(GetChannel().str(), fTemplate->GetRefineFactor());
+}
+
+int TemplateFitAPGenerator::ProcessPulses( 
+      const PulseIslandList& pulseList,
+      AnalysedPulseList& analysedList){
+
+  // Loop over all the TPIs given to us
+  TTemplateFitAnalysedPulse* tap;
+  for (PulseIslandList::const_iterator tpi=pulseList.begin();
+       tpi!=pulseList.end(); tpi++){
+
+    // Analyse each TPI
+    TH1D* hPulseToFit=InterpolatePulse(*tpi,"hPulseToFit","hPulseToFit",false,fTemplate->GetRefineFactor());
+    int fit_status = fFitter->FitPulseToTemplate(fTemplate, hPulseToFit, (*tpi)->GetBankName());
+
+    // Now that we've found the information we were looking for make a TAP to
+    // hold it.  This method makes a TAP and sets the parent TPI info.  It needs
+    // the index of the parent TPI in the container as an argument
+    tap = MakeNewTAP<TTemplateFitAnalysedPulse>(tpi-pulseList.begin());
+    tap->SetTemplate(fTemplate);
+    tap->SetAmplitude(fFitter->GetAmplitudeScaleFactor());
+    tap->SetPedestal(fFitter->GetPedestalOffset());
+    tap->SetTime(fFitter->GetTimeOffset());
+    tap->SetChi2(fFitter->GetChi2());
+    tap->SetNDoF(fFitter->GetNDoF());
+    tap->SetFitStatus(fit_status);
+
+    // Finally add the new TAP to the output list
+    analysedList.push_back(tap);
+   }
+   
+   // Generators have a Debug method similar to modules
+   if(Debug()){
+    // They also have a unique ID, retrievable by GetSource and
+      // a GetChannel method to get the ID of just the channel
+    cout<<"Now running source: "<<GetSource().str()<<" which looks for TAPs on "
+        "channel: "<<GetChannel().str()<<'\n';
+   }
+
+   // returning 0 tells the caller that we were successful, return non-zero if not
+   return 0;
+}
+
+// Similar to the modules, this macro registers the generator with
+// MakeAnalysedPulses. The first argument is compulsory and gives the name of
+// this generator. All subsequent arguments will be used as names for arguments
+// given directly within the modules file.  See the github wiki for more.
+//
+// NOTE: for TAP generators OMIT the APGenerator part of the class' name
+ALCAP_TAP_GENERATOR(TemplateFit,template_archive);

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
@@ -5,6 +5,7 @@
 #include "TTemplateFitAnalysedPulse.h"
 #include "InterpolatePulse.h"
 #include "EventNavigator.h"
+#include "debug_tools.h"
 #include <iostream>
 using std::cout;
 using std::endl;
@@ -13,7 +14,9 @@ TemplateArchive* TemplateFitAPGenerator::fTemplateArchive=NULL;
 
 TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
    TVAnalysedPulseGenerator("TemplateFitAPGenerator",opts),
-    fIntegralRatio(NULL)
+    fInitPedestal(EventNavigator::Instance().GetSetupRecord().GetPedestal(GetChannel())),
+    fIntegralRatio(NULL),
+    fMaxBin(fInitPedestal, EventNavigator::Instance().GetSetupRecord().GetPolarity(GetChannel()))
 {
    if(!fTemplateArchive){
      fTemplateArchive=new TemplateArchive(opts->GetString("template_archive").c_str(),"READ");
@@ -31,6 +34,10 @@ TemplateFitAPGenerator::TemplateFitAPGenerator(TAPGeneratorOptions* opts):
       fIntegralRatioMax=opts->GetDouble("max_ratio");
       fIntegralRatioMin=opts->GetDouble("min_ratio");
   }
+
+  fTemplateAmp=fTemplate->GetAmplitude();
+  fTemplateTime=fTemplate->GetTime();
+  fTemplatePed=fTemplate->GetPedestal();
 }
 
 int TemplateFitAPGenerator::ProcessPulses( 
@@ -39,15 +46,20 @@ int TemplateFitAPGenerator::ProcessPulses(
 
   // Loop over all the TPIs given to us
   TTemplateFitAnalysedPulse* tap;
+  double integral, ratio;
   for (PulseIslandList::const_iterator tpi=pulseList.begin();
        tpi!=pulseList.end(); tpi++){
 
-    if(fIntegralRatio && !PassesIntegralRatio(*tpi)){
+    if(fIntegralRatio && !PassesIntegralRatio(*tpi, integral,ratio)){
        continue;
     }
+    double init_amp=fMaxBin(*tpi)/fTemplateAmp;
+    double init_time= fTemplateTime-fMaxBin.time*fTemplate->GetRefineFactor();
+    fFitter->SetInitialParameterEstimates(fInitPedestal, init_amp, init_time);
 
     // Analyse each TPI
     TH1D* hPulseToFit=InterpolatePulse(*tpi,"hPulseToFit","hPulseToFit",false,fTemplate->GetRefineFactor());
+    
     int fit_status = fFitter->FitPulseToTemplate(fTemplate, hPulseToFit, (*tpi)->GetBankName());
 
     // Now that we've found the information we were looking for make a TAP to
@@ -61,6 +73,17 @@ int TemplateFitAPGenerator::ProcessPulses(
     tap->SetChi2(fFitter->GetChi2());
     tap->SetNDoF(fFitter->GetNDoF());
     tap->SetFitStatus(fit_status);
+    tap->SetIntegral(integral);
+    tap->SetIntegralRatio(ratio);
+
+    // Histogram the residual
+      TH1F* residual=(TH1F*) hPulseToFit->Clone("residual");
+      const TH1F* tap_pulse=tap->GetHisto();
+      residual->Add(tap_pulse, -1);
+
+    tap->SetResidualIntegral(residual->Integral());
+    delete residual;
+    //tap->SetResidual(residual);
 
     // Finally add the new TAP to the output list
     analysedList.push_back(tap);
@@ -69,15 +92,16 @@ int TemplateFitAPGenerator::ProcessPulses(
    // returning 0 tells the caller that we were successful, return non-zero if not
    return 0;
 }
-bool TemplateFitAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse)const{
+
+bool TemplateFitAPGenerator::PassesIntegralRatio(const TPulseIsland* pulse, double& integral, double& ratio)const{
    if(!fIntegralRatio) return true;
    try{
      (*fIntegralRatio)(pulse);
    }catch(std::out_of_range& e){
      return false;
    }
-   const double& integral=fIntegralRatio->GetTotal();
-   const double& ratio=fIntegralRatio->GetRatio();
+   integral=fIntegralRatio->GetTotal();
+   ratio=fIntegralRatio->GetRatio();
    if( fIntegralMax < integral || fIntegralMin > integral
        || fIntegralRatioMax < ratio || fIntegralRatioMin > ratio) {
        return false;

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.cpp
@@ -103,7 +103,7 @@ int TemplateFitAPGenerator::ProcessPulses(
        continue;
     }
     double init_amp=fMaxBin(*tpi)/fTemplateAmp;
-    double init_time=  fMaxBin.time * fTemplate->GetRefineFactor()- fTemplateTime ;
+    double init_time=  fMaxBin.GetTime() * fTemplate->GetRefineFactor()- fTemplateTime ;
     fFitter->SetPedestal(fInitPedestal);
     fFitter->SetPulseEstimates(0, init_amp, init_time);
 

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
@@ -1,0 +1,37 @@
+#ifndef TEMPLATEFITAPGENERATOR_H__
+#define TEMPLATEFITAPGENERATOR_H__
+
+#include "TSetupData.h"
+#include "TVAnalysedPulseGenerator.h"
+#include "definitions.h"
+#include "TemplateArchive.h"
+#include "TemplateFitter.h"
+#include "TTemplate.h"
+#include "TTemplateFitAnalysedPulse.h"
+
+class TemplateFitAPGenerator:public TVAnalysedPulseGenerator {
+
+ public:
+  TemplateFitAPGenerator(TAPGeneratorOptions* opts);
+  virtual ~TemplateFitAPGenerator(){};
+
+ public:
+   virtual int ProcessPulses( const PulseIslandList&,AnalysedPulseList&);
+
+   // This function should return true if this generator could break up a TPI
+   // into more than one TAP
+   virtual bool MayDivideTPIs(){return true;};
+   
+
+   static const char* TapType() {
+       return TTemplateFitAnalysedPulse::Class()->GetName();
+   }
+
+private:
+   static TemplateArchive* fTemplateArchive;
+   TTemplate* fTemplate;
+   TemplateFitter* fFitter;
+
+};
+
+#endif //TEMPLATEFITAPGENERATOR_H__

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
@@ -6,6 +6,7 @@
 #include "definitions.h"
 #include "TemplateArchive.h"
 #include "TemplateFitter.h"
+#include "TemplateMultiFitter.h"
 #include "TTemplate.h"
 #include "TTemplateFitAnalysedPulse.h"
 #include "TAPAlgorithms.h"

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
@@ -29,15 +29,18 @@ class TemplateFitAPGenerator:public TVAnalysedPulseGenerator {
     }
 
   private:
-    bool PassesIntegralRatio(const TPulseIsland* pulse)const;
+    bool PassesIntegralRatio(const TPulseIsland* pulse,double& integral, double& ratio)const;
 
   private:
     static TemplateArchive* fTemplateArchive;
+    double fIntegralMax, fIntegralMin;
+    double fIntegralRatioMax, fIntegralRatioMin;
+    double fTemplateAmp, fTemplatePed, fTemplateTime;
+    double fInitPedestal;
     TTemplate* fTemplate;
     TemplateFitter* fFitter;
     Algorithm::IntegralRatio* fIntegralRatio;
-    double fIntegralMax, fIntegralMin;
-    double fIntegralRatioMax, fIntegralRatioMin;
+    Algorithm::MaxBinAmplitude fMaxBin;
 
 };
 

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
@@ -46,7 +46,7 @@ class TemplateFitAPGenerator:public TVAnalysedPulseGenerator {
     double fChi2MinToRefit;
     TTemplate* fTemplate;
     TTemplate* fTemplate2;
-    TemplateFitter* fFitter;
+    TemplateMultiFitter* fFitter;
     TemplateMultiFitter* fDoubleFitter;
     Algorithm::IntegralRatio* fIntegralRatio;
     Algorithm::MaxBinAmplitude fMaxBin;

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
@@ -14,7 +14,7 @@ class TemplateFitAPGenerator:public TVAnalysedPulseGenerator {
 
  public:
     TemplateFitAPGenerator(TAPGeneratorOptions* opts);
-    virtual ~TemplateFitAPGenerator(){};
+    virtual ~TemplateFitAPGenerator();
 
  public:
     virtual int ProcessPulses( const PulseIslandList&,AnalysedPulseList&);
@@ -30,15 +30,21 @@ class TemplateFitAPGenerator:public TVAnalysedPulseGenerator {
 
   private:
     bool PassesIntegralRatio(const TPulseIsland* pulse,double& integral, double& ratio)const;
+    bool RefitWithTwo( TH1D* tpi, TTemplateFitAnalysedPulse*& tap_one, TTemplateFitAnalysedPulse*& tap_two)const;
 
   private:
     static TemplateArchive* fTemplateArchive;
+    static TemplateArchive* fTemplateArchive2;
     double fIntegralMax, fIntegralMin;
     double fIntegralRatioMax, fIntegralRatioMin;
     double fTemplateAmp, fTemplatePed, fTemplateTime;
+    double fTemplate2Amp, fTemplate2Ped, fTemplate2Time;
     double fInitPedestal;
+    double fChi2MinToRefit;
     TTemplate* fTemplate;
+    TTemplate* fTemplate2;
     TemplateFitter* fFitter;
+    TemplateMultiFitter* fDoubleFitter;
     Algorithm::IntegralRatio* fIntegralRatio;
     Algorithm::MaxBinAmplitude fMaxBin;
 

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
@@ -32,6 +32,8 @@ class TemplateFitAPGenerator:public TVAnalysedPulseGenerator {
   private:
     bool PassesIntegralRatio(const TPulseIsland* pulse,double& integral, double& ratio)const;
     bool RefitWithTwo( TH1D* tpi, TTemplateFitAnalysedPulse*& tap_one, TTemplateFitAnalysedPulse*& tap_two)const;
+    void InitializeSecondPulse( TH1D* tpi, const TTemplateFitAnalysedPulse* tap_one,
+          int& second_time, double& second_scale)const;
 
   private:
     static TemplateArchive* fTemplateArchive;

--- a/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
+++ b/analyzer/rootana/src/TAP_generators/TemplateFitAPGenerator.h
@@ -8,29 +8,36 @@
 #include "TemplateFitter.h"
 #include "TTemplate.h"
 #include "TTemplateFitAnalysedPulse.h"
+#include "TAPAlgorithms.h"
 
 class TemplateFitAPGenerator:public TVAnalysedPulseGenerator {
 
  public:
-  TemplateFitAPGenerator(TAPGeneratorOptions* opts);
-  virtual ~TemplateFitAPGenerator(){};
+    TemplateFitAPGenerator(TAPGeneratorOptions* opts);
+    virtual ~TemplateFitAPGenerator(){};
 
  public:
-   virtual int ProcessPulses( const PulseIslandList&,AnalysedPulseList&);
+    virtual int ProcessPulses( const PulseIslandList&,AnalysedPulseList&);
 
-   // This function should return true if this generator could break up a TPI
-   // into more than one TAP
-   virtual bool MayDivideTPIs(){return true;};
+    // This function should return true if this generator could break up a TPI
+    // into more than one TAP
+    virtual bool MayDivideTPIs(){return true;};
    
 
-   static const char* TapType() {
-       return TTemplateFitAnalysedPulse::Class()->GetName();
-   }
+    static const char* TapType() {
+        return TTemplateFitAnalysedPulse::Class()->GetName();
+    }
 
-private:
-   static TemplateArchive* fTemplateArchive;
-   TTemplate* fTemplate;
-   TemplateFitter* fFitter;
+  private:
+    bool PassesIntegralRatio(const TPulseIsland* pulse)const;
+
+  private:
+    static TemplateArchive* fTemplateArchive;
+    TTemplate* fTemplate;
+    TemplateFitter* fFitter;
+    Algorithm::IntegralRatio* fIntegralRatio;
+    double fIntegralMax, fIntegralMin;
+    double fIntegralRatioMax, fIntegralRatioMin;
 
 };
 

--- a/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
@@ -4,13 +4,118 @@
 #include "debug_tools.h"
 #include <TH1.h>
 #include <iostream>
+#include <utility>
 
 namespace Algorithm{
    class TH1_c_iterator;
    class TH1_wrapper;
    template < typename WeightIterator>
    class Convolver;
+   template < typename InputIterator>
+   class Pedestal_iterator;
 }
+
+class Algorithm::TH1_c_iterator:public std::iterator<std::random_access_iterator_tag, double>{
+   public:
+     TH1_c_iterator():fHist(NULL),fCurrentBin(0),fScale(1.){}
+     TH1_c_iterator(const TH1* hist, int init=1,double scale=1.):fHist(hist),fCurrentBin(init),fScale(scale){}
+     TH1_c_iterator(const TH1_c_iterator& rhs):fHist(rhs.fHist),fCurrentBin(rhs.fCurrentBin),fScale(rhs.fScale){}
+     TH1_c_iterator operator++(){
+       ++fCurrentBin;
+       return *this;
+     }
+     TH1_c_iterator operator++(int){
+       TH1_c_iterator tmp(*this);
+       ++fCurrentBin;
+       return tmp;
+     }
+     TH1_c_iterator operator--(){
+       --fCurrentBin;
+       return *this;
+     }
+     TH1_c_iterator operator--(int){
+       TH1_c_iterator tmp(*this);
+       --fCurrentBin;
+       return tmp;
+     }
+     double operator*()const{ 
+       return fHist?fHist->GetBinContent(fCurrentBin)*fScale:0;
+     }
+     TH1_c_iterator operator+=(int n){
+       fCurrentBin+=n;
+       return *this;
+     }
+
+     TH1_c_iterator operator+(int n)const{ 
+       TH1_c_iterator tmp(*this);
+       tmp.fCurrentBin+=n;
+       return tmp;
+     }
+     TH1_c_iterator operator-(int n)const{ 
+       TH1_c_iterator tmp(*this);
+       tmp.fCurrentBin-=n;
+       return tmp;
+     }
+     bool operator!=(const TH1_c_iterator& rhs)const{
+       return fCurrentBin!=rhs.fCurrentBin || fHist!=rhs.fHist ;
+     }
+     bool operator==(const TH1_c_iterator& rhs)const{
+       return  fCurrentBin==rhs.fCurrentBin && fHist==rhs.fHist;
+     }
+     int operator-(const TH1_c_iterator& rhs)const{ 
+       return fCurrentBin-rhs.fCurrentBin;
+     }
+
+   private:
+     const TH1* fHist;
+     int fCurrentBin;
+     double fScale;
+};
+
+struct Algorithm::TH1_wrapper{
+    TH1_wrapper(const TH1*  hist, double scale=1.): fHisto(hist), fScale(scale){};
+    TH1_c_iterator begin(int skip=0)const{return TH1_c_iterator(fHisto,1+skip,fScale);}
+    TH1_c_iterator end(int skip=0)const{return TH1_c_iterator(fHisto,fHisto->GetNbinsX()-skip,fScale);}
+
+    private:
+    const TH1* fHisto;
+    double fScale;
+};
+
+template <typename InputIterator >
+struct Algorithm::Pedestal_iterator:public InputIterator{
+typedef std::pair<TH1_c_iterator, TH1_c_iterator> HistIter;
+typedef std::vector<HistIter> HistList;
+     Pedestal_iterator(const InputIterator& it, double ped):InputIterator(it),fPedestal(ped){}
+     Pedestal_iterator(const InputIterator& it):InputIterator(it),fPedestal(0){}
+     double operator*()const{
+        ;
+        double val=InputIterator::operator*() - fPedestal;
+        for(HistList::const_iterator i_hist=fHistograms.begin(); i_hist!=fHistograms.end(); ++i_hist){
+           val-=*(i_hist->first);
+        }
+       return val;
+     }
+     void operator++(){
+        InputIterator::operator++();
+        for(HistList::iterator i_hist=fHistograms.begin(); i_hist!=fHistograms.end(); ){
+           ++(i_hist->first);
+           if( i_hist->first == i_hist->second ){
+             fHistograms.erase(i_hist); 
+	     continue;
+	   }
+           ++i_hist;
+	}
+     }
+     void AddHistogram(TH1* hist,double scale){
+       TH1_wrapper wrap(hist, scale);
+       fHistograms.push_back(std::make_pair(wrap.begin(), wrap.end()));
+     }
+
+     private:
+     double fPedestal;
+     HistList fHistograms;
+};
 
 template < typename WeightIterator>
 class Algorithm::Convolver{
@@ -43,71 +148,6 @@ class Algorithm::Convolver{
       int fNWeights;
       WeightIterator fBegin;
       WeightIterator fEnd;
-};
-
-class Algorithm::TH1_c_iterator:public std::iterator<std::random_access_iterator_tag, double>{
-   public:
-     TH1_c_iterator():fHist(NULL),fCurrentBin(0){}
-     TH1_c_iterator(const TH1* hist, int init=1):fHist(hist),fCurrentBin(init){}
-     TH1_c_iterator(const TH1_c_iterator& rhs):fHist(rhs.fHist),fCurrentBin(rhs.fCurrentBin){}
-     TH1_c_iterator operator++(){
-       ++fCurrentBin;
-       return *this;
-     }
-     TH1_c_iterator operator++(int){
-       TH1_c_iterator tmp(*this);
-       ++fCurrentBin;
-       return tmp;
-     }
-     TH1_c_iterator operator--(){
-       --fCurrentBin;
-       return *this;
-     }
-     TH1_c_iterator operator--(int){
-       TH1_c_iterator tmp(*this);
-       --fCurrentBin;
-       return tmp;
-     }
-     double operator*()const{ 
-       return fHist?fHist->GetBinContent(fCurrentBin):0;
-     }
-     TH1_c_iterator operator+=(int n){
-       fCurrentBin+=n;
-       return *this;
-     }
-
-     TH1_c_iterator operator+(int n)const{ 
-       TH1_c_iterator tmp(*this);
-       tmp.fCurrentBin+=n;
-       return tmp;
-     }
-     TH1_c_iterator operator-(int n)const{ 
-       TH1_c_iterator tmp(*this);
-       tmp.fCurrentBin-=n;
-       return tmp;
-     }
-     bool operator!=(const TH1_c_iterator& rhs)const{
-       return fCurrentBin!=rhs.fCurrentBin || fHist!=rhs.fHist ;
-     }
-     bool operator==(const TH1_c_iterator& rhs)const{
-       return  fCurrentBin==rhs.fCurrentBin && fHist==rhs.fHist;
-     }
-     int operator-(const TH1_c_iterator& rhs)const{ 
-       return fCurrentBin-rhs.fCurrentBin;
-     }
-
-   private:
-     const TH1* fHist;
-     int fCurrentBin;
-};
-
-struct Algorithm::TH1_wrapper{
-    TH1_wrapper(const TH1*  hist): fHisto(hist){};
-    TH1_c_iterator begin(int skip=0)const{return TH1_c_iterator(fHisto,1+skip);}
-    TH1_c_iterator end(int skip=0)const{return TH1_c_iterator(fHisto,fHisto->GetNbinsX()-skip);}
-
-    private:
-    const TH1* fHisto;
 };
 
 #endif// TEMPLATE_FITTING_CONVOLVER_H

--- a/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
@@ -1,0 +1,108 @@
+#ifndef TEMPLATE_FITTING_CONVOLVER_H
+#define TEMPLATE_FITTING_CONVOLVER_H
+
+#include <TH1.h>
+
+namespace Algorithm{
+   class TH1_c_iterator;
+   class TH1_wrapper;
+   template < typename WeightIterator>
+   class Convolver;
+}
+
+template < typename WeightIterator>
+class Algorithm::Convolver{
+   public:
+      Convolver( WeightIterator begin, WeightIterator end):fNWeights(end-begin),fBegin(begin), fEnd(end){}
+      
+      template <typename InputIterator >
+      double operator()(const InputIterator& start){
+        double ret_val=0;
+        InputIterator i_in=start;
+        for(WeightIterator i_weight=fBegin; i_weight!=fEnd; ++i_weight){
+           ret_val+= (*i_weight)*(*(i_in++));
+        }
+        return ret_val;
+      }
+
+      template <typename InputIterator, typename OutputIterator >
+      OutputIterator operator()(const InputIterator& start, const InputIterator& stop, OutputIterator result){
+        InputIterator end=stop-fNWeights;
+        for(InputIterator i_in=start;i_in!=end;++i_in){
+           *(result++)=operator()(i_in);
+        }
+        return result;
+      }
+
+   private:
+      ptrdiff_t fNWeights;
+      WeightIterator fBegin;
+      WeightIterator fEnd;
+};
+
+class Algorithm::TH1_c_iterator:public std::iterator<std::random_access_iterator_tag, double>{
+   public:
+     TH1_c_iterator():fHist(NULL),fCurrentBin(0){}
+     TH1_c_iterator(const TH1* hist, int init=1):fHist(hist),fCurrentBin(init){}
+     TH1_c_iterator(const TH1_c_iterator& rhs):fHist(rhs.fHist),fCurrentBin(rhs.fCurrentBin){}
+     TH1_c_iterator operator++(){
+       ++fCurrentBin;
+       return *this;
+     }
+     TH1_c_iterator operator++(int){
+       TH1_c_iterator tmp(*this);
+       ++fCurrentBin;
+       return tmp;
+     }
+     TH1_c_iterator operator--(){
+       --fCurrentBin;
+       return *this;
+     }
+     TH1_c_iterator operator--(int){
+       TH1_c_iterator tmp(*this);
+       --fCurrentBin;
+       return tmp;
+     }
+     double operator*()const{ 
+       return fHist?fHist->GetBinContent(fCurrentBin):0;
+     }
+     TH1_c_iterator operator+=(int n){
+       fCurrentBin+=n;
+       return *this;
+     }
+
+     TH1_c_iterator operator+(int n)const{ 
+       TH1_c_iterator tmp(*this);
+       tmp.fCurrentBin+=n;
+       return tmp;
+     }
+     TH1_c_iterator operator-(int n)const{ 
+       TH1_c_iterator tmp(*this);
+       tmp.fCurrentBin-=n;
+       return tmp;
+     }
+     bool operator!=(const TH1_c_iterator& rhs)const{
+       return fCurrentBin!=rhs.fCurrentBin || fHist!=rhs.fHist ;
+     }
+     bool operator==(const TH1_c_iterator& rhs)const{
+       return  fCurrentBin==rhs.fCurrentBin && fHist==rhs.fHist;
+     }
+     ptrdiff_t operator-(const TH1_c_iterator& rhs)const{ 
+       return fCurrentBin-rhs.fCurrentBin;
+     }
+
+   private:
+     const TH1* fHist;
+     int fCurrentBin;
+};
+
+struct Algorithm::TH1_wrapper{
+    TH1_wrapper(const TH1*  hist): fHisto(hist){};
+    TH1_c_iterator begin(int skip=0)const{return TH1_c_iterator(fHisto,1+skip);}
+    TH1_c_iterator end(int skip=0)const{return TH1_c_iterator(fHisto,fHisto->GetNbinsX()+skip);}
+
+    private:
+    const TH1* fHisto;
+};
+
+#endif// TEMPLATE_FITTING_CONVOLVER_H

--- a/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
@@ -40,7 +40,7 @@ class Algorithm::Convolver{
       }
 
    private:
-      ptrdiff_t fNWeights;
+      int fNWeights;
       WeightIterator fBegin;
       WeightIterator fEnd;
 };
@@ -92,7 +92,7 @@ class Algorithm::TH1_c_iterator:public std::iterator<std::random_access_iterator
      bool operator==(const TH1_c_iterator& rhs)const{
        return  fCurrentBin==rhs.fCurrentBin && fHist==rhs.fHist;
      }
-     ptrdiff_t operator-(const TH1_c_iterator& rhs)const{ 
+     int operator-(const TH1_c_iterator& rhs)const{ 
        return fCurrentBin-rhs.fCurrentBin;
      }
 

--- a/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
@@ -23,7 +23,8 @@ class Algorithm::Convolver{
         double ret_val=0;
         InputIterator i_in=start;
         for(WeightIterator i_weight=fBegin; i_weight!=fEnd; ++i_weight){
-           ret_val+= (*i_weight)*(*(i_in++));
+           ret_val+=(*i_weight)*(*i_in);
+           ++i_in;
         }
         return ret_val;
       }
@@ -32,7 +33,8 @@ class Algorithm::Convolver{
       OutputIterator operator()(const InputIterator& start, const InputIterator& stop, OutputIterator result){
         InputIterator end=stop-fNWeights;
         for(InputIterator i_in=start;i_in!=end;++i_in){
-           *(result++)=operator()(i_in);
+           *(result)=operator()(i_in);
+           ++result;
         }
         return result;
       }

--- a/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
@@ -30,7 +30,7 @@ class Algorithm::Convolver{
       }
 
       template <typename InputIterator, typename OutputIterator >
-      OutputIterator operator()(const InputIterator& start, const InputIterator& stop, OutputIterator result){
+      OutputIterator Process(const InputIterator& start, const InputIterator& stop, OutputIterator result){
         InputIterator end=stop-fNWeights;
         for(InputIterator i_in=start;i_in!=end;++i_in){
            *(result)=operator()(i_in);

--- a/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/Convolver.h
@@ -1,7 +1,9 @@
 #ifndef TEMPLATE_FITTING_CONVOLVER_H
 #define TEMPLATE_FITTING_CONVOLVER_H
 
+#include "debug_tools.h"
 #include <TH1.h>
+#include <iostream>
 
 namespace Algorithm{
    class TH1_c_iterator;
@@ -13,7 +15,8 @@ namespace Algorithm{
 template < typename WeightIterator>
 class Algorithm::Convolver{
    public:
-      Convolver( WeightIterator begin, WeightIterator end):fNWeights(end-begin),fBegin(begin), fEnd(end){}
+      Convolver( WeightIterator begin, WeightIterator end):fNWeights(end-begin),fBegin(begin), fEnd(end){
+      }
       
       template <typename InputIterator >
       double operator()(const InputIterator& start){
@@ -99,7 +102,7 @@ class Algorithm::TH1_c_iterator:public std::iterator<std::random_access_iterator
 struct Algorithm::TH1_wrapper{
     TH1_wrapper(const TH1*  hist): fHisto(hist){};
     TH1_c_iterator begin(int skip=0)const{return TH1_c_iterator(fHisto,1+skip);}
-    TH1_c_iterator end(int skip=0)const{return TH1_c_iterator(fHisto,fHisto->GetNbinsX()+skip);}
+    TH1_c_iterator end(int skip=0)const{return TH1_c_iterator(fHisto,fHisto->GetNbinsX()-skip);}
 
     private:
     const TH1* fHisto;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/QuadraticFit.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/QuadraticFit.h
@@ -16,7 +16,6 @@ class QuadraticFit{
   public:
   /// @brief constructor Taking the number of samples that will be fit to when using this instance 
   QuadraticFit(int length):fN(length+(length+1)%2),fX2(0),fX4(0){
-   //for(double i= -(length-1)/2; i < (length+1)/2; ++i){
    int range=(fN-1)/2;
    for(double x= -range; x <= range; ++x){
      fX2+=x*x;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/QuadraticFit.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/QuadraticFit.h
@@ -1,0 +1,45 @@
+#ifndef TEMPLATE_FITTING_QUADRATICFIT_H
+#define TEMPLATE_FITTING_QUADRATICFIT_H
+
+#include <iterator>
+
+namespace functions{
+
+class QuadraticFit{
+
+  public:
+  QuadraticFit(int length):fN(length),fX2(0),fX4(0){
+   for(int i= -(length-1)/2; i < (length+1)/2; ++i){
+     fX2+=i*i;
+     fX4+=i*i*i*i;
+   }
+   fDet=fX4*fN*fX2 - fX2*fX2*fX2;
+  }
+
+  template <typename InputIterator>
+  void Fit(InputIterator i_in, double& a, double& b, double& c){
+   double Sy=0, Sxy=0, Sx2y=0, y=0;
+   for(int x= -(fN)/2; x < (fN+1)/2; ++x){
+     y=*i_in;
+     Sy+=y;
+     Sxy+=x*y;
+     Sx2y+=x*x*y;
+     ++i_in;
+   }
+   double Da=Sx2y*fX2*fN  - Sy  *fX2*fX2;
+   double Db=Sxy *fX4*fN  - Sxy *fX2*fX2;
+   double Dc=Sy  *fX4*fX2 - Sx2y*fX2*fX2;
+   a=Da/fDet;
+   b=Db/fDet;
+   c=Dc/fDet;
+  }
+
+  int GetSize()const{return fN;}
+  private:
+  int fN;
+  double fDet, fX2, fX4;
+};
+   
+} //namespace functions
+
+#endif // TEMPLATE_FITTING_QUADRATICFIT_H

--- a/analyzer/rootana/src/TAP_generators/template_fitting/QuadraticFit.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/QuadraticFit.h
@@ -2,28 +2,45 @@
 #define TEMPLATE_FITTING_QUADRATICFIT_H
 
 #include <iterator>
+#include "debug_tools.h"
 
 namespace functions{
 
+/// @brief Functor(-ish) class to calculate fit of a quadratic to N data-points
+/// @author Ben Krikler
+/// 
+/// @details Assumes that the x values are spaced evenly and centred at 0 so that the sum over odd powers of x is 0.
+/// Uses a formula derived from least squares regression 
 class QuadraticFit{
 
   public:
-  QuadraticFit(int length):fN(length),fX2(0),fX4(0){
-   for(int i= -(length-1)/2; i < (length+1)/2; ++i){
-     fX2+=i*i;
-     fX4+=i*i*i*i;
+  /// @brief constructor Taking the number of samples that will be fit to when using this instance 
+  QuadraticFit(int length):fN(length+(length+1)%2),fX2(0),fX4(0){
+   //for(double i= -(length-1)/2; i < (length+1)/2; ++i){
+   int range=(fN-1)/2;
+   for(double x= -range; x <= range; ++x){
+     fX2+=x*x;
+     fX4+=x*x*x*x;
    }
    fDet=fX4*fN*fX2 - fX2*fX2*fX2;
   }
 
+  /// @brief Fit a given set of samples.
+  /// @details The input iterator should be the first sample to fit.  Since we
+  /// assume the central sample is the origin, (which simplifies the maths
+  /// considerably), the initial iterator should be set back N/2 samples from the
+  /// centre of the fit, where N is the number of samples to fit. For example,
+  /// to fit a peak at X using 6 samples,  the input iterator should point to X-3.
   template <typename InputIterator>
   void Fit(InputIterator i_in, double& a, double& b, double& c){
    double Sy=0, Sxy=0, Sx2y=0, y=0;
-   for(int x= -(fN)/2; x < (fN+1)/2; ++x){
+   int range=(fN-1)/2;
+   for(double x= -range; x <= range; ++x){
      y=*i_in;
      Sy+=y;
      Sxy+=x*y;
      Sx2y+=x*x*y;
+     //DEBUG_VALUE(x, y,Sy, Sxy, Sx2y);
      ++i_in;
    }
    double Da=Sx2y*fX2*fN  - Sy  *fX2*fX2;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
@@ -137,7 +137,7 @@ void TTemplate::NormaliseToAmplitude(){
     SubtractPedestal();
 
     double norm = std::fabs(fTemplatePulse->GetMaximum()); 
-    fTemplatePulse->Scale(1.0/norm);
+    ScaleHist(1./norm);
 }
 
 void TTemplate::NormaliseToIntegral(){
@@ -146,7 +146,7 @@ void TTemplate::NormaliseToIntegral(){
     SubtractPedestal();
 
     double norm = fTemplatePulse->Integral(); 
-    fTemplatePulse->Scale(1.0/norm);
+    ScaleHist(1./norm);
 }
 
 void TTemplate::NormaliseToSumSquares(){
@@ -154,11 +154,11 @@ void TTemplate::NormaliseToSumSquares(){
     fTemplatePulse->SetBit(TH1::kIsAverage);
     SubtractPedestal();
 
-    TH1* tmp = (TH1*) fTemplatePulse->Clone("tmp"); 
+    TH1D* tmp = (TH1D*) fTemplatePulse->Clone("tmp"); 
     tmp->Multiply(tmp);
     double norm = sqrt(tmp->Integral());
-    fTemplatePulse->Scale(1.0/norm);
     delete tmp;
+    ScaleHist(1./norm);
 }
 
 TH1* TTemplate::RebinToOriginalSampling(){
@@ -184,6 +184,18 @@ void TTemplate::SubtractPedestal(){
       fTemplatePulse->SetBinContent(iBin, new_value);
     }
 }
+
+void TTemplate::ScaleHist(double factor){
+
+    // Subtract off the pedesal
+    for (int iBin = 0; iBin <= fTemplatePulse->GetNbinsX(); ++iBin) {
+      double old_value = fTemplatePulse->GetBinContent(iBin);
+      double new_value = old_value * factor;
+
+      fTemplatePulse->SetBinContent(iBin, new_value);
+    }
+}
+
 
 double TTemplate::GetPedestal()const{
   return fTemplatePulse->GetBinContent(1);

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
@@ -149,6 +149,18 @@ void TTemplate::NormaliseToIntegral(){
     fTemplatePulse->Scale(1.0/norm);
 }
 
+void TTemplate::NormaliseToSumSquares(){
+    if(!fTemplatePulse) return;
+    fTemplatePulse->SetBit(TH1::kIsAverage);
+    SubtractPedestal();
+
+    TH1* tmp = (TH1*) fTemplatePulse->Clone("tmp"); 
+    tmp->Multiply(tmp);
+    double norm = sqrt(tmp->Integral());
+    fTemplatePulse->Scale(1.0/norm);
+    delete tmp;
+}
+
 TH1* TTemplate::RebinToOriginalSampling(){
    return fTemplatePulse->Rebin(fRefineFactor);
 }

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
@@ -24,7 +24,9 @@ TTemplate::TTemplate(const std::string& det,int refine,int trigger_polarity, boo
   fRefineFactor(refine),
   fTriggerPolarity(trigger_polarity),
   fChannel(det),
+  fName(MakeName(fChannel)),
   fTemplatePulse(NULL){
+
        // Setup the error hist
        std::string error_histname = "hErrorVsPulseAdded_" + fChannel.str();
        std::string error_histtitle = "Plot of the Error as each new Pulse is added to the template for the " + fChannel.str() + " channel";
@@ -151,8 +153,8 @@ void TTemplate::Normalise(){
     // Integrate over the histogram and scale to give an area of 1
     // Want the absolute value for the integral because of the negative
     // polarity pulses
-    double integral = std::fabs(fTemplatePulse->Integral()); 
-    fTemplatePulse->Scale(1.0/integral);
+    double norm = std::fabs(fTemplatePulse->GetMaximum()); 
+    fTemplatePulse->Scale(1.0/norm);
 }
 
 double TTemplate::GetPedestal()const{

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
@@ -40,6 +40,7 @@ TTemplate::~TTemplate(){
 void TTemplate::Initialize(int pulseID, TH1D* pulse, TDirectory* dir){
   
   fTemplatePulse=pulse;
+  fTemplatePulse->SetBit(TH1::kIsAverage);
   ++fTotalPulses;
 }
 
@@ -132,6 +133,7 @@ bool TTemplate::CheckConverged(){
 
 void TTemplate::NormaliseToAmplitude(){
     if(!fTemplatePulse) return;
+    fTemplatePulse->SetBit(TH1::kIsAverage);
     SubtractPedestal();
 
     double norm = std::fabs(fTemplatePulse->GetMaximum()); 
@@ -140,10 +142,15 @@ void TTemplate::NormaliseToAmplitude(){
 
 void TTemplate::NormaliseToIntegral(){
     if(!fTemplatePulse) return;
+    fTemplatePulse->SetBit(TH1::kIsAverage);
     SubtractPedestal();
 
     double norm = fTemplatePulse->Integral(); 
     fTemplatePulse->Scale(1.0/norm);
+}
+
+TH1* TTemplate::RebinToOriginalSampling(){
+   return fTemplatePulse->Rebin(fRefineFactor);
 }
     
 void TTemplate::SubtractPedestal(){

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.cpp
@@ -130,8 +130,23 @@ bool TTemplate::CheckConverged(){
   return fConverged;
 }
 
-void TTemplate::Normalise(){
+void TTemplate::NormaliseToAmplitude(){
     if(!fTemplatePulse) return;
+    SubtractPedestal();
+
+    double norm = std::fabs(fTemplatePulse->GetMaximum()); 
+    fTemplatePulse->Scale(1.0/norm);
+}
+
+void TTemplate::NormaliseToIntegral(){
+    if(!fTemplatePulse) return;
+    SubtractPedestal();
+
+    double norm = fTemplatePulse->Integral(); 
+    fTemplatePulse->Scale(1.0/norm);
+}
+    
+void TTemplate::SubtractPedestal(){
 
     // Normalise the template so that it has pedestal=0 and amplitude=1
     // Work out the pedestal of the template from the first 5 bins
@@ -149,12 +164,6 @@ void TTemplate::Normalise(){
 
       fTemplatePulse->SetBinContent(iBin, new_value);
     }
-
-    // Integrate over the histogram and scale to give an area of 1
-    // Want the absolute value for the integral because of the negative
-    // polarity pulses
-    double norm = std::fabs(fTemplatePulse->GetMaximum()); 
-    fTemplatePulse->Scale(1.0/norm);
 }
 
 double TTemplate::GetPedestal()const{

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
@@ -29,6 +29,7 @@ class TTemplate:public TObject{
 
       void NormaliseToAmplitude();
       void NormaliseToIntegral();
+      void NormaliseToSumSquares();
       TH1* RebinToOriginalSampling();
 
       double GetPedestal()const;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
@@ -26,8 +26,10 @@ class TTemplate:public TObject{
         fTemplatePulse->SetDirectory(dir);
         fErrors->SetDirectory(dir);
       }
+
       void NormaliseToAmplitude();
       void NormaliseToIntegral();
+      TH1* RebinToOriginalSampling();
 
       double GetPedestal()const;
       double GetTime()const;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
@@ -26,7 +26,8 @@ class TTemplate:public TObject{
         fTemplatePulse->SetDirectory(dir);
         fErrors->SetDirectory(dir);
       }
-      void Normalise();
+      void NormaliseToAmplitude();
+      void NormaliseToIntegral();
 
       double GetPedestal()const;
       double GetTime()const;
@@ -38,6 +39,8 @@ class TTemplate:public TObject{
 
       const char* GetName()const {return fName.c_str();}
       static std::string MakeName(const IDs::channel& ch){return ch.str()+"_template";}
+   private:
+      void SubtractPedestal();
 
    private:
       bool fDebug;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
@@ -22,9 +22,12 @@ class TTemplate:public TObject{
       void Initialize(int pulseID, TH1D* pulse, TDirectory* dir);
       void AddPulse(double x_offset, double y_scale, double y_offset,const TH1D*);
       void AddToDirectory(TDirectory* dir){
-        dir->Append(this,true);
+       TDirectory* curr=TDirectory::CurrentDirectory();
+        dir->cd();
+        TObject::Write();
         fTemplatePulse->SetDirectory(dir);
         fErrors->SetDirectory(dir);
+        curr->cd();
       }
 
       void NormaliseToAmplitude();

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
@@ -21,12 +21,14 @@ class TTemplate:public TObject{
       int PulsesMerged()const{return fTotalPulses;}
       void Initialize(int pulseID, TH1D* pulse, TDirectory* dir);
       void AddPulse(double x_offset, double y_scale, double y_offset,const TH1D*);
-      void AddToDirectory(TDirectory* dir){
+      void AddToDirectory(TDirectory* dir,TDirectory* hist_dir){
        TDirectory* curr=TDirectory::CurrentDirectory();
         dir->cd();
         TObject::Write();
-        fTemplatePulse->SetDirectory(dir);
-        fErrors->SetDirectory(dir);
+        if(hist_dir){
+          fTemplatePulse->SetDirectory(hist_dir);
+          fErrors->SetDirectory(hist_dir);
+        }
         curr->cd();
       }
 
@@ -53,7 +55,7 @@ class TTemplate:public TObject{
       bool fDebug;
       bool fConverged; ///< have we converged or not?
       int fTotalPulses; ///< How many pulses have been averaged to make the template
-      int fRefineFactor;
+      int fRefineFactor; ///< How many samples in the template correspond to 1 sample in an actual wavform
       int fTriggerPolarity;
       IDs::channel fChannel;
       std::string fName;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
@@ -32,7 +32,12 @@ class TTemplate:public TObject{
       double GetTime()const;
       double GetAmplitude()const;
 
+      double GetRefineFactor()const{return fRefineFactor;}
+
       const TH1D* GetHisto()const{return fTemplatePulse;}
+
+      const char* GetName()const {return fName.c_str();}
+      static std::string MakeName(const IDs::channel& ch){return ch.str()+"_template";}
 
    private:
       bool fDebug;
@@ -41,6 +46,7 @@ class TTemplate:public TObject{
       int fRefineFactor;
       int fTriggerPolarity;
       IDs::channel fChannel;
+      std::string fName;
       TH1D *fErrors;
       TH1D *fTemplatePulse;
    

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
@@ -44,6 +44,7 @@ class TTemplate:public TObject{
       static std::string MakeName(const IDs::channel& ch){return ch.str()+"_template";}
    private:
       void SubtractPedestal();
+      void ScaleHist(double factor);
 
    private:
       bool fDebug;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TTemplate.h
@@ -40,6 +40,7 @@ class TTemplate:public TObject{
       double GetPedestal()const;
       double GetTime()const;
       double GetAmplitude()const;
+      int GetPolarity()const{return fTriggerPolarity;};
 
       double GetRefineFactor()const{return fRefineFactor;}
 

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.cpp
@@ -2,8 +2,10 @@
 
 // option is standard ROOT file options
 TemplateArchive::TemplateArchive(const char* filename, const char* option) {
+  TDirectory* tmp=gDirectory;
   fTemplateFile = new TFile(filename, option);
   fDirectory=TDirectory::CurrentDirectory();
+  tmp->cd();
 }
 
 TemplateArchive::TemplateArchive(TDirectory* dir):fTemplateFile(NULL){

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.cpp
@@ -1,4 +1,8 @@
 #include "TemplateArchive.h"
+#include <iostream>
+
+using std::cout;
+using std::endl;
 
 // option is standard ROOT file options
 TemplateArchive::TemplateArchive(const char* filename, const char* option) {
@@ -26,6 +30,10 @@ TTemplate* TemplateArchive::GetTemplate(const char* template_name) {
 
   TTemplate* hTemplate = NULL;
   fDirectory->GetObject(template_name, hTemplate);
+  if(!hTemplate) {
+   cout<< "TemplateArchive::GetTemplate: ERROR: Unable to find a template called '"
+       <<template_name<<"' in file '"<<fTemplateFile->GetName()<<"'"<<endl;
+  }
   return hTemplate;
 }
 

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.cpp
@@ -14,9 +14,13 @@ TemplateArchive::~TemplateArchive() {
   if(fTemplateFile) fTemplateFile->Close();
 }
 
+TTemplate* TemplateArchive::GetTemplate(const IDs::channel& ch) {
+  return GetTemplate(TTemplate::MakeName(ch).c_str());
+}
+
 // GetTemplate()
 // -- gets a template from the template file
-const TTemplate* TemplateArchive::GetTemplate(const char* template_name) {
+TTemplate* TemplateArchive::GetTemplate(const char* template_name) {
 
   TTemplate* hTemplate = NULL;
   fDirectory->GetObject(template_name, hTemplate);

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.h
@@ -41,6 +41,7 @@ class TemplateArchive {
   ~TemplateArchive();
 
  public:
+  const char* GetName()const{return fTemplateFile?fTemplateFile->GetName(): "";}
   /// \brief
   /// Gets the template histogram of the given name and returns it
   TTemplate* GetTemplate(const char* template_name);

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateArchive.h
@@ -4,6 +4,8 @@
 #include <TFile.h>
 #include "TTemplate.h"
 
+namespace IDs{class channel;};
+
 ////////////////////////////////////////////////////////////////////////////////
 /// \ingroup rootana_modules
 /// \author Andrew Edmonds 
@@ -41,7 +43,11 @@ class TemplateArchive {
  public:
   /// \brief
   /// Gets the template histogram of the given name and returns it
-  const TTemplate* GetTemplate(const char* template_name);
+  TTemplate* GetTemplate(const char* template_name);
+
+  /// \brief
+  /// Gets the template histogram of the given name and returns it
+  TTemplate* GetTemplate(const IDs::channel& channel);
 
   /// \brief
   /// Takes the given histogram and saves it to the ROOT file

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.cpp
@@ -1,5 +1,6 @@
 #include "TemplateConvolver.h"
 #include "TTemplate.h"
+#include "TDirectory.h"
 #include "debug_tools.h"
 #include <iostream>
 #include <cmath>
@@ -31,7 +32,6 @@ TemplateConvolver::TemplateConvolver(const IDs::channel ch, TTemplate* tpl, doub
    const int weights[num_weights]={-1,1};
    fTimeWeights.assign(weights, weights+num_weights);
    fTimeConvolve=new Convolver<std::vector<int>::iterator>(fTimeWeights.begin(),fTimeWeights.end());
-   AutoCorrelateTemplate(fTemplate->GetHisto());
 }
 
 TemplateConvolver::~TemplateConvolver(){
@@ -81,12 +81,14 @@ int TemplateConvolver::FindPeaks(){
    return fPeaks.size();
 }
 
-void TemplateConvolver::AutoCorrelateTemplate(const TH1* histogram){
-   TH1_wrapper hist(histogram);
-   SamplesVector acf_out(histogram->GetNbinsX()- fTemplateLength);
+void TemplateConvolver::AutoCorrelateTemplate(){
+   TH1_wrapper hist(fTemplate->GetHisto());
+   SamplesVector acf_out(fTemplate->GetHisto()->GetNbinsX()- fTemplateLength);
    SamplesVector time_out(acf_out.size()- fTimeWeights.size());
   (*fEnergyConvolve)(hist.begin(), hist.end(), acf_out.begin());
   (*fTimeConvolve)(acf_out.begin(), acf_out.end(), time_out.begin());
-  functions::VectorToHist(acf_out,"Template_ACF","Auto-correlation of template");
-  functions::VectorToHist(time_out,"Template_ACF_derivative","Derivative of auto-correlation of template");
+  TH1* tmp=functions::VectorToHist(acf_out,"Template_ACF","Auto-correlation of template");
+  tmp->Write();
+  tmp=functions::VectorToHist(time_out,"Template_ACF_derivative","Derivative of auto-correlation of template");
+  tmp->Write();
 }

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.cpp
@@ -3,6 +3,7 @@
 #include "debug_tools.h"
 #include <iostream>
 #include <cmath>
+#include "InterpolatePulse.h"
 
 using namespace Algorithm;
 
@@ -30,6 +31,7 @@ TemplateConvolver::TemplateConvolver(const IDs::channel ch, TTemplate* tpl, doub
    const int weights[num_weights]={-1,1};
    fTimeWeights.assign(weights, weights+num_weights);
    fTimeConvolve=new Convolver<std::vector<int>::iterator>(fTimeWeights.begin(),fTimeWeights.end());
+   AutoCorrelateTemplate(fTemplate->GetHisto());
 }
 
 TemplateConvolver::~TemplateConvolver(){
@@ -77,4 +79,14 @@ int TemplateConvolver::FindPeaks(){
       last_was_positive = *i_sample >0;
    }
    return fPeaks.size();
+}
+
+void TemplateConvolver::AutoCorrelateTemplate(const TH1* histogram){
+   TH1_wrapper hist(histogram);
+   SamplesVector acf_out(histogram->GetNbinsX()- fTemplateLength);
+   SamplesVector time_out(acf_out.size()- fTimeWeights.size());
+  (*fEnergyConvolve)(hist.begin(), hist.end(), acf_out.begin());
+  (*fTimeConvolve)(acf_out.begin(), acf_out.end(), time_out.begin());
+  functions::VectorToHist(acf_out,"Template_ACF","Auto-correlation of template");
+  functions::VectorToHist(time_out,"Template_ACF_derivative","Derivative of auto-correlation of template");
 }

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.cpp
@@ -1,0 +1,57 @@
+#include "TemplateConvolver.h"
+#include "TTemplate.h"
+
+using namespace Algorithm;
+
+TemplateConvolver::TemplateConvolver(const IDs::channel ch, TTemplate* tpl, double peak_cut):
+     fChannel(ch), fTemplate(tpl),fSafety(10),fFoundPeakCut(peak_cut){
+   fTemplateLength=fTemplate->GetHisto()->GetNbinsX() - 2*fSafety;
+   if(fTemplateLength <0) return;
+
+   TH1_wrapper hist(fTemplate->GetHisto());
+   fEnergyConvolve=new Convolver<TH1_c_iterator>(hist.begin(fSafety), hist.end(fSafety));
+   
+   const int num_weights=3;
+   const int weights[num_weights]={-1,2,-1};
+   fTimeConvolve=new Convolver<const int*>(weights,weights+num_weights);
+}
+
+TemplateConvolver::~TemplateConvolver(){
+  delete fTimeConvolve;
+  delete fEnergyConvolve;
+}
+
+int TemplateConvolver::Convolve(const TPulseIsland* tpi){
+   // initialize for convolution
+   const std::vector<int>& samples=tpi->GetSamples();
+   ResetVectors(samples.size());
+
+   // convole the waveform with the template
+   /*SamplesVector::iterator last=*/(*fEnergyConvolve)(samples.begin(),samples.end(),fEnergySamples.begin());
+
+   // now run the timing filter (in the future this and the last step could be merged)
+   (*fTimeConvolve)(fEnergySamples.begin(),fEnergySamples.end(),fTimeSamples.begin());
+
+   // finaly get all peaks and return the total number found
+   return FindPeaks();
+}
+
+void TemplateConvolver::ResetVectors(int size){
+   // make sure we're big enough for the number of samples we'll get
+   fEnergySamples.resize(size- fTemplateLength);
+   fTimeSamples.resize(size- fTemplateLength -2);
+   fTimeSamples.clear();
+}
+
+int TemplateConvolver::FindPeaks(){
+   FoundPeaks tmp;
+   for(SamplesVector::const_iterator i_sample=fTimeSamples.begin(); i_sample!=fTimeSamples.end(); ++i_sample){
+      if(*i_sample>fFoundPeakCut){
+        tmp.time=i_sample-fTimeSamples.begin();
+        tmp.amplitude=fEnergySamples[tmp.time];
+        tmp.second_diff=*i_sample;
+        fPeaks.insert(tmp);
+      }
+   }
+   return fPeaks.size();
+}

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.cpp
@@ -21,8 +21,9 @@ namespace{
 }
 
 TemplateConvolver::TemplateConvolver(const IDs::channel ch, TTemplate* tpl, double peak_cut):
-     fChannel(ch), fTemplate(tpl),fLeftSafety(20),fRightSafety(60),fFoundPeakCut(peak_cut){
-   fTemplateLength=fTemplate->GetHisto()->GetNbinsX() - fLeftSafety - fRightSafety;
+     fChannel(ch), fTemplate(tpl),fLeftSafety(20),fRightSafety(60), fFoundPeakCut(peak_cut),
+     fTemplateLength(fTemplate->GetHisto()->GetNbinsX() - fLeftSafety - fRightSafety),
+     fTemplateTime(fTemplate->GetTime()-fLeftSafety){
    if(fTemplateLength <0) return;
 
    TH1_wrapper hist(fTemplate->GetHisto());
@@ -68,15 +69,16 @@ bool TemplateConvolver::ResetVectors(int size){
 
 int TemplateConvolver::FindPeaks(){
    FoundPeaks tmp;
-   bool last_was_positive=fTimeSamples.front() > 0;
+   double last_sample=fTimeSamples.front();
    for(SamplesVector::const_iterator i_sample=fTimeSamples.begin()+1; i_sample!=fTimeSamples.end(); ++i_sample){
-      if( last_was_positive && *i_sample<0){
-        tmp.time=i_sample-fTimeSamples.begin();
+      if( last_sample>0 && *i_sample<0){
+        tmp.time=(i_sample-fTimeSamples.begin());
         tmp.amplitude=fEnergySamples[tmp.time];
-        tmp.second_diff=*i_sample;
+        tmp.time+=fTemplateTime;
+        tmp.second_diff=last_sample - *i_sample;
         fPeaks.insert(tmp);
       }
-      last_was_positive = *i_sample >0;
+      last_sample = *i_sample;
    }
    return fPeaks.size();
 }

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -46,15 +46,16 @@ class TemplateConvolver{
     private:
       IDs::channel fChannel;
       TTemplate* fTemplate;
-      int fTemplateLength;
       Algorithm::Convolver<Algorithm::TH1_c_iterator>* fEnergyConvolve;
       Algorithm::Convolver<std::vector<int>::iterator>* fTimeConvolve;
-      int fLeftSafety, fRightSafety;
-      double fFoundPeakCut;
+      const int fLeftSafety, fRightSafety;
+      const double fFoundPeakCut;
+      const int fTemplateLength;
+      const double fTemplateTime;
       PeaksVector fPeaks;
       SamplesVector fEnergySamples;
       SamplesVector fTimeSamples;
-    std::vector<int> fTimeWeights;
+      std::vector<int> fTimeWeights;
 
 };
 

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -30,7 +30,7 @@ class TemplateConvolver{
       typedef std::vector<double> SamplesVector;
 
     public:
-      TemplateConvolver(const IDs::channel ch, TTemplate*, int peak_fit_samples);
+      TemplateConvolver(const IDs::channel ch, TTemplate* tpl, int peak_fit_samples, int left, int right);
       ~TemplateConvolver();
       bool IsValid()const{return fTemplateLength>0;}
 
@@ -48,7 +48,7 @@ class TemplateConvolver{
 
     private:
       int FindPeaks( const SamplesVector&, const SamplesVector&, const Algorithm::TpiMinusPedestal_iterator* pedestal);
-      void FitPeak(int index, const SamplesVector&, const SamplesVector&, double pedestal);
+      void FitPeak(FoundPeaks& output, int index, const SamplesVector&, const SamplesVector&, double pedestal);
       bool ResetVectors(int size);
 
     private:

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -25,6 +25,15 @@ class TemplateConvolver{
            return time<rhs.time;
            //return amplitude>rhs.amplitude;
          }
+         FoundPeaks& operator=(const FoundPeaks& rhs){
+           time=rhs.time;
+           amplitude=rhs.amplitude;
+           pedestal=rhs.pedestal;
+           quad=rhs.quad;
+           linear=rhs.linear;
+           constant=rhs.constant;
+           return *this;
+         }
       };
       typedef std::set<FoundPeaks> PeaksVector;
       typedef std::vector<double> SamplesVector;
@@ -46,9 +55,12 @@ class TemplateConvolver{
       double GetAmplitudeScale()const{return fTemplateScale;}
       TH1* GetTemplateACF()const {return fTemplateACFHist;}
 
+      int FindPeaks(bool expect_pile_up, const Algorithm::TpiMinusPedestal_iterator& waveform);
+
     private:
-      int FindPeaks( const SamplesVector&, const SamplesVector&, const Algorithm::TpiMinusPedestal_iterator* pedestal);
-      void FitPeak(FoundPeaks& output, int index, const SamplesVector&, const SamplesVector&, double pedestal);
+      int FindAllPeaks( const SamplesVector&, const SamplesVector&, const Algorithm::TpiMinusPedestal_iterator* pedestal);
+      int FindBestPeak( const SamplesVector&, const SamplesVector&, const Algorithm::TpiMinusPedestal_iterator* pedestal);
+      void FitPeak(FoundPeaks& output, int index, const SamplesVector& energy, const SamplesVector& time, double pedestal);
       bool ResetVectors(int size);
 
     private:
@@ -57,6 +69,7 @@ class TemplateConvolver{
       Algorithm::Convolver<Algorithm::TH1_c_iterator>* fEnergyConvolve;
       Algorithm::Convolver<std::vector<int>::iterator>* fTimeConvolve;
       functions::QuadraticFit fQuadFit;
+      const int fPolarity;
       const int fLeftSafety, fRightSafety;
       const int fTemplateLength;
       const double fTemplateTime;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -17,6 +17,7 @@ class TemplateConvolver{
       struct FoundPeaks{
          double time;
          double amplitude;
+         double pedestal;
          double quad;
          double linear;
          double constant;
@@ -34,18 +35,20 @@ class TemplateConvolver{
       bool IsValid()const{return fTemplateLength>0;}
 
     public:
-      int Convolve(const TPulseIsland* tpi,double pedestal=0);
+      int Convolve(const Algorithm::TpiMinusPedestal_iterator& begin,const Algorithm::TpiMinusPedestal_iterator& end);
       void CharacteriseTemplate();
 
       const SamplesVector& GetEnergyConvolution()const{return fEnergySamples;};
       const SamplesVector& GetTimeConvolution()const{return fTimeSamples;};
       const PeaksVector& GetPeaks()const{return fPeaks;};
       double GetTimeShift()const{return fTemplateTime;}
+      double GetLeftSafety()const{return fLeftSafety;}
       double GetAmplitudeScale()const{return fTemplateScale;}
+      TH1* GetTemplateACF()const {return fTemplateACFHist;}
 
     private:
-      int FindPeaks( const SamplesVector&, const SamplesVector&);
-      void FitPeak(int index, const SamplesVector&, const SamplesVector&);
+      int FindPeaks( const SamplesVector&, const SamplesVector&, const Algorithm::TpiMinusPedestal_iterator* pedestal);
+      void FitPeak(int index, const SamplesVector&, const SamplesVector&, double pedestal);
       bool ResetVectors(int size);
 
     private:
@@ -63,6 +66,7 @@ class TemplateConvolver{
       SamplesVector fTimeSamples;
       std::vector<int> fTimeWeights;
       SamplesVector fTemplateACF,fTemplateACFDerivative;
+      TH1 *fTemplateACFHist, *fTemplateACFDerivativeHist;
 
 };
 

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -17,7 +17,7 @@ class TemplateConvolver{
          double amplitude;
          double second_diff;
          bool operator<(const FoundPeaks& rhs)const{
-           return second_diff<rhs.second_diff;
+           return amplitude>rhs.amplitude;
          }
       };
       typedef std::set<FoundPeaks> PeaksVector;
@@ -29,7 +29,7 @@ class TemplateConvolver{
       bool IsValid()const{return fTemplateLength>0;}
 
     public:
-      int Convolve(const TPulseIsland* tpi);
+      int Convolve(const TPulseIsland* tpi,double pedestal=0);
 
       const SamplesVector& GetEnergyConvolution()const{return fEnergySamples;};
       const SamplesVector& GetTimeConvolution()const{return fTimeSamples;};
@@ -46,12 +46,13 @@ class TemplateConvolver{
       TTemplate* fTemplate;
       int fTemplateLength;
       Algorithm::Convolver<Algorithm::TH1_c_iterator>* fEnergyConvolve;
-      Algorithm::Convolver<const int*>* fTimeConvolve;
+      Algorithm::Convolver<std::vector<int>::iterator>* fTimeConvolve;
       int fLeftSafety, fRightSafety;
       double fFoundPeakCut;
       PeaksVector fPeaks;
       SamplesVector fEnergySamples;
       SamplesVector fTimeSamples;
+    std::vector<int> fTimeWeights;
 
 };
 

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -1,0 +1,58 @@
+#ifndef TEMPLATE_FITTING_TEMPLATECONVOLVER_H
+#define TEMPLATE_FITTING_TEMPLATECONVOLVER_H
+
+#include <set>
+#include <vector>
+#include "IdChannel.h"
+#include "Convolver.h"
+
+namespace IDs{ class channel;}
+class TTemplate;
+class TPulseIsland;
+
+class TemplateConvolver{
+    public:
+      struct FoundPeaks{
+         double time;
+         double amplitude;
+         double second_diff;
+         bool operator<(const FoundPeaks& rhs)const{
+           return second_diff<rhs.second_diff;
+         }
+      };
+      typedef std::set<FoundPeaks> PeaksVector;
+      typedef std::vector<double> SamplesVector;
+
+    public:
+      TemplateConvolver(const IDs::channel ch, TTemplate*, double cut);
+      ~TemplateConvolver();
+      bool IsValid()const{return fTemplateLength>0;}
+
+    public:
+      int Convolve(const TPulseIsland* tpi);
+
+      const SamplesVector& GetEnergyConvolution()const{return fEnergySamples;};
+      const SamplesVector& GetTimeConvolution()const{return fTimeSamples;};
+      const PeaksVector& GetPeaks()const{return fPeaks;};
+      double GetTime()const{return fPeaks.begin()->time;}
+      double GetAmplitude()const{return fPeaks.begin()->amplitude;}
+
+    private:
+      int FindPeaks();
+      void ResetVectors(int size);
+
+    private:
+      IDs::channel fChannel;
+      TTemplate* fTemplate;
+      int fTemplateLength;
+      Algorithm::Convolver<Algorithm::TH1_c_iterator>* fEnergyConvolve;
+      Algorithm::Convolver<const int*>* fTimeConvolve;
+      int fSafety;
+      double fFoundPeakCut;
+      PeaksVector fPeaks;
+      SamplesVector fEnergySamples;
+      SamplesVector fTimeSamples;
+
+};
+
+#endif // TEMPLATE_FITTING_TEMPLATECONVOLVER_H

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -39,7 +39,7 @@ class TemplateConvolver{
 
     private:
       int FindPeaks();
-      void ResetVectors(int size);
+      bool ResetVectors(int size);
 
     private:
       IDs::channel fChannel;
@@ -47,7 +47,7 @@ class TemplateConvolver{
       int fTemplateLength;
       Algorithm::Convolver<Algorithm::TH1_c_iterator>* fEnergyConvolve;
       Algorithm::Convolver<const int*>* fTimeConvolve;
-      int fSafety;
+      int fLeftSafety, fRightSafety;
       double fFoundPeakCut;
       PeaksVector fPeaks;
       SamplesVector fEnergySamples;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -21,7 +21,8 @@ class TemplateConvolver{
          double linear;
          double constant;
          bool operator<(const FoundPeaks& rhs)const{
-           return amplitude>rhs.amplitude;
+           return time<rhs.time;
+           //return amplitude>rhs.amplitude;
          }
       };
       typedef std::set<FoundPeaks> PeaksVector;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -40,6 +40,7 @@ class TemplateConvolver{
     private:
       int FindPeaks();
       bool ResetVectors(int size);
+      void AutoCorrelateTemplate(const TH1* histogram);
 
     private:
       IDs::channel fChannel;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateConvolver.h
@@ -9,6 +9,7 @@
 namespace IDs{ class channel;}
 class TTemplate;
 class TPulseIsland;
+class TDirectory;
 
 class TemplateConvolver{
     public:
@@ -30,6 +31,7 @@ class TemplateConvolver{
 
     public:
       int Convolve(const TPulseIsland* tpi,double pedestal=0);
+      void AutoCorrelateTemplate();
 
       const SamplesVector& GetEnergyConvolution()const{return fEnergySamples;};
       const SamplesVector& GetTimeConvolution()const{return fTimeSamples;};
@@ -40,7 +42,6 @@ class TemplateConvolver{
     private:
       int FindPeaks();
       bool ResetVectors(int size);
-      void AutoCorrelateTemplate(const TH1* histogram);
 
     private:
       IDs::channel fChannel;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateCreator.cpp
@@ -177,6 +177,7 @@ int TemplateCreator::ProcessEntry(TGlobalData* gData, const TSetupData* setup){
         continue;
       }
 
+
       // Create the refined pulse waveform
       TH1D* hPulseToFit = CreateRefinedPulseHistogram(pulse, "hPulseToFit", "hPulseToFit", false);
 
@@ -294,55 +295,6 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData, const TSetupData* setup)
   }
 
   return 0;
-}
-
-// Creates a histogram with sub-bin resolution
-TH1D* TemplateCreator::CreateRefinedPulseHistogram(
-    const TPulseIsland* pulse, std::string histname,
-     std::string histtitle, bool interpolate) {
-
-  // Get a few things first
-  const std::string& bankname = pulse->GetBankName();
-  const std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
-  const std::vector<int>& theSamples = pulse->GetSamples();
-  int n_samples = theSamples.size();
-  int n_bins = fRefineFactor*n_samples; // number of bins in the template
-
-  // Create the higher resolution histogram
-  TH1D* hist = new TH1D(histname.c_str(), histtitle.c_str(), n_bins, 0, n_samples);
-
-  double pedestal_error = SetupNavigator::Instance()->GetNoise(detname);
-
-  // Go through the bins in the high-resolution histogram
-  // NB sample numbers go grom 0 to n-1 and bins go from 1 to n
-  for (int i = 0; i < n_bins; ++i) {
-    int bin = i+1; // bins go from 1 to n rather than 0 to n-1
-    int sample_number = i / fRefineFactor;
-    double remainder = i % fRefineFactor;
-    double sample_value;
-
-    // We may want to interpolate between the samples in the samples vector
-    if (interpolate) {
-      try {
-    sample_value = theSamples.at(sample_number) 
-                     + (remainder / fRefineFactor)*(theSamples.at(sample_number+1) 
-                     - theSamples.at(sample_number));
-      }
-      catch (const std::out_of_range& oor) { // if we'll be going out of range of the samples vector
-    sample_value = theSamples.at(sample_number);
-      }
-    }
-    else {
-      sample_value = theSamples.at(sample_number);
-    }
-
-    // Set the bin contents and bin error
-    hist->SetBinContent( bin, sample_value);
-    hist->SetBinError( bin, pedestal_error);
-  }
-  hist->SetDirectory(0);
-
-  return hist;
 }
 
 int TemplateCreator::HasPulseOverflowed(const TPulseIsland* pulse, const std::string& bankname){

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateCreator.cpp
@@ -285,7 +285,7 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData, const TSetupData* setup)
 
     // Normalise the templates
     //i_ch->template_pulse->NormaliseToAmplitude();
-    i_ch->template_pulse->AddToDirectory(GetDirectory());
+    i_ch->template_pulse->AddToDirectory(GetDirectory("../"), GetDirectory());
 
     // Save the template to the file
     fTemplateArchive->SaveTemplate(i_ch->template_pulse);

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateCreator.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateCreator.cpp
@@ -284,7 +284,7 @@ int TemplateCreator::AfterLastEntry(TGlobalData* gData, const TSetupData* setup)
          << ((double)i_ch->fit_successes/(double)i_ch->fit_attempts)*100 << "%)" << endl;
 
     // Normalise the templates
-    i_ch->template_pulse->Normalise();
+    //i_ch->template_pulse->NormaliseToAmplitude();
     i_ch->template_pulse->AddToDirectory(GetDirectory());
 
     // Save the template to the file

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateCreator.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateCreator.h
@@ -12,6 +12,7 @@ class TH1D;
 #include "PulseCandidateFinder.h"
 #include "TemplateFitter.h"
 #include "TTemplate.h"
+#include "InterpolatePulse.h"
 
 class TemplateCreator : public BaseModule{
   struct ChannelSet{
@@ -48,7 +49,9 @@ class TemplateCreator : public BaseModule{
 
   /// \brief
   /// Creates a refined histogram for a given TPulseIsland
-  TH1D* CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, bool interpolate);
+  TH1D* CreateRefinedPulseHistogram(const TPulseIsland* pulse, std::string histname, std::string histtitle, bool interpolate){
+     return InterpolatePulse(pulse,histname,histtitle, interpolate, fRefineFactor);
+  }
 
   /// \brief
   /// Checks if the template has converged and that adding a new pulse has not effect on the template

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
@@ -43,7 +43,7 @@ int TemplateFitter::FitPulseToTemplate(const TTemplate* hTemplate, const TH1D* h
                                                     // these heavily.
 
   // Loop through some time offsets ourselved
-  double max_time_offset = 4*fRefineFactor; // maximum distance to go from the initial estimate
+  double max_time_offset = 8*fRefineFactor; // maximum distance to go from the initial estimate
   double best_time_offset = 0;
   double best_pedestal_offset = 0;
   double best_amplitude_scale_factor = 0;

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
@@ -77,9 +77,11 @@ int TemplateFitter::FitPulseToTemplate(const TTemplate* hTemplate, const TH1D* h
     // Minimize and notify if there was a problem
     status = fMinuitFitter->Minimize(1000); // set limit of 1000 calls to FCN
 
-    if (print_dbg) {
-      if (status != 0)
+    if (status != 0){
+      if (print_dbg){ 
 	std::cout << "ERROR: Problem with fit (" << status << ")!" << std::endl;
+      }
+      continue;
     }
 
     // Get the fitted values

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
@@ -32,7 +32,7 @@ int TemplateFitter::FitPulseToTemplate(const TTemplate* hTemplate, const TH1D* h
   // Prepare for minimizations
   fMinuitFitter->Clear();
   HistogramFitFCN* fcn = (HistogramFitFCN*)fMinuitFitter->GetMinuitFCN();
-  fcn->SetTemplateHist(hTemplate->GetHisto());
+  fcn->SetTemplateHist(hTemplate->GetHisto(), hTemplate->GetPedestal());
   fcn->SetPulseHist(hPulse);
 
   //  fMinuitFitter->SetParameter(2, "TimeOffset", fTimeOffset, 1., -10, 10); // Timing should have step size no smaller than binning,
@@ -47,7 +47,7 @@ int TemplateFitter::FitPulseToTemplate(const TTemplate* hTemplate, const TH1D* h
   double best_time_offset = 0;
   double best_pedestal_offset = 0;
   double best_amplitude_scale_factor = 0;
-  double best_chi2 = 99999999999;
+  double best_chi2 = 1e11;
   int best_status = -10000;
 
   // Calculate the bounds of the parameters
@@ -88,17 +88,19 @@ int TemplateFitter::FitPulseToTemplate(const TTemplate* hTemplate, const TH1D* h
 
     double delta_ped_offset_error = 1; // if the given parameter is within this much of the boundaries, then we will ignore it
     double delta_amp_sf_error = 0.001;
-    if ( (fPedestalOffset < fPedestalOffset_minimum + delta_ped_offset_error && fPedestalOffset > fPedestalOffset_minimum - delta_ped_offset_error) ||
-	 (fPedestalOffset < fPedestalOffset_maximum + delta_ped_offset_error && fPedestalOffset > fPedestalOffset_maximum - delta_ped_offset_error) ) {
-
+    if ( (fPedestalOffset < fPedestalOffset_minimum + delta_ped_offset_error 
+           && fPedestalOffset > fPedestalOffset_minimum - delta_ped_offset_error) 
+         || (fPedestalOffset < fPedestalOffset_maximum + delta_ped_offset_error 
+             && fPedestalOffset > fPedestalOffset_maximum - delta_ped_offset_error) ) {
       if (print_dbg) {
 	std::cout << "ERROR: PedestalOffset has hit a boundary (" << fPedestalOffset << ")" << std::endl;
       }
       status = -9999;
     }
-    else if ( (fAmplitudeScaleFactor < fAmplitudeScaleFactor_minimum + delta_amp_sf_error && fAmplitudeScaleFactor > fAmplitudeScaleFactor_minimum - delta_amp_sf_error) ||
-	      (fAmplitudeScaleFactor < fAmplitudeScaleFactor_maximum + delta_amp_sf_error && fAmplitudeScaleFactor > fAmplitudeScaleFactor_maximum - delta_amp_sf_error) ) {
-
+    else if (    (fAmplitudeScaleFactor < fAmplitudeScaleFactor_minimum + delta_amp_sf_error 
+                   && fAmplitudeScaleFactor > fAmplitudeScaleFactor_minimum - delta_amp_sf_error) 
+              || (fAmplitudeScaleFactor < fAmplitudeScaleFactor_maximum + delta_amp_sf_error 
+                   && fAmplitudeScaleFactor > fAmplitudeScaleFactor_maximum - delta_amp_sf_error) ) {
       if (print_dbg) {
 	std::cout << "ERROR: AmplitudeScaleFactor has hit a boundary (" << fAmplitudeScaleFactor << ")" << std::endl;
       }

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
@@ -58,7 +58,7 @@ int TemplateFitter::FitPulseToTemplate(const TTemplate* hTemplate, const TH1D* h
   fPedestalOffset_maximum = max_adc_value;
 
   fAmplitudeScaleFactor_minimum = 0.1;
-  fAmplitudeScaleFactor_maximum = 100;
+  fAmplitudeScaleFactor_maximum = 1000;
 
   for (double time_offset = fTimeOffset_minimum; time_offset <= fTimeOffset_maximum; ++time_offset) {
     if (print_dbg) {

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateFitter.cpp
@@ -43,7 +43,7 @@ int TemplateFitter::FitPulseToTemplate(const TTemplate* hTemplate, const TH1D* h
                                                     // these heavily.
 
   // Loop through some time offsets ourselved
-  double max_time_offset = 8*fRefineFactor; // maximum distance to go from the initial estimate
+  double max_time_offset = 10*fRefineFactor; // maximum distance to go from the initial estimate
   double best_time_offset = 0;
   double best_pedestal_offset = 0;
   double best_amplitude_scale_factor = 0;
@@ -58,7 +58,7 @@ int TemplateFitter::FitPulseToTemplate(const TTemplate* hTemplate, const TH1D* h
   fPedestalOffset_maximum = max_adc_value;
 
   fAmplitudeScaleFactor_minimum = 0.1;
-  fAmplitudeScaleFactor_maximum = 1000;
+  fAmplitudeScaleFactor_maximum = 1500;
 
   for (double time_offset = fTimeOffset_minimum; time_offset <= fTimeOffset_maximum; ++time_offset) {
     if (print_dbg) {

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateMultiFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateMultiFitter.cpp
@@ -1,0 +1,174 @@
+#include "TemplateMultiFitter.h"
+#include "MultiHistogramFitFCN.h"
+#include "SetupNavigator.h"
+#include "EventNavigator.h"
+#include "debug_tools.h"
+#include <iostream>
+
+#include "TMath.h"
+
+using std::cout;
+using std::endl;
+
+TemplateMultiFitter::TemplateMultiFitter(const IDs::channel& ch): 
+   fMinuitFitter(NULL), fFitFCN(NULL), fChannel(ch),fPedestal(0), fRefineFactor(0) {
+
+  // Calculate the max ADC value
+  fMinADC = EventNavigator::Instance().GetSetupRecord().GetMaxADC(fChannel);
+  fMaxADC = EventNavigator::Instance().GetSetupRecord().GetMaxADC(fChannel);
+}
+
+void TemplateMultiFitter::Init(){
+  if(fFitFCN || fMinuitFitter) {
+     cout<< "TemplateMultiFitter: Warning: trying to initialize fitter which was already initialised!"<<endl;
+     return;
+  }
+
+  fFitFCN=new MultiHistogramFitFCN(fRefineFactor);
+  fFitFCN->SetRefineFactor(fRefineFactor);
+  for(TemplateList::const_iterator i_tpl=fTemplates.begin(); i_tpl!=fTemplates.end(); ++i_tpl){
+     fFitFCN->AddTemplate(i_tpl->fTemplate->GetHisto());
+  }
+ 
+  fMinuitFitter = new TFitterMinuit(fTemplates.size()+1); //  1 parameter per template (amplitude) + global pedestal.
+  fMinuitFitter->SetMinuitFCN(fFitFCN);
+  fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
+  fMinuitFitter->CreateMinimizer(TFitterMinuit::kMigrad);
+}
+
+TemplateMultiFitter::~TemplateMultiFitter() {
+}
+
+int TemplateMultiFitter::FitWithOneTimeFree(int index, const TH1D* hPulse){
+
+  // Get the template we're going to shift around
+  TemplateDetails_t& current=fTemplates.at(index);
+
+  // Prepare for minimizations
+  fMinuitFitter->Clear();
+  fFitFCN->SetPulseHist(hPulse);
+
+  // Loop through some time offsets ourselved
+  const double offset_range = 10*fRefineFactor; // maximum distance to go from the initial estimate
+  double best_time_offset = 0;
+  std::vector<double> best_parameters(1+fTemplates.size());
+  double best_chi2 = 1e11;
+  int best_ndof = 0;
+  int best_status = kInitialised;
+  int status = kInitialised;
+
+  // Calculate the bounds of the parameters
+  int min_offset = current.fTimeOffset - offset_range;
+  int max_offset = current.fTimeOffset + offset_range;
+
+  std::vector<double> parameters(1+fTemplates.size());
+  for (double time_offset = min_offset; time_offset <= max_offset; ++time_offset) {
+    fFitFCN->SetTimeOffset(index, time_offset);
+
+    // Reset the estimates
+    fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestal, 0.1, fMinADC, fMaxADC);
+    for(TemplateList::const_iterator i_tpl=fTemplates.begin(); i_tpl!=fTemplates.end(); ++i_tpl){
+        int i=i_tpl-fTemplates.begin();
+        fMinuitFitter->SetParameter(i+1, Form("AmplitudeScaleFactor_%d",i), i_tpl->fAmplitudeScaleFactor, 0.1, fMinADC, fMaxADC);
+    }
+
+    // Minimize and notify if there was a problem
+    status = fMinuitFitter->Minimize(1000); // set limit of 1000 calls to FCN
+    if(status!=0) continue;
+
+    // Store the Chi2 and degrees of freedom
+    parameters[0]=fMinuitFitter->GetParameter(0); 
+    for(std::vector<double>::iterator i_par=parameters.begin()+1; i_par!=parameters.end(); ++i_par){
+       *i_par= fMinuitFitter->GetParameter(i_par-parameters.begin()+1);
+    }
+
+    // Check the bounds
+    const double delta_ped_offset_error = 1; // if the given parameter is within this much of the boundaries, then we will ignore it
+    const double delta_amp_sf_error = 0.001;
+    if ( (parameters[0] < delta_ped_offset_error ) || (parameters[0] > fMaxADC - delta_ped_offset_error) ) {
+      status = kPedestalOutOfBounds;
+    } else {
+       for(std::vector<double>::const_iterator i_par=parameters.begin()+1; i_par!=parameters.end(); ++i_par){
+          if (    ( *i_par > fMinADC + delta_amp_sf_error ) || ( *i_par < fMaxADC - delta_amp_sf_error ) ) {
+                status = kAmplitudeOutOfBounds;
+                break;
+          }
+       }
+    }
+
+    // get the chi-2
+    fChi2 = (*fFitFCN)(parameters);
+    fNDoF = fFitFCN->GetNDoF();
+
+    if (status == 0 && fChi2 < best_chi2) {
+      best_time_offset = time_offset;
+      best_parameters=parameters;
+      best_chi2 = fChi2;
+      best_status = status;
+      best_ndof = fNDoF;
+    }
+  }
+
+  // Store the final best values
+  fChi2 = best_chi2;
+  fNDoF = best_ndof;
+  current.fTimeOffset = best_time_offset;
+  fPedestal = best_parameters[0];
+  for(TemplateList::iterator i_tpl=fTemplates.begin(); i_tpl!=fTemplates.end(); ++i_tpl){
+      i_tpl->fAmplitudeScaleFactor=best_parameters[i_tpl-fTemplates.begin()+1];
+  }
+
+  static int offset_safety = 1;
+  if ( (current.fTimeOffset < min_offset + offset_safety && current.fTimeOffset > min_offset - offset_safety) ||
+       (current.fTimeOffset < max_offset + offset_safety && current.fTimeOffset > max_offset - offset_safety) ) {
+
+      best_status = kTimeOutOfBounds;
+  }
+
+  return best_status; // return status for the calling module to look at
+}
+
+int TemplateMultiFitter::FitWithAllTimesFixed( const TH1D* hPulse){
+  // Prepare for minimizations
+  fMinuitFitter->Clear();
+  fFitFCN->SetPulseHist(hPulse);
+
+  // initialise fit
+  fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestal, 0.1, fMinADC, fMaxADC);
+  for(TemplateList::const_iterator i_tpl=fTemplates.begin(); i_tpl!=fTemplates.end(); ++i_tpl){
+      int i=i_tpl-fTemplates.begin();
+      fMinuitFitter->SetParameter(i+1, Form("AmplitudeScaleFactor_%d",i), i_tpl->fAmplitudeScaleFactor, 0.1, fMinADC, fMaxADC);
+      fFitFCN->SetTimeOffset(i, i_tpl->fTimeOffset);
+  }
+
+  // run the fitter
+  int status = fMinuitFitter->Minimize(1000); 
+
+  // get fitted parameters
+  std::vector<double> parameters(1+fTemplates.size());
+  parameters[0]=fPedestal=fMinuitFitter->GetParameter(0); 
+  for(TemplateList::iterator i_tpl=fTemplates.begin(); i_tpl!=fTemplates.end(); ++i_tpl)
+     parameters[i_tpl-fTemplates.begin()+1]=i_tpl->fAmplitudeScaleFactor= fMinuitFitter->GetParameter(i_tpl-fTemplates.begin()+1);
+
+  // check chi-2
+  fChi2 = (*fFitFCN)(parameters);
+  fNDoF = fFitFCN->GetNDoF();
+
+  // return status
+  return status;
+
+}
+
+void TemplateMultiFitter::AddTemplate(TTemplate* tpl){
+  fFitFCN->AddTemplate(tpl->GetHisto());
+  int i=fFitFCN->GetNTemplates();
+  TemplateDetails_t tmp;
+  tmp.fTemplate=tpl;
+  tmp.fAmplitudeScaleFactor=fFitFCN->GetAmplitudeScaleFactor(i);
+  tmp.fTimeOffset=fFitFCN->GetTimeOffset(i); 
+  fTemplates.push_back(tmp);
+  if(fRefineFactor==0) fRefineFactor=tpl->GetRefineFactor();
+  else if(fRefineFactor!= tpl->GetRefineFactor()){
+    throw Except::MismatchedTemplateRefineFactors();
+  }
+}

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateMultiFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateMultiFitter.cpp
@@ -30,10 +30,10 @@ void TemplateMultiFitter::Init(){
      fFitFCN->AddTemplate(i_tpl->fTemplate->GetHisto());
   }
  
-  fMinuitFitter = new TFitterMinuit(fTemplates.size()+1); //  1 parameter per template (amplitude) + global pedestal.
+  int num_params=fTemplates.size()+1; //  1 parameter per template (amplitude) + global pedestal.
+  fMinuitFitter = new TFitterMinuit(num_params);
   fMinuitFitter->SetMinuitFCN(fFitFCN);
   fMinuitFitter->SetPrintLevel(-1); // set the debug level to quiet (-1=quiet, 0=normal, 1=verbose)
-  fMinuitFitter->CreateMinimizer(TFitterMinuit::kMigrad);
 }
 
 TemplateMultiFitter::~TemplateMultiFitter() {
@@ -47,6 +47,7 @@ int TemplateMultiFitter::FitWithOneTimeFree(int index, const TH1D* hPulse){
   // Prepare for minimizations
   fMinuitFitter->Clear();
   fFitFCN->SetPulseHist(hPulse);
+  fMinuitFitter->CreateMinimizer(TFitterMinuit::kMigrad);
 
   // Loop through some time offsets ourselved
   const double offset_range = 10*fRefineFactor; // maximum distance to go from the initial estimate
@@ -79,7 +80,8 @@ int TemplateMultiFitter::FitWithOneTimeFree(int index, const TH1D* hPulse){
     // Store the Chi2 and degrees of freedom
     parameters[0]=fMinuitFitter->GetParameter(0); 
     for(std::vector<double>::iterator i_par=parameters.begin()+1; i_par!=parameters.end(); ++i_par){
-       *i_par= fMinuitFitter->GetParameter(i_par-parameters.begin()+1);
+       int n=i_par-parameters.begin();
+       *i_par= fMinuitFitter->GetParameter(n);
     }
 
     // Check the bounds
@@ -132,6 +134,7 @@ int TemplateMultiFitter::FitWithAllTimesFixed( const TH1D* hPulse){
   // Prepare for minimizations
   fMinuitFitter->Clear();
   fFitFCN->SetPulseHist(hPulse);
+  fMinuitFitter->CreateMinimizer(TFitterMinuit::kMigrad);
 
   // initialise fit
   fMinuitFitter->SetParameter(0, "PedestalOffset", fPedestal, 0.1, fMinADC, fMaxADC);

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateMultiFitter.cpp
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateMultiFitter.cpp
@@ -26,7 +26,7 @@ void TemplateMultiFitter::Init(){
 
   fFitFCN=new MultiHistogramFitFCN(fRefineFactor);
   fFitFCN->SetRefineFactor(fRefineFactor);
-  for(TemplateList::const_iterator i_tpl=fTemplates.begin(); i_tpl!=fTemplates.end(); ++i_tpl){
+  for(TemplateList::iterator i_tpl=fTemplates.begin(); i_tpl!=fTemplates.end(); ++i_tpl){
      fFitFCN->AddTemplate(i_tpl->fTemplate->GetHisto());
   }
  
@@ -160,12 +160,8 @@ int TemplateMultiFitter::FitWithAllTimesFixed( const TH1D* hPulse){
 }
 
 void TemplateMultiFitter::AddTemplate(TTemplate* tpl){
-  fFitFCN->AddTemplate(tpl->GetHisto());
-  int i=fFitFCN->GetNTemplates();
   TemplateDetails_t tmp;
   tmp.fTemplate=tpl;
-  tmp.fAmplitudeScaleFactor=fFitFCN->GetAmplitudeScaleFactor(i);
-  tmp.fTimeOffset=fFitFCN->GetTimeOffset(i); 
   fTemplates.push_back(tmp);
   if(fRefineFactor==0) fRefineFactor=tpl->GetRefineFactor();
   else if(fRefineFactor!= tpl->GetRefineFactor()){

--- a/analyzer/rootana/src/TAP_generators/template_fitting/TemplateMultiFitter.h
+++ b/analyzer/rootana/src/TAP_generators/template_fitting/TemplateMultiFitter.h
@@ -1,0 +1,83 @@
+#ifndef TemplateMultiFitter_h_
+#define TemplateMultiFitter_h_
+
+#include "TFitterMinuit.h"
+#include "TPulseIsland.h"
+#include "TTemplate.h"
+
+class MultiHistogramFitFCN;
+#include "definitions.h"
+#include "AlcapExcept.h"
+
+MAKE_EXCEPTION(TemplateMultiFitter, Base);
+MAKE_EXCEPTION(MismatchedTemplateRefineFactors, TemplateMultiFitter);
+
+class TemplateMultiFitter {
+  void operator=(const TemplateMultiFitter&);
+
+  struct TemplateDetails_t{
+    double fAmplitudeScaleFactor;
+    double fTimeOffset;
+    TTemplate* fTemplate;
+    double GetTime()const{ return  fTemplate->GetTime()+fTimeOffset; }
+    double GetAmplitude()const{ return  fTemplate->GetAmplitude()*fAmplitudeScaleFactor; }
+    void Set(double amp, double time){
+      fAmplitudeScaleFactor=amp/fTemplate->GetAmplitude();
+      fTimeOffset=time- fTemplate->GetTime();
+    }
+  };
+  typedef std::vector<TemplateDetails_t> TemplateList;
+
+ public:
+  TemplateMultiFitter(const IDs::channel& ch);
+  ~TemplateMultiFitter();
+  void Init();
+
+ public:
+  enum FitStatus{
+    kSuccess=0 ,
+    kPedestalOutOfBounds= -100,
+    kAmplitudeOutOfBounds= -101,
+    kTimeOutOfBounds= -102,
+    kFitNotConverged= 1,
+    kInitialised=-200
+  };
+  void AddTemplate(TTemplate* tpl);
+
+  /// @name fitting
+  /// @{
+  /// \brief
+  /// Sets the intial estimates for the template fitter
+  void SetPedestal(double v){fPedestal=v;}
+  void SetPulseEstimates( int index, double amp, double time){
+      fTemplates.at(index).Set(amp,time);
+  }
+  int FitWithOneTimeFree(int index,const TH1D* hPulse);
+  int FitWithAllTimesFixed(const TH1D* hPulse);
+  /// @}
+
+  /// @name getters
+  /// @{
+  double GetPedestal()const { return fPedestal; }
+  double GetAmplitude(int i)const { return fTemplates.at(i).GetAmplitude();}
+  double GetTime(int i)const { return fTemplates.at(i).GetTime(); }
+  double GetChi2()const { return fChi2; }
+  double GetNDoF()const { return fNDoF; }
+  /// @}
+
+ private:
+  TFitterMinuit* fMinuitFitter;
+  MultiHistogramFitFCN* fFitFCN;
+  IDs::channel fChannel;
+  double fMaxADC,fMinADC;
+
+  double fPedestal;
+  int fRefineFactor;
+  TemplateList fTemplates;
+  int fFreeTemplate;
+
+  double fChi2;
+  int fNDoF; // number of degress of freedom in fit
+};
+
+#endif

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -72,6 +72,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   }
 
   double f;
+  double temp_ped=fTemplateHist->GetBinContent(1);
   for (int i = bounds[0]+(fRefineFactor/2.0); i <= bounds[1]-(fRefineFactor/2.0); i += fRefineFactor) { 
     // calculate the chi^2 based on the centre of the 5 bins to avoid getting
     // abonus from mathcing all 5.  We shift and scale the template so that it
@@ -84,7 +85,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
       std::cout << "i = " << i << ", i - T_int = " << i-T_int << std::endl;
       std::cout << "f (before) = " << f << std::endl;
     }
-    f = A * (f - fTemplatePedestal) + P; // apply the transformation to this bin
+    f = A * (f - temp_ped) + P; // apply the transformation to this bin
     if (print_dbg) {
       std::cout << "f (after) = " << f << std::endl;
     }

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -9,8 +9,13 @@ HistogramFitFCN::HistogramFitFCN(const TH1D* hTemplate,const TH1D* hPulse) : fTe
 HistogramFitFCN::~HistogramFitFCN() {
 }
 
-void HistogramFitFCN::SetTemplateHist(const TH1D* hTemplate) {
+void HistogramFitFCN::SetTemplateHist(const TH1D* hTemplate, double pedestal) {
   fTemplateHist = hTemplate;
+  if(pedestal>0){
+    fTemplatePedestal = pedestal;
+  } else {
+    fTemplatePedestal = fTemplateHist->GetBinContent(1);
+  }
 }
 
 void HistogramFitFCN::SetPulseHist(const TH1D* hPulse) {
@@ -67,7 +72,6 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
   }
 
   double f;
-  double template_pedestal = fTemplateHist->GetBinContent(1);
   for (int i = bounds[0]+(fRefineFactor/2.0); i <= bounds[1]-(fRefineFactor/2.0); i += fRefineFactor) { 
     // calculate the chi^2 based on the centre of the 5 bins to avoid getting
     // abonus from mathcing all 5.  We shift and scale the template so that it
@@ -80,7 +84,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
       std::cout << "i = " << i << ", i - T_int = " << i-T_int << std::endl;
       std::cout << "f (before) = " << f << std::endl;
     }
-    f = A * (f - template_pedestal) + P; // apply the transformation to this bin
+    f = A * (f - fTemplatePedestal) + P; // apply the transformation to this bin
     if (print_dbg) {
       std::cout << "f (after) = " << f << std::endl;
     }
@@ -92,7 +96,7 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
     }
     double hTemplate_bin_error = fTemplateHist->GetBinError(i - T_int);
     //double hPulse_bin_error = fPulseHist->GetBinError(i);
-    chi2 += delta*delta / (hTemplate_bin_error*hTemplate_bin_error);
+    chi2 += delta*delta / (A*hTemplate_bin_error*hTemplate_bin_error);
     if (print_dbg) {
       std::cout << "Template Error = " << hTemplate_bin_error << ", chi2 (added) = " << delta*delta/(hTemplate_bin_error*hTemplate_bin_error) << ", chi2 (total) = " << chi2 << std::endl;
     }

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.cpp
@@ -40,7 +40,10 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
 
   if (print_dbg) { 
     std::cout << "HistogramFitFCN::operator() (start):" << std::endl;
-    std::cout << "\tpedestal = " << P << ", amplitude = " << A << ", time (integer part) = " << T_int << " and time (float part) = " << T_flt << std::endl;
+    std::cout << "\tpedestal = " << P 
+              << ", amplitude = " << A 
+              << ", time (integer part) = " << T_int 
+              << " and time (float part) = " << T_flt << std::endl;
   }
  
   int half_range = 10*fRefineFactor; // remove a few bins from the fit
@@ -65,10 +68,14 @@ double HistogramFitFCN::operator() (const std::vector<double>& par) const {
 
   double f;
   double template_pedestal = fTemplateHist->GetBinContent(1);
-  for (int i = bounds[0]+(fRefineFactor/2.0); i <= bounds[1]-(fRefineFactor/2.0); i += fRefineFactor) { // calculate the chi^2 based on the centre of the 5 bins to avoid getting abonus from mathcing all 5
-    // We shift and scale the template so that it matches the pulse.
-    // This is because, when we have a normalised template, we will get the actual amplitude, pedestal and time from the fit and not just offsets
-    f = fTemplateHist->GetBinContent(i - T_int) + T_flt*(fTemplateHist->GetBinContent(i - T_int + 1) - fTemplateHist->GetBinContent(i - T_int)); // linear interpolation between the i'th and the (i+1)'th bin
+  for (int i = bounds[0]+(fRefineFactor/2.0); i <= bounds[1]-(fRefineFactor/2.0); i += fRefineFactor) { 
+    // calculate the chi^2 based on the centre of the 5 bins to avoid getting
+    // abonus from mathcing all 5.  We shift and scale the template so that it
+    // matches the pulse.  This is because, when we have a normalised template,
+    // we will get the actual amplitude, pedestal and time from the fit and not
+    // just offsets
+    f = fTemplateHist->GetBinContent(i - T_int) ;
+    f += T_flt*(fTemplateHist->GetBinContent(i - T_int + 1) - f); // linear interpolation between the i'th and the (i+1)'th bin
     if (print_dbg) {
       std::cout << "i = " << i << ", i - T_int = " << i-T_int << std::endl;
       std::cout << "f (before) = " << f << std::endl;

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
@@ -8,10 +8,6 @@
 
 class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
 
- private:
-  const TH1D* fTemplateHist; // The template
-  const TH1D* fPulseHist; // The histogram to fit
-
  public:
   HistogramFitFCN(const TH1D* = NULL,const  TH1D* = NULL);
   ~HistogramFitFCN();
@@ -19,34 +15,37 @@ class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
   void SetTemplateHist(const TH1D*);
   void SetPulseHist(const TH1D*);
 
-  // Used for calls with parameters
-  // The return value is the chi squared
-  // weighted by errors in fTemplateHist
-  // Parameters:
-  // 1. Pedestal
-  // 2. Amplitude
-  // 3. Timing
+  void SetRefineFactor(int refine_factor) {fRefineFactor = refine_factor;}
+  void SetTimeOffset(double time_offset);
+
+
+  /// @brief Used for calls with parameters
+  /// The return value is the chi squared
+  /// weighted by errors in fTemplateHist
+  /// Parameters:
+  /// 1. Pedestal
+  /// 2. Amplitude
+  /// 3. Timing
   double operator() (const std::vector<double>& par) const;
-  // Used for error... somehow?
+
+  /// Used for error... somehow?
   double Up() const;
 
- private:
-  mutable int fNDoF; // record this for TemplateFitter to retrieve later (NB mutable so that it can be set in operator(), which is const)
-  
- public:
   int GetNDoF() { return fNDoF; }
 
  private:
-  double fTimeOffset; // the time offset to use
+  /// record this for TemplateFitter to retrieve later (NB mutable so that it
+  /// can be set in operator(), which is const)
+  mutable int fNDoF;
+  
+  /// the time offset to use
+  double fTimeOffset;
 
- public:
-  void SetTimeOffset(double time_offset);
-
- private:
   int fRefineFactor;
 
- public:
-  void SetRefineFactor(int refine_factor) {fRefineFactor = refine_factor;}
+  const TH1D* fTemplateHist; // The template
+  const TH1D* fPulseHist; // The histogram to fit
+
 };
 
 #endif

--- a/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/HistogramFitFCN.h
@@ -12,7 +12,7 @@ class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
   HistogramFitFCN(const TH1D* = NULL,const  TH1D* = NULL);
   ~HistogramFitFCN();
 
-  void SetTemplateHist(const TH1D*);
+  void SetTemplateHist(const TH1D*,double ped=-1);
   void SetPulseHist(const TH1D*);
 
   void SetRefineFactor(int refine_factor) {fRefineFactor = refine_factor;}
@@ -40,6 +40,7 @@ class HistogramFitFCN : public ROOT::Minuit2::FCNBase {
   
   /// the time offset to use
   double fTimeOffset;
+  double fTemplatePedestal;
 
   int fRefineFactor;
 

--- a/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.cpp
@@ -1,0 +1,56 @@
+#include "InterpolatePulse.h"
+
+#include <TH1D.h>
+#include <stdexcept>
+#include "TPulseIsland.h"
+#include "TSetupData.h"
+#include "SetupNavigator.h"
+
+TH1D* InterpolatePulse(
+    const TPulseIsland* pulse, std::string histname,
+     std::string histtitle, bool interpolate, int refine) {
+
+  // Get a few things first
+  const std::string& bankname = pulse->GetBankName();
+  const std::string detname = TSetupData::Instance()->GetDetectorName(bankname);
+  const std::vector<int>& theSamples = pulse->GetSamples();
+  int n_samples = theSamples.size();
+  int n_bins = refine*n_samples; // number of bins in the template
+
+  // Create the higher resolution histogram
+  TH1D* hist = new TH1D(histname.c_str(), histtitle.c_str(), n_bins, 0, n_samples);
+
+  double pedestal_error = SetupNavigator::Instance()->GetNoise(detname);
+
+  // Go through the bins in the high-resolution histogram
+  // NB sample numbers go grom 0 to n-1 and bins go from 1 to n
+  for (int i = 0; i < n_bins; ++i) {
+    int bin = i+1; // bins go from 1 to n rather than 0 to n-1
+    int sample_number = i / refine;
+    double remainder = i % refine;
+    double sample_value;
+
+    // We may want to interpolate between the samples in the samples vector
+    if (interpolate) {
+      try {
+        sample_value = theSamples.at(sample_number) 
+                     + (remainder / refine)*(theSamples.at(sample_number+1) 
+                                                     - theSamples.at(sample_number));
+      }
+      catch (const std::out_of_range& oor) { // if we'll be going out of range of the samples vector
+        sample_value = theSamples.at(sample_number);
+      }
+    }
+    else {
+      sample_value = theSamples.at(sample_number);
+    }
+
+    // Set the bin contents and bin error
+    hist->SetBinContent( bin, sample_value);
+    hist->SetBinError( bin, pedestal_error);
+  }
+  hist->SetDirectory(0);
+
+  return hist;
+}
+

--- a/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.cpp
@@ -5,8 +5,9 @@
 #include "TPulseIsland.h"
 #include "TSetupData.h"
 #include "SetupNavigator.h"
+#include <algorithm> //std::generate_n
 
-TH1D* InterpolatePulse(
+TH1D* functions::InterpolatePulse(
     const TPulseIsland* pulse, std::string histname,
      std::string histtitle, bool interpolate, int refine) {
 
@@ -54,3 +55,16 @@ TH1D* InterpolatePulse(
   return hist;
 }
 
+namespace{
+  struct unique_n{
+    int operator() () { return current+=step; }
+    int current;
+    const int step;
+    unique_n(int b,int s):current(b),step(s){}
+  };
+}
+
+void functions::FillBinLabels(double* labels, int size, int start, int increment){
+   unique_n uniq(start,increment);
+   std::generate_n(labels,size, uniq);
+}

--- a/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.h
+++ b/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.h
@@ -20,6 +20,7 @@ TH1F* VectorToHist( const std::vector<ValueType>& vect, std::string name,
    FillBinLabels(labels,size);
    TH1F* hist=new TH1F(name.c_str(),title.c_str(), size,0,size);
    hist->FillN(size,labels,vect.data());
+   hist->SetDirectory(0);
    return hist;
 }
 

--- a/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.h
+++ b/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.h
@@ -1,0 +1,14 @@
+#ifndef UTILS_INTERPOLATEPULSE_H
+#define UTILS_INTERPOLATEPULSE_H
+
+class TH1D;
+class TPulseIsland;
+#include <string>
+
+// Creates a histogram with sub-bin resolution
+TH1D* InterpolatePulse(
+    const TPulseIsland* pulse, std::string histname,
+     std::string histtitle, bool interpolate, int refine);
+
+
+#endif //UTILS_INTERPOLATEPULSE_H

--- a/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.h
+++ b/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.h
@@ -12,6 +12,8 @@ TH1D* InterpolatePulse(
     const TPulseIsland* pulse, std::string histname,
      std::string histtitle, bool interpolate, int refine);
 
+void FillBinLabels(double* labels, int size, int start=-1, int increment=1);
+
 template<typename ValueType>
 TH1F* VectorToHist( const std::vector<ValueType>& vect, std::string name,
      std::string title){
@@ -23,7 +25,6 @@ TH1F* VectorToHist( const std::vector<ValueType>& vect, std::string name,
    return hist;
 }
 
-void FillBinLabels(double* labels, int size, int start=-1, int increment=1);
 }
 
 using functions::InterpolatePulse;

--- a/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.h
+++ b/analyzer/rootana/src/TAP_generators/utils/InterpolatePulse.h
@@ -1,14 +1,31 @@
 #ifndef UTILS_INTERPOLATEPULSE_H
 #define UTILS_INTERPOLATEPULSE_H
 
-class TH1D;
 class TPulseIsland;
 #include <string>
+#include <vector>
+#include <TH1.h>
 
+namespace functions{
 // Creates a histogram with sub-bin resolution
 TH1D* InterpolatePulse(
     const TPulseIsland* pulse, std::string histname,
      std::string histtitle, bool interpolate, int refine);
 
+template<typename ValueType>
+TH1F* VectorToHist( const std::vector<ValueType>& vect, std::string name,
+     std::string title){
+   const int size=vect.size();
+   double labels[size];
+   FillBinLabels(labels,size);
+   TH1F* hist=new TH1F(name.c_str(),title.c_str(), size,0,size);
+   hist->FillN(size,labels,vect.data());
+   return hist;
+}
+
+void FillBinLabels(double* labels, int size, int start=-1, int increment=1);
+}
+
+using functions::InterpolatePulse;
 
 #endif //UTILS_INTERPOLATEPULSE_H

--- a/analyzer/rootana/src/TAP_generators/utils/MultiHistogramFitFCN.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/MultiHistogramFitFCN.cpp
@@ -1,0 +1,69 @@
+#include "MultiHistogramFitFCN.h"
+
+#include <cmath>
+#include <iostream>
+#include <cassert>
+
+MultiHistogramFitFCN::MultiHistogramFitFCN(double refine_factor):
+  fRefineFactor(refine_factor){
+}
+
+MultiHistogramFitFCN::~MultiHistogramFitFCN() {
+}
+
+double MultiHistogramFitFCN::HistogramDetails_t::GetHeight(double t)const{
+    int bin=t - fTimeOffset;
+    double remainder=t - fTimeOffset - bin;
+    assert( remainder<1 );
+    double y0 = fTemplateHist->GetBinContent(bin);
+    double y1 = fTemplateHist->GetBinContent(bin+1);
+    return (y0 + remainder*((y1-y0)))*fAmplitudeScale;
+}
+
+double MultiHistogramFitFCN::HistogramDetails_t::GetError2(double t)const{
+    int bin= t - fTimeOffset;
+    double error= fTemplateHist->GetBinError(bin);
+    return error*error;
+}
+
+double MultiHistogramFitFCN::operator() (const std::vector<double>& par) const {
+  // Chi2 fit with pedestal P, amplitude A, and timing T
+  // Warning: The time is truncated to an int, so if there's
+  // so if the step size in MINUIT is smalled than 1,
+  // Any value of T will probably be seen as minimized, which it
+  // almost certainly will not be.
+  UnpackParameters(par);
+  double chi2 = 0.;
+
+  int safety = 6*fRefineFactor; // remove a few bins from the fit
+  int bounds[2];
+  GetHistogramBounds(safety,bounds[0], bounds[1]);
+  
+  if( (bounds[1]-bounds[0]) < 40*fRefineFactor ) throw Except::SlimlyOverlappingTemplates();
+
+  // Calculate the degrees of freedom ( #data - #fit_params)
+  // +1 because we include both ends of the bounds when we loop through
+  fNDoF = ((bounds[1] - bounds[0] + 1)/fRefineFactor) - par.size(); 
+
+  double tpl_height,tpl_error;
+  for (int i = bounds[0]+(fRefineFactor/2.0); i <= bounds[1]-(fRefineFactor/2.0); i += fRefineFactor) { 
+    // calculate the chi^2 based on the centre of the 5 bins to avoid getting
+    // abonus from mathcing all 5.  We shift and scale the template so that it
+    // matches the pulse.  This is because, when we have a normalised template,
+    // we will get the actual amplitude, pedestal and time from the fit and not
+    // just offsets
+    tpl_height=0;
+    tpl_error=0;
+    
+    for(TemplateList::const_iterator i_tpl=fTemplates.begin(); 
+         i_tpl!=fTemplates.end(); ++i_tpl){
+       tpl_height+=i_tpl->GetHeight(i);
+       tpl_error+=i_tpl->fAmplitudeScale*i_tpl->GetError2(i);
+    }
+
+    double delta = fPulseHist->GetBinContent(i) - tpl_height;
+    chi2 += delta*delta / tpl_error;
+  }
+
+  return chi2;
+}

--- a/analyzer/rootana/src/TAP_generators/utils/MultiHistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/MultiHistogramFitFCN.h
@@ -5,6 +5,9 @@
 #include "TH1D.h"
 #include "AlcapExcept.h"
 
+#include "debug_tools.h"
+#include <iostream>
+
 #include <vector>
 
 MAKE_EXCEPTION(MultiHistogramFitFCN, Base);
@@ -114,8 +117,8 @@ inline void MultiHistogramFitFCN::UnpackParameters(const std::vector<double>& pa
     const std::vector<double>::const_iterator begin=par.begin();
     std::vector<double>::const_iterator i_par=begin;
     fPedestal=*i_par;
-    for( ; i_par!=par.end(); ++i_par){
-      int n= (i_par-begin+1) ;
+    for(++i_par ; i_par!=par.end(); ++i_par){
+      int n= (i_par-begin-1) ;
       fTemplates.at(n).fAmplitudeScale=*i_par;
     }
   }

--- a/analyzer/rootana/src/TAP_generators/utils/MultiHistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/MultiHistogramFitFCN.h
@@ -15,7 +15,6 @@ class MultiHistogramFitFCN : public ROOT::Minuit2::FCNBase {
   double fTimeOffset, fAmplitudeScale;
   const TH1D* fTemplateHist; 
   int fNDoF;
-  bool fFixed;
   double GetHeight(double t)const;
   double GetError2(double t)const;
  };
@@ -25,16 +24,18 @@ class MultiHistogramFitFCN : public ROOT::Minuit2::FCNBase {
   MultiHistogramFitFCN(double refine_factor=1);
   ~MultiHistogramFitFCN();
 
-  void AddTemplate(const TH1D* hist, double time=0, bool fixed=false){
+  void AddTemplate(const TH1D* hist, double time=0){
      HistogramDetails_t tmp;
      tmp.fTemplateHist=hist;
      tmp.fTimeOffset=time;
      tmp.fNDoF=0;
-     tmp.fFixed=fixed;
      fTemplates.push_back(tmp);
   }
   void SetTemplateHist( int n , const TH1D* hist){
     fTemplates.at(n).fTemplateHist=hist;
+  }
+  void SetTimeOffset(int n, double offset){
+    fTemplates.at(n).fTimeOffset=offset;
   }
   void SetTime(int n, double time){
     fTemplates.at(n).fTimeOffset=time - fTemplates[n].fTemplateHist->GetMaximumBin();
@@ -46,19 +47,13 @@ class MultiHistogramFitFCN : public ROOT::Minuit2::FCNBase {
     SetTime(n, time_offset);
     SetAmplitude(n, amp);
   }
-  void FixTemplate(int n, bool fix=true){
-    fTemplates.at(n).fFixed=fix;
-  }
-  void FixAllTemplatesBut(int n, bool fix=true){
-    for(TemplateList::iterator i_hist=fTemplates.begin();
-        i_hist!=fTemplates.end(); ++i_hist){
-       if(i_hist- fTemplates.begin() == n) continue;
-       i_hist->fFixed=fix;
-    }
-  }
 
   void SetPulseHist(const TH1D* pulse){fPulseHist=pulse;}
   void SetRefineFactor(int refine_factor) {fRefineFactor = refine_factor;}
+  
+  double& GetAmplitudeScaleFactor(int i)const{return fTemplates.at(i).fAmplitudeScale;}
+  double& GetTimeOffset(int i)const{return fTemplates.at(i).fTimeOffset;}
+  int GetNTemplates()const{return fTemplates.size();}
 
   /// @brief Used to calculate the chi-2
   /// @details

--- a/analyzer/rootana/src/TAP_generators/utils/MultiHistogramFitFCN.h
+++ b/analyzer/rootana/src/TAP_generators/utils/MultiHistogramFitFCN.h
@@ -1,0 +1,128 @@
+#ifndef MultiHistogramFitFCN_h__
+#define MultiHistogramFitFCN_h__
+
+#include "Minuit2/FCNBase.h"
+#include "TH1D.h"
+#include "AlcapExcept.h"
+
+#include <vector>
+
+MAKE_EXCEPTION(MultiHistogramFitFCN, Base);
+MAKE_EXCEPTION(SlimlyOverlappingTemplates,MultiHistogramFitFCN);
+
+class MultiHistogramFitFCN : public ROOT::Minuit2::FCNBase {
+ struct HistogramDetails_t {
+  double fTimeOffset, fAmplitudeScale;
+  const TH1D* fTemplateHist; 
+  int fNDoF;
+  bool fFixed;
+  double GetHeight(double t)const;
+  double GetError2(double t)const;
+ };
+ typedef std::vector<HistogramDetails_t> TemplateList;
+
+ public:
+  MultiHistogramFitFCN(double refine_factor=1);
+  ~MultiHistogramFitFCN();
+
+  void AddTemplate(const TH1D* hist, double time=0, bool fixed=false){
+     HistogramDetails_t tmp;
+     tmp.fTemplateHist=hist;
+     tmp.fTimeOffset=time;
+     tmp.fNDoF=0;
+     tmp.fFixed=fixed;
+     fTemplates.push_back(tmp);
+  }
+  void SetTemplateHist( int n , const TH1D* hist){
+    fTemplates.at(n).fTemplateHist=hist;
+  }
+  void SetTime(int n, double time){
+    fTemplates.at(n).fTimeOffset=time - fTemplates[n].fTemplateHist->GetMaximumBin();
+  }
+  void SetAmplitude(int n, double amp){
+    fTemplates.at(n).fAmplitudeScale=amp/fTemplates[n].fTemplateHist->GetMaximum();
+  }
+  void SetInitialValues(int n, double time_offset, double amp){
+    SetTime(n, time_offset);
+    SetAmplitude(n, amp);
+  }
+  void FixTemplate(int n, bool fix=true){
+    fTemplates.at(n).fFixed=fix;
+  }
+  void FixAllTemplatesBut(int n, bool fix=true){
+    for(TemplateList::iterator i_hist=fTemplates.begin();
+        i_hist!=fTemplates.end(); ++i_hist){
+       if(i_hist- fTemplates.begin() == n) continue;
+       i_hist->fFixed=fix;
+    }
+  }
+
+  void SetPulseHist(const TH1D* pulse){fPulseHist=pulse;}
+  void SetRefineFactor(int refine_factor) {fRefineFactor = refine_factor;}
+
+  /// @brief Used to calculate the chi-2
+  /// @details
+  /// The return value is the chi squared
+  /// weighted by errors in fTemplateHist
+  /// Parameters:
+  /// 0. Pedestal 
+  /// 1. Amplitude of first pulse
+  /// 2. Amplitude of second pulse
+  /// ....
+  /// N Amplitude of Nth pulse
+  double operator() (const std::vector<double>& par) const;
+
+  /// Used for error... somehow?
+  double Up() const {return 1.;}
+
+  int GetNDoF() { return fNDoF; }
+
+ private:
+  inline void UnpackParameters(const std::vector<double>& par)const;
+  inline void GetHistogramBounds(int safety, int &low_edge, int& high_edge)const;
+
+  /// record this for TemplateFitter to retrieve later (NB mutable so that it
+  /// can be set in operator(), which is const)
+  mutable int fNDoF;
+  mutable double fChi2;
+  mutable double fPedestal;
+  
+  int fRefineFactor;
+
+  mutable TemplateList fTemplates;
+
+  const TH1D* fPulseHist; // The histogram to fit
+
+};
+
+inline void MultiHistogramFitFCN::GetHistogramBounds(int safety, int &low_edge, int& high_edge)const{
+  // init to pulse histogram
+  low_edge=safety;
+  high_edge=fPulseHist->GetNbinsX()-safety;
+
+  // for each templatint 
+  int tpl_start, tpl_stop;
+  for(TemplateList::const_iterator i_tpl=fTemplates.begin(); i_tpl!=fTemplates.end(); ++i_tpl){
+    tpl_start=i_tpl->fTimeOffset + safety;
+    tpl_stop=i_tpl->fTimeOffset+i_tpl->fTemplateHist->GetNbinsX() - safety;
+
+    // find the maximum of all the starts of a template
+    if(high_edge>tpl_stop) high_edge=tpl_stop;
+
+    // find the minimum of all the ends of a template
+    if(low_edge>tpl_start) low_edge=tpl_start;
+  }
+}
+
+inline void MultiHistogramFitFCN::UnpackParameters(const std::vector<double>& par)const{
+    if ( par.size() < fTemplates.size()+1) return;
+    const std::vector<double>::const_iterator begin=par.begin();
+    std::vector<double>::const_iterator i_par=begin;
+    fPedestal=*i_par;
+    for( ; i_par!=par.end(); ++i_par){
+      int n= (i_par-begin+1) ;
+      fTemplates.at(n).fAmplitudeScale=*i_par;
+    }
+  }
+
+#endif

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -83,8 +83,11 @@ double Algorithm::SimpleIntegral::operator() (const TPulseIsland* tpi)const {
   return integral;
 }
 
-double Algorithm::IntegralRatio::operator() (const TPulseIsland* tpi){
+void Algorithm::IntegralRatio::SetPedestalToMinimum(const TPulseIsland* tpi){
      SetPedestal(*std::min_element(tpi->GetSamples().begin(), tpi->GetSamples().end()));
+}
+
+double Algorithm::IntegralRatio::operator() (const TPulseIsland* tpi){
      fHead=fHeadIntegrator(tpi);
      fTail=fTailIntegrator(tpi);
      return GetRatio();

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -22,7 +22,7 @@ double Algorithm::MaxBinAmplitude::operator() (const TPulseIsland* tpi) const {
     peak_sample_pos = std::min_element(pulseSamples.begin(), pulseSamples.end());
 
   // Now calculate the amplitude
-  double amplitude = trigger_polarity*(*peak_sample_pos - pedestal);
+  amplitude = trigger_polarity*(*peak_sample_pos - pedestal);
   time = peak_sample_pos- pulseSamples.begin();
 
   return amplitude;

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.cpp
@@ -23,6 +23,7 @@ double Algorithm::MaxBinAmplitude::operator() (const TPulseIsland* tpi) const {
 
   // Now calculate the amplitude
   double amplitude = trigger_polarity*(*peak_sample_pos - pedestal);
+  time = peak_sample_pos- pulseSamples.begin();
 
   return amplitude;
 }

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -23,6 +23,7 @@ struct Algorithm::MaxBinAmplitude {
   const int trigger_polarity;
   const double pedestal;
   mutable double time;
+  mutable double amplitude;
 };
 
 struct Algorithm::MaxBinTime {

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -16,14 +16,17 @@ namespace Algorithm {
 
 struct Algorithm::MaxBinAmplitude {
   public:
-  MaxBinAmplitude(double ped, int trig_pol)
-    :trigger_polarity(trig_pol), pedestal(ped){}
-  double operator() (const TPulseIsland* tpi) const;
+    MaxBinAmplitude(double ped, int trig_pol)
+      :trigger_polarity(trig_pol), pedestal(ped){}
+    double operator() (const TPulseIsland* tpi) const;
+    double GetTime()const {return time;}
+    double GetAmplitude()const {return amplitude;}
 
-  const int trigger_polarity;
-  const double pedestal;
-  mutable double time;
-  mutable double amplitude;
+    const int trigger_polarity;
+    const double pedestal;
+  private:
+    mutable double time;
+    mutable double amplitude;
 };
 
 struct Algorithm::MaxBinTime {

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -22,6 +22,7 @@ struct Algorithm::MaxBinAmplitude {
 
   const int trigger_polarity;
   const double pedestal;
+  mutable double time;
 };
 
 struct Algorithm::MaxBinTime {

--- a/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
+++ b/analyzer/rootana/src/TAP_generators/utils/TAPAlgorithms.h
@@ -93,6 +93,7 @@ struct Algorithm::IntegralRatio{
   
   void SetTailStart(int v){ fTailIntegrator.SetStart(v); fHeadIntegrator.SetStop(v);}
   void SetPedestal(double v){ fTailIntegrator.SetPedestal(v); fHeadIntegrator.SetPedestal(v);}
+  void SetPedestalToMinimum(const TPulseIsland* tpi);
 
 private:
   Algorithm::SimpleIntegral fTailIntegrator;

--- a/analyzer/rootana/src/TME_generators/FixedWindowMEGenerator.cpp
+++ b/analyzer/rootana/src/TME_generators/FixedWindowMEGenerator.cpp
@@ -91,7 +91,6 @@ void FixedWindowMEGenerator::AddPulsesInWindow(
     // skip empty lists
     if(start==end) return;
 
-
     // Move the iteator for the start of the window
     int look_ahead=1;
     while((start+look_ahead!=end) && (start!=end) ){

--- a/analyzer/rootana/src/files.make
+++ b/analyzer/rootana/src/files.make
@@ -17,6 +17,7 @@ DIRS += src/\
 ROOT_DICT_CLASSES:=TAnalysedPulseMapWrapper\
 	TDetectorPulse\
 	TGaussFitAnalysedPulse\
+	TTemplateFitAnalysedPulse\
 	TIntegralRatioAnalysedPulse\
 	IdChannel\
 	IdGenerator\

--- a/analyzer/rootana/src/files.make
+++ b/analyzer/rootana/src/files.make
@@ -18,6 +18,7 @@ ROOT_DICT_CLASSES:=TAnalysedPulseMapWrapper\
 	TDetectorPulse\
 	TGaussFitAnalysedPulse\
 	TTemplateFitAnalysedPulse\
+	TTemplateConvolveAnalysedPulse\
 	TIntegralRatioAnalysedPulse\
 	IdChannel\
 	IdGenerator\

--- a/analyzer/rootana/src/framework/EventNavigator.h
+++ b/analyzer/rootana/src/framework/EventNavigator.h
@@ -63,7 +63,7 @@ class EventNavigator {
 
   /// Gives access to the run meta-data, including all information
   /// stored in the TSetupData struct
-  const SetupRecord& GetSetupRecord() {return *fSetupRecord;}
+  static const SetupRecord& GetSetupRecord() {return *Instance().fSetupRecord;}
 
   /// Gives read access to the LoopSequence, which must first be
   /// initailised with MakeLoopSequence() in main()

--- a/analyzer/rootana/src/framework/TemplateFactory.tpl
+++ b/analyzer/rootana/src/framework/TemplateFactory.tpl
@@ -58,8 +58,9 @@ const typename TemplateFactory<BaseModule,OptionsType>::PerModule& TemplateFacto
      const std::string& name)const{
     typename ModuleList::const_iterator it  = fModules.find(name);
     if(it == fModules.end() ){
-        std::cout<<fName<<"::GetModuleDetails: Error: Unknown module requested: "<<name<<std::endl;
-        throw std::out_of_range(("unknown module "+name).c_str());
+        std::cout<<fName<<"::GetModuleDetails: Error: I don't know how to make : "<<name<<std::endl;
+        PrintPossibleModules();
+        throw std::out_of_range(("unknown: "+name).c_str());
     }
     return it->second;
 }

--- a/analyzer/rootana/src/plotters/ExportPulse.cpp
+++ b/analyzer/rootana/src/plotters/ExportPulse.cpp
@@ -10,7 +10,7 @@
 //ROOT
 #include <TH1F.h>
 #include <THStack.h>
-#include <TObjArray.h>
+#include <TDirectory.h>
 
 //Local
 #include "ModulesFactory.h"
@@ -21,6 +21,7 @@
 #include "RegisterModule.inc"
 #include "EventNavigator.h"
 #include "SetupNavigator.h"
+#include "debug_tools.h"
 
 using std::cout;
 using std::endl;
@@ -43,6 +44,9 @@ ExportPulse::ExportPulse(modules::options* opts)
   if(fUsePCF){
       fPulseFinder=new PulseCandidateFinder();
   }
+  
+  fTPIDirectory=GetDirectory("TPIs");
+  fTAPDirectory=GetDirectory("TAPs");
 }
 
 
@@ -121,9 +125,11 @@ int ExportPulse::ProcessEntry(TGlobalData *gData, const TSetupData* gSetup){
   // Check if we have any pulses to draw that were requested through the MODULEs file
   LoadPulsesRequestedByConfig();
 
+  fTPIDirectory->cd();
   int ret_val=DrawTPIs();
   if(ret_val!=0) return ret_val;
 
+  fTAPDirectory->cd();
   ret_val=DrawTAPs();
   if(ret_val!=0) return ret_val;
 
@@ -231,7 +237,7 @@ int ExportPulse::PlotTPI(const TPulseIsland* pulse, const PulseInfo_t& info){
   }
   
   TH1F* fullPulse=MakeHistTPI(pulse,hist);
-  fullPulse->SetDirectory(GetDirectory());
+  fullPulse->SetDirectory(fTPIDirectory);
   fullPulse->SetTitle(title.str().c_str());
 
   if(fUsePCF){
@@ -257,7 +263,7 @@ int ExportPulse::PlotTPI(const TPulseIsland* pulse, const PulseInfo_t& info){
       }
 
       // Save the stack
-      GetDirectory()->Add(stack);
+      fTPIDirectory->Add(stack);
   }
 
   return 0;
@@ -287,7 +293,7 @@ TH1F* ExportPulse::MakeHistTPI(const TPulseIsland* pulse, const std::string& nam
 int ExportPulse::PlotTAP(const TAnalysedPulse* pulse, const PulseInfo_t& info)const{
   std::string hist=info.MakeTPIName();
   TH1F* tpi_hist=NULL;
-  gDirectory->GetObject(hist.c_str(),tpi_hist);
+  fTPIDirectory->GetObject(hist.c_str(),tpi_hist);
   pulse->Draw(tpi_hist);
   return 0;
 }

--- a/analyzer/rootana/src/plotters/ExportPulse.h
+++ b/analyzer/rootana/src/plotters/ExportPulse.h
@@ -14,6 +14,7 @@
 #include "ModulesNavigator.h"
 #include "PulseCandidateFinder.h"
 
+class TDirectory;
 class TVAnalysedPulseGenerator;
 class TPulseIsland;
 #include "TAnalysedPulse.h"
@@ -130,6 +131,8 @@ class ExportPulse : public BaseModule{
   bool fUsePCF;
   PulseCandidateFinder* fPulseFinder;
   PulseIslandList fSubPulses;
+  TDirectory* fTPIDirectory;
+  TDirectory* fTAPDirectory;
 
   TGlobalData* fGlobalData; // To be removed once Phill finishes the event navigator
 

--- a/analyzer/rootana/src/plotters/PulseViewer.cpp
+++ b/analyzer/rootana/src/plotters/PulseViewer.cpp
@@ -10,6 +10,7 @@
 #include "IdSource.h"
 #include "EventNavigator.h"
 #include "TIntegralRatioAnalysedPulse.h"
+#include "TTemplateFitAnalysedPulse.h"
 
 #include <TFormula.h>
 
@@ -77,6 +78,7 @@ int PulseViewer::BeforeFirstEntry(TGlobalData* gData, const TSetupData* setup){
    if(fAvailablePulseTypes.empty()){
      fAvailablePulseTypes["TAnalysedPulse"]=kTAP;
      fAvailablePulseTypes["IntegralRatioAP"]=kIntegralRatioAP;
+     fAvailablePulseTypes["TemplateFitAP"]=kTemplateFitAP;
    }
 
    int ret_val= CheckPulseType(fRequestedPulseType);
@@ -99,6 +101,11 @@ int PulseViewer::CheckPulseType(const std::string& pulse_type){
    fPulseType=i_type->second;
    switch(fPulseType){
       case kTAP: break;
+      case kTemplateFitAP:
+         fAvailableParams["Chi2"]=kChi2;
+         fAvailableParams["Status"]=kStatus;
+         fAvailableParams["Integral_ratio"]=kIntegralRatio;
+         break;
       case kIntegralRatioAP:
          fAvailableParams["Integral_ratio"]=kIntegralRatio;
          fAvailableParams["Integral_tail"]=kIntegralTail;
@@ -179,6 +186,7 @@ bool PulseViewer::TestPulseType(const TAnalysedPulse* pulse){
   switch(fPulseType){
     case kTAP: return false;
     case kIntegralRatioAP: return dynamic_cast<const TIntegralRatioAnalysedPulse*>(pulse);
+    case kTemplateFitAP: return dynamic_cast<const TTemplateFitAnalysedPulse*>(pulse);
   }
   return false;
 }
@@ -210,23 +218,37 @@ double PulseViewer::GetParameterValue(const TIntegralRatioAnalysedPulse* pulse,c
     return retVal;
 }
 
+double PulseViewer::GetParameterValue(const TTemplateFitAnalysedPulse* pulse,const ParameterType& parameter){
+   double retVal=0;
+   switch (parameter){
+       case kIntegralRatio: retVal=pulse->GetIntegralRatio(); break;
+       case kChi2: retVal=pulse->GetChi2(); break;
+       case kStatus: retVal=pulse->GetFitStatus(); break;
+       default: retVal=GetParameterValue( static_cast<const TAnalysedPulse*>(pulse),parameter);
+    }
+    return retVal;
+}
+
 int PulseViewer::ConsiderDrawing(const TAnalysedPulseID& id, const TAnalysedPulse* pulse){
   // Check pulse passes trigger condition
     double vals[fAvailableParams.size()];
     switch (fPulseType){
        case kTAP: GetVals(vals,pulse); break;
-       case kIntegralRatioAP: 
-            const TIntegralRatioAnalysedPulse* ir_pulse
-              =static_cast<const TIntegralRatioAnalysedPulse*>(pulse);
+       case kTemplateFitAP: if(true){
+            const TTemplateFitAnalysedPulse* tf_pulse =static_cast<const TTemplateFitAnalysedPulse*>(pulse);
+            GetVals(vals,tf_pulse);
+            } break;
+       case kIntegralRatioAP: if(true){
+            const TIntegralRatioAnalysedPulse* ir_pulse =static_cast<const TIntegralRatioAnalysedPulse*>(pulse);
             GetVals(vals,ir_pulse);
-            break;
+            } break;
     }
     fFormula->SetParameters(vals);
     double value=fFormula->Eval(0);
   if(!value) return 0;
   if(Debug()){
     cout<<"PulseViewer: Event: "<<EventNavigator::Instance().EntryNo()
-        <<" Plotting pulse "<<id<<" [ "<<fFormula->GetExpFormula("P")<<" ]"<<endl;
+        <<" Plotting pulse "<<id<<" [ "<<fTriggerCondition<<" => "<<fFormula->GetExpFormula("P")<<" ]"<<endl;
   }
   
   // If it does, ask ExportPulse to draw it

--- a/analyzer/rootana/src/plotters/PulseViewer.cpp
+++ b/analyzer/rootana/src/plotters/PulseViewer.cpp
@@ -11,6 +11,7 @@
 #include "EventNavigator.h"
 #include "TIntegralRatioAnalysedPulse.h"
 #include "TTemplateFitAnalysedPulse.h"
+#include "TTemplateConvolveAnalysedPulse.h"
 
 #include <TFormula.h>
 
@@ -79,6 +80,7 @@ int PulseViewer::BeforeFirstEntry(TGlobalData* gData, const TSetupData* setup){
      fAvailablePulseTypes["TAnalysedPulse"]=kTAP;
      fAvailablePulseTypes["IntegralRatioAP"]=kIntegralRatioAP;
      fAvailablePulseTypes["TemplateFitAP"]=kTemplateFitAP;
+     fAvailablePulseTypes["TemplateConvolveAP"]=kTemplateConvolveAP;
    }
 
    int ret_val= CheckPulseType(fRequestedPulseType);
@@ -101,6 +103,11 @@ int PulseViewer::CheckPulseType(const std::string& pulse_type){
    fPulseType=i_type->second;
    switch(fPulseType){
       case kTAP: break;
+      case kTemplateConvolveAP:
+         fAvailableParams["NPeaks"]=kNPeaks;
+         fAvailableParams["PeakRank"]=kPeakRank;
+         fAvailableParams["Integral_ratio"]=kIntegralRatio;
+         break;
       case kTemplateFitAP:
          fAvailableParams["Chi2"]=kChi2;
          fAvailableParams["Status"]=kStatus;
@@ -188,6 +195,7 @@ bool PulseViewer::TestPulseType(const TAnalysedPulse* pulse){
     case kTAP: return false;
     case kIntegralRatioAP: return dynamic_cast<const TIntegralRatioAnalysedPulse*>(pulse);
     case kTemplateFitAP: return dynamic_cast<const TTemplateFitAnalysedPulse*>(pulse);
+    case kTemplateConvolveAP: return dynamic_cast<const TTemplateConvolveAnalysedPulse*>(pulse);
   }
   return false;
 }
@@ -231,11 +239,26 @@ double PulseViewer::GetParameterValue(const TTemplateFitAnalysedPulse* pulse,con
     return retVal;
 }
 
+double PulseViewer::GetParameterValue(const TTemplateConvolveAnalysedPulse* pulse,const ParameterType& parameter){
+   double retVal=0;
+   switch (parameter){
+       case kIntegralRatio: retVal=pulse->GetIntegralRatio(); break;
+       case kNPeaks: retVal=pulse->GetNPeaks(); break;
+       case kPeakRank: retVal=pulse->GetPeakRank(); break;
+       default: retVal=GetParameterValue( static_cast<const TAnalysedPulse*>(pulse),parameter);
+    }
+    return retVal;
+}
+
 int PulseViewer::ConsiderDrawing(const TAnalysedPulseID& id, const TAnalysedPulse* pulse){
   // Check pulse passes trigger condition
     double vals[fAvailableParams.size()];
     switch (fPulseType){
        case kTAP: GetVals(vals,pulse); break;
+       case kTemplateConvolveAP: if(true){
+            const TTemplateConvolveAnalysedPulse* tc_pulse =static_cast<const TTemplateConvolveAnalysedPulse*>(pulse);
+            GetVals(vals,tc_pulse);
+            } break;
        case kTemplateFitAP: if(true){
             const TTemplateFitAnalysedPulse* tf_pulse =static_cast<const TTemplateFitAnalysedPulse*>(pulse);
             GetVals(vals,tf_pulse);

--- a/analyzer/rootana/src/plotters/PulseViewer.cpp
+++ b/analyzer/rootana/src/plotters/PulseViewer.cpp
@@ -105,6 +105,7 @@ int PulseViewer::CheckPulseType(const std::string& pulse_type){
          fAvailableParams["Chi2"]=kChi2;
          fAvailableParams["Status"]=kStatus;
          fAvailableParams["Integral_ratio"]=kIntegralRatio;
+         fAvailableParams["Double_fitted"]=kWasDouble;
          break;
       case kIntegralRatioAP:
          fAvailableParams["Integral_ratio"]=kIntegralRatio;
@@ -224,6 +225,7 @@ double PulseViewer::GetParameterValue(const TTemplateFitAnalysedPulse* pulse,con
        case kIntegralRatio: retVal=pulse->GetIntegralRatio(); break;
        case kChi2: retVal=pulse->GetChi2(); break;
        case kStatus: retVal=pulse->GetFitStatus(); break;
+       case kWasDouble: retVal=pulse->WasFirstOfDouble(); break;
        default: retVal=GetParameterValue( static_cast<const TAnalysedPulse*>(pulse),parameter);
     }
     return retVal;

--- a/analyzer/rootana/src/plotters/PulseViewer.h
+++ b/analyzer/rootana/src/plotters/PulseViewer.h
@@ -9,6 +9,7 @@ namespace modules {class options;}
 class TFormula;
 class TIntegralRatioAnalysedPulse;
 class TTemplateFitAnalysedPulse;
+class TTemplateConvolveAnalysedPulse;
 
 /// @brief Module to plot pulses meeting a certain criteria
 /// @see https://github.com/alcap-org/AlcapDAQ/wiki/rootana-module-PulseViewer
@@ -32,13 +33,16 @@ class PulseViewer : public BaseModule{
         kIntegralTail,
         kChi2,
         kStatus,
-        kWasDouble
+        kWasDouble,
+        kNPeaks,
+        kPeakRank
     };
 
     enum PulseType{
         kTAP,
         kIntegralRatioAP,
-        kTemplateFitAP
+        kTemplateFitAP,
+        kTemplateConvolveAP
     };
 
     public:
@@ -61,6 +65,7 @@ class PulseViewer : public BaseModule{
     double GetParameterValue(const TAnalysedPulse* pulse,const ParameterType& parameter);
     double GetParameterValue(const TIntegralRatioAnalysedPulse* pulse,const ParameterType& parameter);
     double GetParameterValue(const TTemplateFitAnalysedPulse* pulse,const ParameterType& parameter);
+    double GetParameterValue(const TTemplateConvolveAnalysedPulse* pulse,const ParameterType& parameter);
 
     /// Parse a trigger condition and set up the values needed to handle it
     /// @return 0 on success, non-zero otherwise

--- a/analyzer/rootana/src/plotters/PulseViewer.h
+++ b/analyzer/rootana/src/plotters/PulseViewer.h
@@ -8,6 +8,7 @@ class TSetupData;
 namespace modules {class options;}
 class TFormula;
 class TIntegralRatioAnalysedPulse;
+class TTemplateFitAnalysedPulse;
 
 /// @brief Module to plot pulses meeting a certain criteria
 /// @see https://github.com/alcap-org/AlcapDAQ/wiki/rootana-module-PulseViewer
@@ -28,12 +29,15 @@ class PulseViewer : public BaseModule{
         kTriggerTime,
         kEventNo,
         kIntegralRatio,
-        kIntegralTail
+        kIntegralTail,
+        kChi2,
+        kStatus
     };
 
     enum PulseType{
         kTAP,
-        kIntegralRatioAP
+        kIntegralRatioAP,
+        kTemplateFitAP
     };
 
     public:
@@ -55,6 +59,7 @@ class PulseViewer : public BaseModule{
     /// Get the value of interest from pulse
     double GetParameterValue(const TAnalysedPulse* pulse,const ParameterType& parameter);
     double GetParameterValue(const TIntegralRatioAnalysedPulse* pulse,const ParameterType& parameter);
+    double GetParameterValue(const TTemplateFitAnalysedPulse* pulse,const ParameterType& parameter);
 
     /// Parse a trigger condition and set up the values needed to handle it
     /// @return 0 on success, non-zero otherwise

--- a/analyzer/rootana/src/plotters/PulseViewer.h
+++ b/analyzer/rootana/src/plotters/PulseViewer.h
@@ -31,7 +31,8 @@ class PulseViewer : public BaseModule{
         kIntegralRatio,
         kIntegralTail,
         kChi2,
-        kStatus
+        kStatus,
+        kWasDouble
     };
 
     enum PulseType{


### PR DESCRIPTION
This is to merge the work with template fitting and convolution back into develop.  On the whole I think this work was isolated from other people's work however I have changed a few parts of common code so I wanted to check everyone was aware and ok with these changes.

The changes to core (framework) bits of code:
- `EventNavigator::GetSetupRecord` is now a static method so you don't need to get the EventNavigator Instance first.
- SavePulses fills the TAPs with the Copy method.  That means that in derived types of TAPs you should overload this method and call the base-class's version from within that.  This was a bit of a hack really because for some reason ROOT wasn't copying the fields of a derived tap over correctly.  You can see an example of this in the TTemplateConvolveAnalysedPulse class.
- ExportPulse now saves TAPs and TPIs to sub-directories of itself since there were too many plots in the single directory to be manageable I found.
- I have extended the PulseViewer to work with some of the newer derived-type TAPs.  If anyone wants to use it with a different kind then hopefully they can follow the way these other types work.
- Some changes went into the TAPAlgorithms classes but I don't think the default behaviours were changed.
