### PR TITLE
Feature/bk si r2 protons

### DIFF
--- a/analyzer/rootana/src/LibraryLinkDef.h
+++ b/analyzer/rootana/src/LibraryLinkDef.h
@@ -17,6 +17,8 @@
 #pragma link C++ class TTemplateFitAnalysedPulse+;
 #pragma link C++ class TAnalysedPulse+;
 #pragma link C++ class TDetectorPulse+;
+#pragma link C++ class TSiliconEvent+;
+#pragma link C++ class TMuonEvent+;
 #pragma link C++ class vector<TAnalysedPulse*>+;
 #pragma link C++ class vector<TAnalysedPulse*>::iterator;
 #pragma link C++ function operator!= (vector<TAnalysedPulse*>::iterator, vector<TAnalysedPulse*>::iterator);

--- a/analyzer/rootana/src/TDP_generators/MakeDetectorPulses.cpp
+++ b/analyzer/rootana/src/TDP_generators/MakeDetectorPulses.cpp
@@ -80,6 +80,7 @@ int MakeDetectorPulses::BeforeFirstEntry(TGlobalData* gData, const TSetupData* s
             bool success=ParseGeneratorList(i_source->first, partner,fPassThruName);
             if(! success) return 1;
         } else {
+           // Else we use the default pairing algorithm
             bool success=ParseGeneratorList(i_source->first, partner,fDefaultAlgorithm);
             if(! success) return 1;
         }
@@ -207,11 +208,13 @@ TVDetectorPulseGenerator* MakeDetectorPulses::MakeGenerator(const IDs::source& c
 
     if(ch.isFast()) {
         // fast channels go first
+        generator->SetPulseSources(current_source,partner_source);
         fFastSlowPairs.insert(Detector_t(tdp_source, current_source,partner_source,generator));
     }else{ 
         // slow channels go second
         // if both fast and slow are the same then later there will be
         // nothing to do.
+        generator->SetPulseSources(partner_source,current_source);
         fFastSlowPairs.insert(Detector_t(tdp_source, partner_source,current_source,generator));
     }
 

--- a/analyzer/rootana/src/TDP_generators/PassThroughDPGenerator.cpp
+++ b/analyzer/rootana/src/TDP_generators/PassThroughDPGenerator.cpp
@@ -1,4 +1,5 @@
 #include "TDPGeneratorFactory.h"
+#include "debug_tools.h"
 #include "PassThroughDPGenerator.h"
 #include <iostream>
 using std::cout;
@@ -10,11 +11,13 @@ PassThroughDPGenerator::PassThroughDPGenerator(TDPGeneratorOptions* opts):
     TVDetectorPulseGenerator("PassThrough",opts), fUseFast(opts->GetBool("use_fast",true)){
     // double check that we can use the slow source, ie. for detectors where
     // the fast / slow channel are different
-      if(GetFastSource()==GetSlowSource()) fUseFast=true;
 }
 
 int PassThroughDPGenerator::ProcessPulses( DetectorPulseList& output){
     const AnalysedPulseList* pulses=PulseList(fUseFast);
+    // Major hack to force fill both channels in the produced TDP which makes
+    // later analysis easier
+    SetPulseLists(pulses,pulses);
     for(AnalysedPulseList::const_iterator i_pulse=pulses->begin();
             i_pulse!=pulses->end(); i_pulse++){
         TDetectorPulse* det_pulse = MakeTDP(i_pulse-pulses->begin(),i_pulse-pulses->begin()); // Create the TDetectorPulse

--- a/analyzer/rootana/src/TDP_generators/PassThroughDPGenerator.cpp
+++ b/analyzer/rootana/src/TDP_generators/PassThroughDPGenerator.cpp
@@ -17,7 +17,7 @@ int PassThroughDPGenerator::ProcessPulses( DetectorPulseList& output){
     const AnalysedPulseList* pulses=PulseList(fUseFast);
     for(AnalysedPulseList::const_iterator i_pulse=pulses->begin();
             i_pulse!=pulses->end(); i_pulse++){
-        TDetectorPulse* det_pulse = MakeTDP(i_pulse-pulses->begin(), -1); // Create the TDetectorPulse
+        TDetectorPulse* det_pulse = MakeTDP(i_pulse-pulses->begin(),i_pulse-pulses->begin()); // Create the TDetectorPulse
         output.push_back(det_pulse);
     }
     return 0;

--- a/analyzer/rootana/src/TME_generators/ActiveSiRMuStopAlgo.cpp
+++ b/analyzer/rootana/src/TME_generators/ActiveSiRMuStopAlgo.cpp
@@ -1,0 +1,24 @@
+#include "ActiveSiRMuStopAlgo.h"
+#include "IdSource.h"
+#include "TMuonEvent.h"
+
+TMEAlgorithm::ActiveSiRStop::ActiveSiRStop(const IDs::source& sir2, double muSc_min, double muSc_max, double SiR2_min, double SiR2_max):
+     fMuScMax(muSc_max),fMuScMin(muSc_min),  fSiR2Max(SiR2_max),fSiR2Min(SiR2_min),fSiR2source(sir2){
+}
+
+
+bool TMEAlgorithm::ActiveSiRStop::operator()(const TMuonEvent* tme, TDetectorPulse::ParentChannel_t channel)const{
+  const double muSc_amp=tme->GetCentralMuon()->GetAmplitude(TDetectorPulse::kFast);
+  bool ret_val=false;
+  if(muSc_amp>fMuScMin && muSc_amp< fMuScMax){
+    const int N_sir2=tme->NumPulses(fSiR2source);
+    for(int i=0; i< N_sir2; ++i){
+      const double sir2_amp=tme->GetPulse(fSiR2source,i)->GetAmplitude(channel);
+      if(sir2_amp > fSiR2Min && sir2_amp < fSiR2Max){
+         ret_val=true;
+         break;
+      }
+    }
+  }
+  return ret_val;
+}

--- a/analyzer/rootana/src/TME_generators/ActiveSiRMuStopAlgo.h
+++ b/analyzer/rootana/src/TME_generators/ActiveSiRMuStopAlgo.h
@@ -13,6 +13,7 @@ class TMEAlgorithm::ActiveSiRStop{
     public:
      ActiveSiRStop(const IDs::source& sir2, double muSc_min, double muSc_max, double SiR2_min, double SiR2_max);
 
+     void SetSiR2Source(const IDs::source so){fSiR2source=so;}
      bool operator()(const TMuonEvent* tme, TDetectorPulse::ParentChannel_t)const;
 
      private:

--- a/analyzer/rootana/src/TME_generators/ActiveSiRMuStopAlgo.h
+++ b/analyzer/rootana/src/TME_generators/ActiveSiRMuStopAlgo.h
@@ -1,0 +1,24 @@
+#ifndef TME_GENERATORS_ACTIVESIRMUSTOPALGO_H
+#define TME_GENERATORS_ACTIVESIRMUSTOPALGO_H
+
+class TMuonEvent;
+namespace IDs{class source;}
+#include "TDetectorPulse.h"
+
+namespace TMEAlgorithm{
+    class ActiveSiRStop;
+}
+
+class TMEAlgorithm::ActiveSiRStop{
+    public:
+     ActiveSiRStop(const IDs::source& sir2, double muSc_min, double muSc_max, double SiR2_min, double SiR2_max);
+
+     bool operator()(const TMuonEvent* tme, TDetectorPulse::ParentChannel_t)const;
+
+     private:
+     double fMuScMax, fMuScMin, fSiR2Max, fSiR2Min;
+     IDs::source fSiR2source;
+     
+};
+
+#endif // TME_GENERATORS_ACTIVESIRMUSTOPALGO_H

--- a/analyzer/rootana/src/TME_generators/MakeSiliconEvents.cpp
+++ b/analyzer/rootana/src/TME_generators/MakeSiliconEvents.cpp
@@ -4,23 +4,65 @@
 #include "TSetupData.h"
 #include "ModulesOptions.h"
 #include "definitions.h"
+#include "TSiliconEvent.h"
+#include "TMuonEvent.h"
 
 #include <iostream>
 using std::cout;
 using std::endl;
 
+extern SourceDetPulseMap gDetectorPulseMap;
+extern MuonEventList gMuonEvents;
+
 MakeSiliconEvents::MakeSiliconEvents(modules::options* opts):
-   BaseModule("MakeSiliconEvents",opts){
+   BaseModule("MakeSiliconEvents",opts,false),
+  fSiWindow(opts->GetDouble("si_window",100)){
 }
 
 MakeSiliconEvents::~MakeSiliconEvents(){
 }
 
 int MakeSiliconEvents::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
+  // Get all the sources for the silicon channels
+  for(int i=0;i<LR::kNum;i++){
+     for(int ch=0;ch<Ch::kNum;ch++){
+        fSourceList[i][ch]=GetTDPSource(Form("Si%s%s",LR::str(i),Ch::str(ch)));
+     }
+  }
   return 0;
 }
 
 int MakeSiliconEvents::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+  
+  // loop over each TME
+  TSiliconEvent si_hit;
+  for(MuonEventList::iterator i_tme=gMuonEvents.begin();
+          i_tme!=gMuonEvents.end(); ++i_tme){
+    TMuonEvent* tme=*i_tme;
+    // loop over both Si packages
+    for(int i_side=0;i_side <2; ++i_side){
+       // Loop over the thick silicon
+       for(DetectorPulseList::const_iterator i_Si2=tme->BeginPulses(fSourceList[i_side][Ch::k2]);
+             i_Si2!=tme->EndPulses(fSourceList[i_side][Ch::k2]); ++i_Si2){
+           si_hit.Reset();
+           double thick_time=(*i_Si2)->GetTime();
+           double E_thick=(*i_Si2)->GetEnergy(TDetectorPulse::kSlow);
+           si_hit.SetThick(E_thick,thick_time);
+           for(int i=0; i<4;++i){
+              for(DetectorPulseList::const_iterator i_thin=tme->BeginPulses(fSourceList[i_side][i]);
+             i_thin!=tme->EndPulses(fSourceList[i_side][i]); ++i_thin){
+                 const TDetectorPulse* pulse=*i_thin;
+                 if(!pulse->IsGood())continue;
+                 double time=pulse->GetTime(TDetectorPulse::kFast);
+                 if( time > thick_time +fSiWindow) break;
+                 if( time < thick_time -fSiWindow) continue;
+                 si_hit.AddThin(i+1,pulse->GetEnergy(TDetectorPulse::kSlow));
+              }
+           }
+           tme->InsertSiliconEvent((TMuonEvent::LeftRight_t) i_side,si_hit);
+       }
+    } // loop over both Si packages
+  } // loop over each TME
   return 0;
 }
 
@@ -28,4 +70,38 @@ int MakeSiliconEvents::AfterLastEntry(TGlobalData* gData,const TSetupData *setup
   return 0;
 }
 
-ALCAP_REGISTER_MODULE(MakeSiliconEvents);
+const IDs::source& MakeSiliconEvents::GetTDPSource(const std::string& ch ){
+    IDs::channel chan(ch);
+    SourceDetPulseMap::const_iterator i_so=gDetectorPulseMap.begin();
+    while(i_so!=gDetectorPulseMap.end() && !(i_so->first==chan)) ++i_so;
+    if(i_so==gDetectorPulseMap.end()){
+        static IDs::source invalid(IDs::kErrorDetector, IDs::kErrorSlowFast, "","");
+        return invalid;
+    }
+    return i_so->first;
+}
+
+const char* Ch::str(Ch::Type e){
+    switch(e){
+        case Ch::k1_1          : return "1_1";
+        case Ch::k1_2          : return "1_2";
+        case Ch::k1_3          : return "1_3";
+        case Ch::k1_4          : return "1_4";
+        case Ch::k2            : return "2";
+        case Ch::kNum : return "NumThinThick";
+    }
+    return "-------";
+}
+
+const char* LR::str(LR::Type e, bool big){
+    switch(e){
+        case LR::kLeft:  return big?"Left":"L";
+        case LR::kRight: return big?"Right":"R";
+        case LR::kNum:   return "NumLR";
+    }
+    return "-------";
+}
+
+
+
+ALCAP_REGISTER_MODULE(MakeSiliconEvents, si_window);

--- a/analyzer/rootana/src/TME_generators/MakeSiliconEvents.cpp
+++ b/analyzer/rootana/src/TME_generators/MakeSiliconEvents.cpp
@@ -1,0 +1,31 @@
+#include "MakeSiliconEvents.h"
+#include "RegisterModule.inc"
+#include "TGlobalData.h"
+#include "TSetupData.h"
+#include "ModulesOptions.h"
+#include "definitions.h"
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+MakeSiliconEvents::MakeSiliconEvents(modules::options* opts):
+   BaseModule("MakeSiliconEvents",opts){
+}
+
+MakeSiliconEvents::~MakeSiliconEvents(){
+}
+
+int MakeSiliconEvents::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
+  return 0;
+}
+
+int MakeSiliconEvents::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+  return 0;
+}
+
+int MakeSiliconEvents::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
+  return 0;
+}
+
+ALCAP_REGISTER_MODULE(MakeSiliconEvents);

--- a/analyzer/rootana/src/TME_generators/MakeSiliconEvents.h
+++ b/analyzer/rootana/src/TME_generators/MakeSiliconEvents.h
@@ -1,0 +1,42 @@
+#ifndef MAKESILICONEVENTS_H_
+#define MAKESILICONEVENTS_H_
+
+#include "BaseModule.h"
+class TGlobalData;
+class TSetupData;
+namespace modules {class options;}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \ingroup rootana_modules
+/// \author AuthorName
+///
+/// \brief
+/// A one line description of what your module does.
+///
+/// \details
+/// A longer, more descriptive block of text.
+/// Specifics like members and methods will be described later.
+/// You can add this to other groups instead of rootana_modules or in addition
+/// to rootana_modules by adding more of the ingroup tags.
+////////////////////////////////////////////////////////////////////////////////
+class MakeSiliconEvents : public BaseModule {
+
+ public:
+  /// \brief
+  /// Constructor description. If necessary, add a details tag like above.
+  ///
+  /// \param[in] opts Describe the options this module takes.
+  MakeSiliconEvents(modules::options* opts);
+  /// \brief
+  /// Is anything done in the destructor?
+  ~MakeSiliconEvents();
+
+ private:
+  virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
+  virtual int BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup);
+  virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
+
+  int fXMax;
+};
+
+#endif //MAKESILICONEVENTS_H_

--- a/analyzer/rootana/src/TME_generators/MakeSiliconEvents.h
+++ b/analyzer/rootana/src/TME_generators/MakeSiliconEvents.h
@@ -2,9 +2,23 @@
 #define MAKESILICONEVENTS_H_
 
 #include "BaseModule.h"
+#include "IdSource.h"
 class TGlobalData;
 class TSetupData;
 namespace modules {class options;}
+
+namespace{
+namespace LR{
+    enum Type{kLeft=0, kRight, kNum};
+    const char* str(Type,bool big=false);
+    const char* str(int e,bool big=false){return str((Type)e, big);}
+}
+namespace Ch{
+    enum Type{k1_1=0, k1_2, k1_3, k1_4, k2, kNum};
+    const char* str(Type);
+    const char* str(int e){return str((Type)e);}
+}
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \ingroup rootana_modules
@@ -32,11 +46,15 @@ class MakeSiliconEvents : public BaseModule {
   ~MakeSiliconEvents();
 
  private:
+  const IDs::source& GetTDPSource(const std::string& ch );
+
+ private:
   virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
   virtual int BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup);
   virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
 
-  int fXMax;
+  IDs::source fSourceList[LR::kNum][Ch::kNum];
+  double fSiWindow;
 };
 
 #endif //MAKESILICONEVENTS_H_

--- a/analyzer/rootana/src/TME_generators/TMuonEvent.cpp
+++ b/analyzer/rootana/src/TME_generators/TMuonEvent.cpp
@@ -118,8 +118,10 @@ bool TMuonEvent::WasLateInEvent(double event_length, double event_uncertainty)co
 }
 
 DetectorPulseList::const_iterator TMuonEvent::BeginPulses(const IDs::source& detector)const{
-    return alcap::at<Except::InvalidSource>(fPulseLists,detector,detector.str().c_str()).begin();
+    if(NumPulses(detector)==0) return DetectorPulseList::const_iterator();
+    return fPulseLists.at(detector).begin();
 }
 DetectorPulseList::const_iterator TMuonEvent::EndPulses(const IDs::source& detector)const{
-    return alcap::at<Except::InvalidSource>(fPulseLists,detector,detector.str().c_str()).end();
+    if(NumPulses(detector)==0) return DetectorPulseList::const_iterator();
+    return fPulseLists.at(detector).end();
 }

--- a/analyzer/rootana/src/TME_generators/TMuonEvent.h
+++ b/analyzer/rootana/src/TME_generators/TMuonEvent.h
@@ -102,6 +102,7 @@ class TMuonEvent{
 
         /// Get the time of this TME defined as the arrival time of the central muon
         double GetTime()const {return fCentralMuon->GetTime(TDetectorPulse::kFast);}
+        double GetAmplitude()const {return fCentralMuon->GetAmplitude(TDetectorPulse::kFast);}
         const TDetectorPulse* GetCentralMuon()const {return fCentralMuon;}
 
         void InsertSiliconEvent(LeftRight_t lr, const TSiliconEvent& si_evt){
@@ -109,6 +110,7 @@ class TMuonEvent{
         }
         SiliconHitList::const_iterator BeginSiEvents(LeftRight_t lr)const{ return fSiliconHits[lr].begin();}
         SiliconHitList::const_iterator EndSiEvents(LeftRight_t lr)const{ return fSiliconHits[lr].end();}
+        int NumSiHits(LeftRight_t lr)const{ return fSiliconHits[lr].size();}
 
     private:
         SourceDetPulseMap fPulseLists;

--- a/analyzer/rootana/src/TME_generators/TMuonEvent.h
+++ b/analyzer/rootana/src/TME_generators/TMuonEvent.h
@@ -6,6 +6,7 @@
 #include "TSiliconEvent.h"
 #include <set>
 #include <vector>
+#include <TObject.h>
 
 /// @brief Single event in the muon centred tree
 /// @author Ben Krikler
@@ -19,7 +20,7 @@
 /// @TODO Implement early / late TME flags
 ///
 /// @see www.github.com/alcap-org/AlcapDAQ/issues/110
-class TMuonEvent{
+class TMuonEvent:public TObject{
     public:
         enum LeftRight_t{kLeft, kRight};
         
@@ -120,5 +121,6 @@ class TMuonEvent{
         typedef std::set<IDs::source> SourceSet;
         SourceSet fExhaustedChannels;
 
+    ClassDef(TMuonEvent, 1);
 };
 #endif // TMuonEvent_hh_

--- a/analyzer/rootana/src/TME_generators/TMuonEvent.h
+++ b/analyzer/rootana/src/TME_generators/TMuonEvent.h
@@ -3,6 +3,7 @@
 
 #include "definitions.h"
 #include "TDetectorPulse.h"
+#include "TSiliconEvent.h"
 #include <set>
 #include <vector>
 
@@ -20,6 +21,8 @@
 /// @see www.github.com/alcap-org/AlcapDAQ/issues/110
 class TMuonEvent{
     public:
+        enum LeftRight_t{kLeft, kRight};
+        
         /// @brief Construct a TMuonEvent with a known central muon
         TMuonEvent(const TDetectorPulse* central_mu, double window):
             fCentralMuon(central_mu),fWindowWidth(window) {};
@@ -101,11 +104,19 @@ class TMuonEvent{
         double GetTime()const {return fCentralMuon->GetTime(TDetectorPulse::kFast);}
         const TDetectorPulse* GetCentralMuon()const {return fCentralMuon;}
 
+        void InsertSiliconEvent(LeftRight_t lr, const TSiliconEvent& si_evt){
+           fSiliconHits[lr].push_back(si_evt); 
+        }
+        SiliconHitList::const_iterator BeginSiEvents(LeftRight_t lr)const{ return fSiliconHits[lr].begin();}
+        SiliconHitList::const_iterator EndSiEvents(LeftRight_t lr)const{ return fSiliconHits[lr].end();}
+
     private:
-            SourceDetPulseMap fPulseLists;
-            const TDetectorPulse* fCentralMuon;
-            double fWindowWidth;
-            typedef std::set<IDs::source> SourceSet;
-            SourceSet fExhaustedChannels;
+        SourceDetPulseMap fPulseLists;
+        SiliconHitList fSiliconHits[2];
+        const TDetectorPulse* fCentralMuon;
+        double fWindowWidth;
+        typedef std::set<IDs::source> SourceSet;
+        SourceSet fExhaustedChannels;
+
 };
 #endif // TMuonEvent_hh_

--- a/analyzer/rootana/src/TME_generators/TSiliconEvent.h
+++ b/analyzer/rootana/src/TME_generators/TSiliconEvent.h
@@ -6,30 +6,36 @@
 class TSiliconEvent{
 
    public:
-     TSiliconEvent()fNThinHits(0),fDeltaE(0),fTotalE(0){};
+     TSiliconEvent():fNThinHits(0),fDeltaE(0),fTotalE(0){};
      ~TSiliconEvent(){};
 
-     void Reset(const char =""){ 
+     void Reset(const char* o=""){ 
        fDeltaE=0;
        fNThinHits=0;
        fTotalE=0;
+       fLastQuad=0;
      } 
 
-     void SetThick(double e){ fTotalE=e;} 
-     void AddThin(double e){
+     void SetThick(double e, double t){ fTotalE=e; fThickTime=t;} 
+     void AddThin(int quad, double e){
         ++fNThinHits;
+        fLastQuad=quad;
         fDeltaE+=e;
         fTotalE+=e;
      }
 
      int GetNThinHits()const{return fNThinHits;}
+     int GetLastQuad()const{return fLastQuad;}
      double GetDeltaE()const{return fDeltaE;}
      double GetTotalE()const{return fTotalE;}
+     double GetThickTime()const{return fThickTime;}
 
    private:
      int fNThinHits;
+     int fLastQuad;
      double fDeltaE;
      double fTotalE;
+     double fThickTime;
 
 };
 

--- a/analyzer/rootana/src/TME_generators/TSiliconEvent.h
+++ b/analyzer/rootana/src/TME_generators/TSiliconEvent.h
@@ -2,8 +2,9 @@
 #define TME_GENERATORS_TSILICONEVENT_H
 
 #include <vector>
+#include "TObject.h"
 
-class TSiliconEvent{
+class TSiliconEvent:public TObject{
 
    public:
      TSiliconEvent():fNThinHits(0),fDeltaE(0),fTotalE(0){};
@@ -36,6 +37,8 @@ class TSiliconEvent{
      double fDeltaE;
      double fTotalE;
      double fThickTime;
+
+   ClassDef(TSiliconEvent,1);
 
 };
 

--- a/analyzer/rootana/src/TME_generators/TSiliconEvent.h
+++ b/analyzer/rootana/src/TME_generators/TSiliconEvent.h
@@ -1,0 +1,38 @@
+#ifndef TME_GENERATORS_TSILICONEVENT_H
+#define TME_GENERATORS_TSILICONEVENT_H
+
+#include <vector>
+
+class TSiliconEvent{
+
+   public:
+     TSiliconEvent()fNThinHits(0),fDeltaE(0),fTotalE(0){};
+     ~TSiliconEvent(){};
+
+     void Reset(const char =""){ 
+       fDeltaE=0;
+       fNThinHits=0;
+       fTotalE=0;
+     } 
+
+     void SetThick(double e){ fTotalE=e;} 
+     void AddThin(double e){
+        ++fNThinHits;
+        fDeltaE+=e;
+        fTotalE+=e;
+     }
+
+     int GetNThinHits()const{return fNThinHits;}
+     double GetDeltaE()const{return fDeltaE;}
+     double GetTotalE()const{return fTotalE;}
+
+   private:
+     int fNThinHits;
+     double fDeltaE;
+     double fTotalE;
+
+};
+
+typedef std::vector<TSiliconEvent> SiliconHitList;
+
+#endif // TME_GENERATORS_TSILICONEVENT_H

--- a/analyzer/rootana/src/files.make
+++ b/analyzer/rootana/src/files.make
@@ -26,3 +26,5 @@ ROOT_DICT_CLASSES:=TAnalysedPulseMapWrapper\
         BankBranch\
         FlyWeight\
         TTemplate\
+        TSiliconEvent\
+        TMuonEvent

--- a/analyzer/rootana/src/framework/IdChannel.h
+++ b/analyzer/rootana/src/framework/IdChannel.h
@@ -129,10 +129,10 @@ public:
   /// Check if this channel ID is for a slow channel
   bool isSlow() const {return fSlowFast==kSlow;};
 
-    /// If this is a fast channel return the corresponding slow one
-    /// else if it's a slow channel return the corresponding fast one
-    /// else return the same ID
-    channel GetCorrespondingFastSlow()const;
+  /// If this is a fast channel return the corresponding slow one
+  /// else if it's a slow channel return the corresponding fast one
+  /// else return the same ID
+  channel GetCorrespondingFastSlow()const;
 
   /// Convert a Detector_t enum into the corresponding string
   static std::string GetDetectorString(Detector_t det);

--- a/analyzer/rootana/src/framework/IdSource.cpp
+++ b/analyzer/rootana/src/framework/IdSource.cpp
@@ -1,10 +1,13 @@
 #include "IdSource.h"
 #include <iostream>
 #include "debug_tools.h"
+#include "ModulesParser.h"
 ClassImp(IDs::source);
 
-std::string IDs::source::str()const{
-	return fChannel.str() + IDs::field_separator +fGenerator.str();
+std::string IDs::source::str(bool cpp_safe)const{
+	std::string tmp= fChannel.str() + IDs::field_separator +fGenerator.str();
+        if(cpp_safe) modules::parser::ToCppValid(tmp);
+        return tmp;
 }
 
 ostream& operator<< (ostream& os ,const IDs::source& id) {

--- a/analyzer/rootana/src/framework/IdSource.h
+++ b/analyzer/rootana/src/framework/IdSource.h
@@ -96,7 +96,7 @@ class IDs::source:public TObject{
   const channel& Channel()const{return fChannel;};
 
   /// Returns the source as a string
-  std::string str()const;
+  std::string str(bool cpp_valid=false)const;
 
   IDs::source& operator=(const std::string& rhs);
 

--- a/analyzer/rootana/src/framework/SetupNavigator.cpp
+++ b/analyzer/rootana/src/framework/SetupNavigator.cpp
@@ -138,6 +138,7 @@ bool SetupNavigator::ReadPedestalAndNoiseValues() {
 bool SetupNavigator::ReadCoarseTimeOffsetValues() {
   // The values that we will read in
   const std::vector<std::string> table = GetCoarseTimeOffsetColumns();
+for(unsigned i=0;i<table.size();++i) DEBUG_VALUE(i, table[i]);
 
   std::stringstream query;
   query << "SELECT channel";
@@ -258,3 +259,12 @@ double SetupNavigator::GetPedestal(const IDs::channel& channel) const {
 SetupNavigator::EnergyCalibRow_t SetupNavigator::GetEnergyCalibrationConstants(const IDs::channel& ch) const {
   return alcap::at<Except::InvalidDetector>(fEnergyCalibrationConstants, ch, ch.str().c_str());
 }
+double SetupNavigator::GetCoarseTimeOffset( IDs::source source) const {
+// Massive hack to remove config strings that specify other options.  Assumes
+// the timing option is placed first for the generator
+ std::string conf=source.Generator().Config();
+ unsigned curly_br=conf.find('}');
+if(curly_br!=std::string::npos){ source.Generator().Config(conf.substr(0,curly_br+1));}
+ 
+ return source.matches(IDs::channel("muSc")) ? 0. : alcap::at<Except::InvalidDetector>(fCoarseTimeOffset,source,source.str().c_str());
+ }

--- a/analyzer/rootana/src/framework/SetupNavigator.h
+++ b/analyzer/rootana/src/framework/SetupNavigator.h
@@ -45,7 +45,7 @@ class SetupNavigator{
   /// \brief
   /// Gets the error on the pedestal from the SQLite database
   double GetNoise(const IDs::channel& channel) const ;
-  double GetCoarseTimeOffset(const IDs::source& src) const { return src.matches(IDs::channel("muSc")) ? 0. : fCoarseTimeOffset.at(src); }
+  double GetCoarseTimeOffset( IDs::source src) const ;
   /// \brief
   /// Gets the energy calibration constants
   std::pair<double,double> GetEnergyCalibrationConstants(const IDs::channel&) const;

--- a/analyzer/rootana/src/physics/PlotTME_EvdE.cpp
+++ b/analyzer/rootana/src/physics/PlotTME_EvdE.cpp
@@ -6,70 +6,97 @@
 #include "ModulesOptions.h"
 #include "definitions.h"
 #include "debug_tools.h"
+#include "ModulesNavigator.h"
 
 #include <iostream>
 #include <algorithm>
 using std::cout;
 using std::endl;
 
+extern SourceDetPulseMap gDetectorPulseMap;
 extern MuonEventList gMuonEvents;
 
 PlotTME_EvdE::PlotTME_EvdE(modules::options* opts):
    BaseModule("PlotTME_EvdE",opts),
    fMinTime(opts->GetDouble("min_time",500)),
    fMuScMax(opts->GetDouble("muSc_max",1e9)),
-   fMuScMin(opts->GetDouble("muSc_min",0)){
+   fMuScMin(opts->GetDouble("muSc_min",0)),
+   fActiveStops(IDs::source(),fMuScMin,fMuScMax,opts->GetDouble("SiR2_min",0),opts->GetDouble("SiR2_max",1e9)){
 }
 
 PlotTME_EvdE::~PlotTME_EvdE(){
 }
 
 int PlotTME_EvdE::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
-    const char* titles[kNHists]={ "Muon Pile-up allowed",
-                                  "Muon Pile-up protection",
-                                  "Muon amp. cut and pile-up protection",
-                                  Form("#mu PP, #mu amp. cut and time in thick > %gns",fMinTime)
-                                };
-    const char* names[kNHists]={"","_mu_PP",  "_mu_PP_mu_amp","_mu_PP_mu_amp_t_cut"};
 
-std::vector<double> t_bins;
-while(true){
-double t=1;
-for(; t<100; t+=10) t_bins.push_back(t);
-for(; t<500; t+=20) t_bins.push_back(t);
-for(; t<1000; t+=100) t_bins.push_back(t);
-for(; t<10000; t+=1000) t_bins.push_back(t);
-break;
-}
-for(unsigned i=0;i<t_bins.size();i++) cout<<i<<": "<<t_bins[i]<<endl;
+    // Make sure we've got MakeSiliconEvents being used
+    if(!modules::navigator::Instance()->Before("MakeSiliconEvents","PlotTME_EvdE")){
+        cout<<"It's meaningless to use the PlotTME_EvdE module without the MakeSiliconEvents module running first as well"<<endl;
+        return 1;
+    }
+
+    // Find the SiR2 TDP generator
+    IDs::source tmp(IDs::kSiR2, IDs::kAnySlowFast, IDs::kAnyGenerator, IDs::kAnyConfig);
+    for(SourceDetPulseMap::iterator i_source=gDetectorPulseMap.begin();
+            i_source!= gDetectorPulseMap.end(); ++i_source){
+        if(i_source->first.matches(tmp)){
+            tmp=i_source->first;
+            break;
+        }
+    }
+    fActiveStops.SetSiR2Source(tmp);
+
+    std::string titles[kNHists];
+    titles[kNoCuts]         = "Muon Pile-up allowed";
+    titles[kMuPP]           = "Muon Pile-up protection";
+    titles[kMuPP_muAmp]     = "Muon amp. cut and pile-up protection";
+    titles[kMuPP_muAmp_T500]= Form("#mu PP, #mu amp. cut and time in thick > %gns",fMinTime);
+    titles[kActiveStop]     = "All cuts including active Si hit";
+
+    std::string names[kNHists];
+    names[kNoCuts]         ="";
+    names[kMuPP]           ="_mu_PP";
+    names[kMuPP_muAmp]     ="_mu_PP_mu_amp";
+    names[kMuPP_muAmp_T500]="_mu_PP_mu_amp_t_cut";
+    names[kActiveStop]     ="_active_stop";
+
+    std::vector<double> t_bins;
+    while(true){
+    double total=1e4;
+    double tstep=total/16.;
+    for(double t=0; t<total; t+=tstep) t_bins.push_back(t);
+    break;
+    }
+    //for(unsigned i=0;i<t_bins.size();i++) cout<<i<<": "<<t_bins[i]<<endl;
 
     // for left and right packages
-    for(int i=0;i<2;i++){
+    for(int i=0;i<1;i++){
+    //for(int i=0;i<2;i++){
         TString title_kernel= i==0? "Left" : "Right";
         title_kernel+= " Silicon with ";
         TString name_kernel= i==0? "_L" : "_R";
 
-        int min_dE=0, max_dE=7e3;
-        int min_E=0, max_E=25e3;
+        int min_dE=0, max_dE=8000;
+        int min_E=0, max_E=25000;
         int min_dT=0, max_dT=10000;
         for(int i_hist=0; i_hist< kNHists; ++i_hist){
-           for(int i_quad=0; i_quad< 4; ++i_quad){
+           for(int i_quad=0; i_quad< 5; ++i_quad){
               fHists[i][i_hist][i_quad].EvdE=new TH2F(
-                      Form("hEvdE_%s%s_%d",name_kernel.Data(),names[i_hist],i_quad-1),
-                      Form("E vs dE for %s %s %d",title_kernel.Data(),titles[i_hist],i_quad-1),
+                      Form("hEvdE_%s%s_%d",name_kernel.Data(),names[i_hist].c_str(),i_quad),
+                      Form("E vs dE for %s %s %d",title_kernel.Data(),titles[i_hist].c_str(),i_quad),
                       400,min_E,max_E,400,min_dE,max_dE);
               fHists[i][i_hist][i_quad].EvdE->SetXTitle("Total energy (KeV)");
               fHists[i][i_hist][i_quad].EvdE->SetYTitle("dE/dx (KeV)");
 
               fHists[i][i_hist][i_quad].time=new TH1F(
-                      Form("hTime%s%s_%d",name_kernel.Data(),names[i_hist],i_quad-1),
-                      Form("Timing for %s %s %d",title_kernel.Data(),titles[i_hist],i_quad-1),
+                      Form("hTime%s%s_%d",name_kernel.Data(),names[i_hist].c_str(),i_quad),
+                      Form("Timing for %s %s %d",title_kernel.Data(),titles[i_hist].c_str(),i_quad),
                       600,min_dT,max_dT);
               fHists[i][i_hist][i_quad].time->SetXTitle("Time (ns)");
 
               fHists[i][i_hist][i_quad].EvdEvTime=new TH3I(
-                      Form("hEvdEvTime%s%s_%d",name_kernel.Data(),names[i_hist],i_quad-1),
-                      Form("E vs dE vs Timing for %s %s %d",title_kernel.Data(),titles[i_hist],i_quad-1),
+                      Form("hEvdEvTime%s%s_%d",name_kernel.Data(),names[i_hist].c_str(),i_quad),
+                      Form("E vs dE vs Timing for %s %s %d",title_kernel.Data(),titles[i_hist].c_str(),i_quad),
                       100,min_E,max_E,100,min_dE,max_dE,t_bins.size(),min_dT,max_dT);
               fHists[i][i_hist][i_quad].EvdEvTime->GetZaxis()->Set(t_bins.size()-1, t_bins.data());
               fHists[i][i_hist][i_quad].EvdEvTime->SetXTitle("Total energy (KeV)");
@@ -91,7 +118,8 @@ int PlotTME_EvdE::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
         double tme_time=tme->GetTime();
         double tme_amp=tme->GetAmplitude();
         // for each Si packet
-        for(int i_side=0;i_side<2;++i_side){
+        for(int i_side=0;i_side<1;++i_side){
+        //for(int i_side=0;i_side<2;++i_side){
             TMuonEvent::LeftRight_t side=(TMuonEvent::LeftRight_t) i_side;
             const SiliconHitList::const_iterator begin=tme->BeginSiEvents( side);
             const SiliconHitList::const_iterator end=tme->EndSiEvents( side);
@@ -111,6 +139,9 @@ int PlotTME_EvdE::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
                      fHists[i_side][kMuPP_muAmp][quad].Fill(tot_E,del_E,deltaT);
 	             if(deltaT > fMinTime) {
                         fHists[i_side][kMuPP_muAmp_T500][quad].Fill(tot_E,del_E,deltaT);
+                        if(fActiveStops(tme, TDetectorPulse::kFast)) {
+                            fHists[i_side][kActiveStop][quad].Fill(tot_E,del_E,deltaT);
+                        }
 	             }
 	          }
                }
@@ -122,15 +153,20 @@ int PlotTME_EvdE::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
 
 int PlotTME_EvdE::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
   if(Debug()){
-    for(int side=0;side<2;++side){
-      for(int pp=0;pp<3;++pp){
+    for(int side=0;side<1;++side){
+    //for(int side=0;side<2;++side){
+      for(int pp=0;pp<kNHists;++pp){
          for(int quad=0;quad<4;++quad){
+            fHists[side][pp][4].EvdE     ->Add(fHists[side][pp][quad].EvdE);
+            fHists[side][pp][4].time     ->Add(fHists[side][pp][quad].time);
+            fHists[side][pp][4].EvdEvTime->Add(fHists[side][pp][quad].EvdEvTime);
             cout<<"PlotTME_EvdE: "<< fHists[side][pp][quad].EvdE->GetName() <<" has "<<fHists[side][pp][quad].EvdE->GetEntries()<<endl;
           }
+          cout<<"PlotTME_EvdE: "<< fHists[side][pp][4].EvdE->GetName() <<" has "<<fHists[side][pp][4].EvdE->GetEntries()<<endl;
        }
     }
   }
   return 0;
 }
 
-ALCAP_REGISTER_MODULE(PlotTME_EvdE, min_time,muSc_min, muSc_max)
+ALCAP_REGISTER_MODULE(PlotTME_EvdE, min_time,muSc_min, muSc_max,SiR2_min,SiR2_max)

--- a/analyzer/rootana/src/physics/PlotTME_EvdE.cpp
+++ b/analyzer/rootana/src/physics/PlotTME_EvdE.cpp
@@ -7,122 +7,114 @@
 #include "definitions.h"
 #include "debug_tools.h"
 
-#include <TH2F.h>
-#include <TH1F.h>
-
 #include <iostream>
 #include <algorithm>
 using std::cout;
 using std::endl;
 
 extern MuonEventList gMuonEvents;
-extern const SourceDetPulseMap gDetectorPulseMap;
-
-const char* Ch::str(Ch::Type e){
-    switch(e){
-        case Ch::k1_1          : return "1_1";
-        case Ch::k1_2          : return "1_2";
-        case Ch::k1_3          : return "1_3";
-        case Ch::k1_4          : return "1_4";
-        case Ch::k2            : return "2";
-        case Ch::kNum : return "NumThinThick";
-    }
-    return "-------";
-}
-
-const char* LR::str(LR::Type e, bool big){
-    switch(e){
-        case LR::kLeft:  return big?"Left":"L";
-        case LR::kRight: return big?"Right":"R";
-        case LR::kNum:   return "NumLR";
-    }
-    return "-------";
-}
 
 PlotTME_EvdE::PlotTME_EvdE(modules::options* opts):
    BaseModule("PlotTME_EvdE",opts),
-   fSiWindow(opts->GetDouble("si_window",100)){
+   fMinTime(opts->GetDouble("min_time",500)),
+   fMuScMax(opts->GetDouble("muSc_max",1e9)),
+   fMuScMin(opts->GetDouble("muSc_min",0)){
 }
 
 PlotTME_EvdE::~PlotTME_EvdE(){
 }
 
 int PlotTME_EvdE::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
+    const char* titles[kNHists]={ "Muon Pile-up allowed",
+                                  "Muon Pile-up protection",
+                                  "Muon amp. cut and pile-up protection",
+                                  Form("#mu PP, #mu amp. cut and time in thick > %gns",fMinTime)
+                                };
+    const char* names[kNHists]={"","_mu_PP",  "_mu_PP_mu_amp","_mu_PP_mu_amp_t_cut"};
+
+std::vector<double> t_bins;
+while(true){
+double t=1;
+for(; t<100; t+=10) t_bins.push_back(t);
+for(; t<500; t+=20) t_bins.push_back(t);
+for(; t<1000; t+=100) t_bins.push_back(t);
+for(; t<10000; t+=1000) t_bins.push_back(t);
+break;
+}
+for(unsigned i=0;i<t_bins.size();i++) cout<<i<<": "<<t_bins[i]<<endl;
 
     // for left and right packages
-    for(int i=0;i<LR::kNum;i++){
-        // Get the source IDs for all necessary channels
-        for(int ch=0;ch<Ch::kNum;ch++){
-            fSourceList[i].sources[ch]=GetTDPSource(Form("Si%s%s",LR::str(i),Ch::str(ch)));
-        }
+    for(int i=0;i<2;i++){
+        TString title_kernel= i==0? "Left" : "Right";
+        title_kernel+= " Silicon with ";
+        TString name_kernel= i==0? "_L" : "_R";
 
-        /******** Create all plots ********/
-        // E vs dE without muon pile-up
-        fSourceList[i].E_vs_dE_no_pileUp=new TH2F(
-                Form("hE_vs_dE_no_pileUp_%s",LR::str(i,1)),
-                Form("Pile-up protected E vs dE for Si%s",LR::str(i)),
-                400,0,8000,400,0,8000);
-        fSourceList[i].E_vs_dE_no_pileUp->SetXTitle("Amplitude");
-        fSourceList[i].E_vs_dE_no_pileUp->SetYTitle("Amplitude");
+        int min_dE=0, max_dE=7e3;
+        int min_E=0, max_E=25e3;
+        int min_dT=0, max_dT=10000;
+        for(int i_hist=0; i_hist< kNHists; ++i_hist){
+           for(int i_quad=0; i_quad< 4; ++i_quad){
+              fHists[i][i_hist][i_quad].EvdE=new TH2F(
+                      Form("hEvdE_%s%s_%d",name_kernel.Data(),names[i_hist],i_quad-1),
+                      Form("E vs dE for %s %s %d",title_kernel.Data(),titles[i_hist],i_quad-1),
+                      400,min_E,max_E,400,min_dE,max_dE);
+              fHists[i][i_hist][i_quad].EvdE->SetXTitle("Total energy (KeV)");
+              fHists[i][i_hist][i_quad].EvdE->SetYTitle("dE/dx (KeV)");
 
-        // E vs dE including muon pile-up
-        fSourceList[i].E_vs_dE_with_pileUp=new TH2F(
-                Form("hE_vs_dE_with_pileUp%s",LR::str(i,1)),
-                Form("E vs dE (without pile-up protection) for Si%s",LR::str(i)),
-                400,0,8000,400,0,8000);
-                //400,0,2500,400,0,0.1);
-        fSourceList[i].E_vs_dE_with_pileUp->SetXTitle("E + dE (KeV)");
-        fSourceList[i].E_vs_dE_with_pileUp->SetYTitle("E (keV)");
+              fHists[i][i_hist][i_quad].time=new TH1F(
+                      Form("hTime%s%s_%d",name_kernel.Data(),names[i_hist],i_quad-1),
+                      Form("Timing for %s %s %d",title_kernel.Data(),titles[i_hist],i_quad-1),
+                      600,min_dT,max_dT);
+              fHists[i][i_hist][i_quad].time->SetXTitle("Time (ns)");
+
+              fHists[i][i_hist][i_quad].EvdEvTime=new TH3I(
+                      Form("hEvdEvTime%s%s_%d",name_kernel.Data(),names[i_hist],i_quad-1),
+                      Form("E vs dE vs Timing for %s %s %d",title_kernel.Data(),titles[i_hist],i_quad-1),
+                      100,min_E,max_E,100,min_dE,max_dE,t_bins.size(),min_dT,max_dT);
+              fHists[i][i_hist][i_quad].EvdEvTime->GetZaxis()->Set(t_bins.size()-1, t_bins.data());
+              fHists[i][i_hist][i_quad].EvdEvTime->SetXTitle("Total energy (KeV)");
+              fHists[i][i_hist][i_quad].EvdEvTime->SetYTitle("dE/dx (KeV)");
+              fHists[i][i_hist][i_quad].EvdEvTime->SetZTitle("Time (ns)");
+           }
+       }
     }
 
   return 0;
 }
 
 int PlotTME_EvdE::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
-    DetectorPulseList::const_iterator begin[Ch::kNum];
-    DetectorPulseList::const_iterator end[Ch::kNum];
-    DetectorPulseList::const_iterator i_thin[4];
-
     // for each TME
     for(MuonEventList::const_iterator i_tme=gMuonEvents.begin();
             i_tme!=gMuonEvents.end(); ++i_tme){
+
         const TMuonEvent* tme=*i_tme;
+        double tme_time=tme->GetTime();
+        double tme_amp=tme->GetAmplitude();
         // for each Si packet
-        for(int side=0;side<LR::kNum;++side){
-            // setup limits
-            for(int i_ch=0;i_ch<Ch::kNum;++i_ch){
-                begin[i_ch]=tme->BeginPulses(fSourceList[side].sources[i_ch]);
-                end[i_ch]=tme->EndPulses(fSourceList[side].sources[i_ch]);
-                if(i_ch<4) i_thin[i_ch]=begin[i_ch];
+        for(int i_side=0;i_side<2;++i_side){
+            TMuonEvent::LeftRight_t side=(TMuonEvent::LeftRight_t) i_side;
+            const SiliconHitList::const_iterator begin=tme->BeginSiEvents( side);
+            const SiliconHitList::const_iterator end=tme->EndSiEvents( side);
+            for(SiliconHitList::const_iterator i_SHit=begin; i_SHit!=end; ++i_SHit){
+               const double deltaT=i_SHit->GetThickTime()- tme_time; 
+               const double tot_E=i_SHit->GetTotalE();
+               const double del_E=i_SHit->GetDeltaE();
+               int quad=i_SHit->GetLastQuad()-1;
+	       if(quad<0) continue;
+
+               // Now fill all the histograms
+               fHists[i_side][kNoCuts][quad].Fill(tot_E,del_E,deltaT);
+               if(i_SHit->GetNThinHits()== 0) continue; // don't keep hits with nothing in the thin
+               if(!tme->HasMuonPileup()) {
+                  fHists[i_side][kMuPP][quad].Fill(tot_E,del_E,deltaT);
+	          if( tme_amp > fMuScMin && tme_amp < fMuScMax){
+                     fHists[i_side][kMuPP_muAmp][quad].Fill(tot_E,del_E,deltaT);
+	             if(deltaT > fMinTime) {
+                        fHists[i_side][kMuPP_muAmp_T500][quad].Fill(tot_E,del_E,deltaT);
+	             }
+	          }
+               }
             }
-
-            // For each SiR2 hit
-            for(DetectorPulseList::const_iterator i_Si2=begin[Ch::k2]; i_Si2!=end[Ch::k2]; ++i_Si2){
-                double time_start=(*i_Si2)->GetTime() - fSiWindow;
-                double time_stop=(*i_Si2)->GetTime() + fSiWindow;
-                double E_thick=(*i_Si2)->GetEnergy(TDetectorPulse::kSlow);
-                for(int i=0; i<4;++i) n_thin[i]=0;  // reset the thin pulse counters
-
-                // Add all correlated thin hits together
-                double dE=0;
-                for(int i=0; i<4;++i){
-                    for(;i_thin[i]!=end[i] ; ++i_thin[i]){
-                        const TDetectorPulse* pulse=*i_thin[i];
-                        if(!pulse->IsGood())continue;
-                        double time=pulse->GetTime(TDetectorPulse::kFast);
-                        if( time > time_stop) break;
-                        if( time < time_start) continue;
-                        dE+=pulse->GetEnergy(TDetectorPulse::kSlow);
-                    }
-                }
-
-                // Fill histograms
-                if(!tme->HasMuonPileup()){
-                    fSourceList[side].E_vs_dE_no_pileUp->Fill(E_thick+dE,dE);
-                }
-                fSourceList[side].E_vs_dE_with_pileUp->Fill(E_thick+dE,dE);
-
-            } // each SiR2 hit
         } // each side
     } // each TME
   return 0;
@@ -130,22 +122,15 @@ int PlotTME_EvdE::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
 
 int PlotTME_EvdE::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
   if(Debug()){
-    for(int side=0;side<LR::kNum;++side){
-      cout<<"PlotTME_EvdE: E_vs_dE_no_pileUp "<< LR::str(side) <<" has "<<fSourceList[side].E_vs_dE_no_pileUp->GetEntries()<<endl;
-      cout<<"PlotTME_EvdE: E_vs_dE_with_pileUp "<< LR::str(side) <<" has "<<fSourceList[side].E_vs_dE_with_pileUp->GetEntries()<<endl;
+    for(int side=0;side<2;++side){
+      for(int pp=0;pp<3;++pp){
+         for(int quad=0;quad<4;++quad){
+            cout<<"PlotTME_EvdE: "<< fHists[side][pp][quad].EvdE->GetName() <<" has "<<fHists[side][pp][quad].EvdE->GetEntries()<<endl;
+          }
+       }
     }
   }
   return 0;
 }
 
-const IDs::source& PlotTME_EvdE::GetTDPSource(const std::string& ch ){
-    IDs::channel chan(ch);
-    SourceDetPulseMap::const_iterator i_so=gDetectorPulseMap.begin();
-    while(i_so!=gDetectorPulseMap.end() && !(i_so->first==chan)) ++i_so;
-    if(i_so==gDetectorPulseMap.end()){
-        static IDs::source invalid(IDs::kErrorDetector, IDs::kErrorSlowFast, "","");
-        return invalid;
-    }
-    return i_so->first;
-}
-ALCAP_REGISTER_MODULE(PlotTME_EvdE);
+ALCAP_REGISTER_MODULE(PlotTME_EvdE, min_time,muSc_min, muSc_max)

--- a/analyzer/rootana/src/physics/PlotTME_EvdE.h
+++ b/analyzer/rootana/src/physics/PlotTME_EvdE.h
@@ -6,6 +6,7 @@
 #include <string>
 #include "ActiveSiRMuStopAlgo.h"
 
+#include <TF1.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TH3.h>
@@ -33,9 +34,10 @@ class PlotTME_EvdE : public BaseModule {
         virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
         virtual int BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup);
         virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
+        void FillSiR2Hits(const TMuonEvent* tme,int quad,double deltaE, double totalE, double time);
 
     private:
-        enum Plots{ kNoCuts=0, kActiveStop, kMuPP, kMuPP_muAmp, kMuPP_muAmp_T500, kNHists};
+        enum Plots{ kNoCuts=0, kActiveStop,kProtonBand, kMuPP, kMuPP_muAmp, kMuPP_muAmp_T500, kNHists};
         struct Hists{
            TH2 *EvdE;
            TH1 *time;
@@ -49,6 +51,14 @@ class PlotTME_EvdE : public BaseModule {
         Hists fHists[2][kNHists][5];
         double fMinTime, fMuScMax, fMuScMin;
         TMEAlgorithm::ActiveSiRStop fActiveStops;
+        IDs::source fSiR2Source;
+
+        double fEmissionTimeWidth, fEmissionTimeCentre;
+        TF1 *fHighCut, *fLowCut;
+        TH1 *fSiR2HitsThick[5];
+        TH1 *fSiR2HitsThin[5];
+        TH2 *fSiR2Hits_timeVsE;
+        TH1 *fSiR2Hits_time, *fSiR2Hits_time_zoom;
 };
 
 #endif //PLOTTME_EVDE_H_

--- a/analyzer/rootana/src/physics/PlotTME_EvdE.h
+++ b/analyzer/rootana/src/physics/PlotTME_EvdE.h
@@ -4,6 +4,7 @@
 #include "IdSource.h"
 #include "BaseModule.h"
 #include <string>
+#include "ActiveSiRMuStopAlgo.h"
 
 #include <TH1.h>
 #include <TH2.h>
@@ -34,7 +35,7 @@ class PlotTME_EvdE : public BaseModule {
         virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
 
     private:
-        enum Plots{ kNoCuts=0, kMuPP, kMuPP_muAmp, kMuPP_muAmp_T500, kNHists};
+        enum Plots{ kNoCuts=0, kActiveStop, kMuPP, kMuPP_muAmp, kMuPP_muAmp_T500, kNHists};
         struct Hists{
            TH2 *EvdE;
            TH1 *time;
@@ -45,8 +46,9 @@ class PlotTME_EvdE : public BaseModule {
               EvdEvTime->Fill(totalE,deltaE,deltaT);
            }
         };
-        Hists fHists[2][kNHists][4];
+        Hists fHists[2][kNHists][5];
         double fMinTime, fMuScMax, fMuScMin;
+        TMEAlgorithm::ActiveSiRStop fActiveStops;
 };
 
 #endif //PLOTTME_EVDE_H_

--- a/analyzer/rootana/src/physics/PlotTME_EvdE.h
+++ b/analyzer/rootana/src/physics/PlotTME_EvdE.h
@@ -63,6 +63,7 @@ class PlotTME_EvdE : public BaseModule {
 
     private:
         SourceSet fSourceList[LR::kNum];
+        double fSiWindow;
 };
 
 #endif //PLOTTME_EVDE_H_

--- a/analyzer/rootana/src/physics/PlotTME_EvdE.h
+++ b/analyzer/rootana/src/physics/PlotTME_EvdE.h
@@ -5,24 +5,12 @@
 #include "BaseModule.h"
 #include <string>
 
-class TH2F;
-class TH1F;
+#include <TH1.h>
+#include <TH2.h>
+#include <TH3.h>
 class TGlobalData;
 class TSetupData;
 namespace modules {class options;}
-
-namespace{
-namespace LR{
-    enum Type{kLeft=0, kRight, kNum};
-    const char* str(Type,bool big=false);
-    const char* str(int e,bool big=false){return str((Type)e, big);}
-}
-namespace Ch{
-    enum Type{k1_1=0, k1_2, k1_3, k1_4, k2, kNum};
-    const char* str(Type);
-    const char* str(int e){return str((Type)e);}
-}
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \ingroup rootana_modules
@@ -34,11 +22,6 @@ namespace Ch{
 ///////////////////////////////////////////////////////////////////////////////1
 class PlotTME_EvdE : public BaseModule {
 
-    struct SourceSet{
-        TH2F *E_vs_dE_no_pileUp, *E_vs_dE_with_pileUp;
-        IDs::source sources[Ch::kNum];
-    };
-
     public:
         /// \brief
         /// Constructor 
@@ -46,24 +29,24 @@ class PlotTME_EvdE : public BaseModule {
         ~PlotTME_EvdE();
 
     private:
-        /// \brief
-        /// Fills the EvdE histogram
-        /// \return Non-zero to indicate a problem.
         virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
-        /// \brief
-        /// Set up the histograms and source IDs
-        /// \return Non-zero to indicate a problem.
         virtual int BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup);
-        /// \brief
-        /// \return Non-zero to indicate a problem.
         virtual int AfterLastEntry(TGlobalData* gData,const TSetupData *setup);
 
-        /// @brief Get the source for a given channel in the list of TDP
-        const IDs::source& GetTDPSource(const std::string& ch );
-
     private:
-        SourceSet fSourceList[LR::kNum];
-        double fSiWindow;
+        enum Plots{ kNoCuts=0, kMuPP, kMuPP_muAmp, kMuPP_muAmp_T500, kNHists};
+        struct Hists{
+           TH2 *EvdE;
+           TH1 *time;
+           TH3 *EvdEvTime;
+           void Fill(double totalE, double deltaE, double deltaT){
+              EvdE->Fill(totalE,deltaE);
+              time->Fill(deltaT);
+              EvdEvTime->Fill(totalE,deltaE,deltaT);
+           }
+        };
+        Hists fHists[2][kNHists][4];
+        double fMinTime, fMuScMax, fMuScMin;
 };
 
 #endif //PLOTTME_EVDE_H_

--- a/analyzer/rootana/src/physics/PlotTME_EvdE_ActiveSi.cpp
+++ b/analyzer/rootana/src/physics/PlotTME_EvdE_ActiveSi.cpp
@@ -1,4 +1,4 @@
-#include "PlotTME_EvdE.h"
+#include "PlotTME_EvdE_ActiveSi.h"
 #include "RegisterModule.inc"
 #include "TGlobalData.h"
 #include "TMuonEvent.h"
@@ -17,8 +17,8 @@ using std::endl;
 extern SourceDetPulseMap gDetectorPulseMap;
 extern MuonEventList gMuonEvents;
 
-PlotTME_EvdE::PlotTME_EvdE(modules::options* opts):
-   BaseModule("PlotTME_EvdE",opts),
+PlotTME_EvdE_ActiveSi::PlotTME_EvdE_ActiveSi(modules::options* opts):
+   BaseModule("PlotTME_EvdE_ActiveSi",opts),
    fMinTime(opts->GetDouble("min_time",500)),
    fMuScMax(opts->GetDouble("muSc_max",1e9)),
    fMuScMin(opts->GetDouble("muSc_min",0)),
@@ -30,14 +30,14 @@ PlotTME_EvdE::PlotTME_EvdE(modules::options* opts):
 {
 }
 
-PlotTME_EvdE::~PlotTME_EvdE(){
+PlotTME_EvdE_ActiveSi::~PlotTME_EvdE_ActiveSi(){
 }
 
-int PlotTME_EvdE::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
+int PlotTME_EvdE_ActiveSi::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
 
     // Make sure we've got MakeSiliconEvents being used
-    if(!modules::navigator::Instance()->Before("MakeSiliconEvents","PlotTME_EvdE")){
-        cout<<"It's meaningless to use the PlotTME_EvdE module without the MakeSiliconEvents module running first as well"<<endl;
+    if(!modules::navigator::Instance()->Before("MakeSiliconEvents","PlotTME_EvdE_ActiveSi")){
+        cout<<"It's meaningless to use the PlotTME_EvdE_ActiveSi module without the MakeSiliconEvents module running first as well"<<endl;
         return 1;
     }
 
@@ -70,8 +70,6 @@ int PlotTME_EvdE::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
 
     std::vector<double> t_bins;
     while(true){
-    double total=1e4;
-    double tstep=total/16.;
     for(double t=0; t<1600; t+=200) t_bins.push_back(t);
     for(double t=0; t<4800; t+=400) t_bins.push_back(t);
     break;
@@ -146,7 +144,7 @@ int PlotTME_EvdE::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
   return 0;
 }
 
-int PlotTME_EvdE::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
+int PlotTME_EvdE_ActiveSi::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
     // for each TME
     for(MuonEventList::const_iterator i_tme=gMuonEvents.begin();
             i_tme!=gMuonEvents.end(); ++i_tme){
@@ -195,7 +193,7 @@ int PlotTME_EvdE::ProcessEntry(TGlobalData* gData,const TSetupData *setup){
   return 0;
 }
 
-void PlotTME_EvdE::FillSiR2Hits(const TMuonEvent* tme,int quad, double deltaE, double totalE, double time){
+void PlotTME_EvdE_ActiveSi::FillSiR2Hits(const TMuonEvent* tme,int quad, double deltaE, double totalE, double time){
   // Loop over SiR2 hits
   // If hit is within time window of deltaT then fill amplitude onto SiR2 emission spectrum
 
@@ -213,7 +211,7 @@ void PlotTME_EvdE::FillSiR2Hits(const TMuonEvent* tme,int quad, double deltaE, d
   }
 }
 
-int PlotTME_EvdE::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
+int PlotTME_EvdE_ActiveSi::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
   if(Debug()){
     for(int side=0;side<1;++side){
     //for(int side=0;side<2;++side){
@@ -222,21 +220,21 @@ int PlotTME_EvdE::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
             fHists[side][pp][4].EvdE     ->Add(fHists[side][pp][quad].EvdE);
             fHists[side][pp][4].time     ->Add(fHists[side][pp][quad].time);
             fHists[side][pp][4].EvdEvTime->Add(fHists[side][pp][quad].EvdEvTime);
-            cout<<"PlotTME_EvdE: "<< fHists[side][pp][quad].EvdE->GetName() <<" has "<<fHists[side][pp][quad].EvdE->GetEntries()<<endl;
+            cout<<"PlotTME_EvdE_ActiveSi: "<< fHists[side][pp][quad].EvdE->GetName() <<" has "<<fHists[side][pp][quad].EvdE->GetEntries()<<endl;
           }
-          cout<<"PlotTME_EvdE: "<< fHists[side][pp][4].EvdE->GetName() <<" has "<<fHists[side][pp][4].EvdE->GetEntries()<<endl;
+          cout<<"PlotTME_EvdE_ActiveSi: "<< fHists[side][pp][4].EvdE->GetName() <<" has "<<fHists[side][pp][4].EvdE->GetEntries()<<endl;
        }
     }
     for(int quad=0;quad<4;++quad){
         fSiR2HitsThick[4]->Add(fSiR2HitsThick[quad]);
         fSiR2HitsThin[4]->Add(fSiR2HitsThin[quad]);
-        cout<<"PlotTME_EvdE: "<< fSiR2HitsThick[quad]->GetName() <<" has "<<fSiR2HitsThick[quad]->GetEntries()<<endl;
-        cout<<"PlotTME_EvdE: "<< fSiR2HitsThin[quad]->GetName() <<" has "<<fSiR2HitsThin[quad]->GetEntries()<<endl;
+        cout<<"PlotTME_EvdE_ActiveSi: "<< fSiR2HitsThick[quad]->GetName() <<" has "<<fSiR2HitsThick[quad]->GetEntries()<<endl;
+        cout<<"PlotTME_EvdE_ActiveSi: "<< fSiR2HitsThin[quad]->GetName() <<" has "<<fSiR2HitsThin[quad]->GetEntries()<<endl;
     }
-    cout<<"PlotTME_EvdE: "<< fSiR2HitsThick[4]->GetName() <<" has "<<fSiR2HitsThick[4]->GetEntries()<<endl;
-    cout<<"PlotTME_EvdE: "<< fSiR2HitsThin[4]->GetName() <<" has "<<fSiR2HitsThin[4]->GetEntries()<<endl;
+    cout<<"PlotTME_EvdE_ActiveSi: "<< fSiR2HitsThick[4]->GetName() <<" has "<<fSiR2HitsThick[4]->GetEntries()<<endl;
+    cout<<"PlotTME_EvdE_ActiveSi: "<< fSiR2HitsThin[4]->GetName() <<" has "<<fSiR2HitsThin[4]->GetEntries()<<endl;
   }
   return 0;
 }
 
-ALCAP_REGISTER_MODULE(PlotTME_EvdE, min_time,muSc_min, muSc_max,SiR2_min,SiR2_max)
+ALCAP_REGISTER_MODULE(PlotTME_EvdE_ActiveSi, min_time,muSc_min, muSc_max,SiR2_min,SiR2_max)

--- a/analyzer/rootana/src/physics/PlotTME_EvdE_ActiveSi.h
+++ b/analyzer/rootana/src/physics/PlotTME_EvdE_ActiveSi.h
@@ -1,5 +1,5 @@
-#ifndef PLOTTME_EVDE_H_
-#define PLOTTME_EVDE_H_
+#ifndef PLOTTME_EVDE_ACTIVESI_H_
+#define PLOTTME_EVDE_ACTIVESI_H_
 
 #include "IdSource.h"
 #include "BaseModule.h"
@@ -22,13 +22,13 @@ namespace modules {class options;}
 /// Make the E vs dE plot using TMEs
 ///
 ///////////////////////////////////////////////////////////////////////////////1
-class PlotTME_EvdE : public BaseModule {
+class PlotTME_EvdE_ActiveSi : public BaseModule {
 
     public:
         /// \brief
         /// Constructor 
-        PlotTME_EvdE(modules::options* opts);
-        ~PlotTME_EvdE();
+        PlotTME_EvdE_ActiveSi(modules::options* opts);
+        ~PlotTME_EvdE_ActiveSi();
 
     private:
         virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
@@ -61,4 +61,4 @@ class PlotTME_EvdE : public BaseModule {
         TH1 *fSiR2Hits_time, *fSiR2Hits_time_zoom;
 };
 
-#endif //PLOTTME_EVDE_H_
+#endif //PLOTTME_EVDE_ACTIVESI_H_

--- a/analyzer/rootana/src/plotters/PlotTAP_Energy.cpp
+++ b/analyzer/rootana/src/plotters/PlotTAP_Energy.cpp
@@ -1,0 +1,76 @@
+//#define USE_PRINT_OUT 
+
+#include "PlotTAP_Energy.h"
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <map>
+//#include <utility>
+//#include <algorithm>
+#include <cmath>
+
+#include "TAnalysedPulse.h"
+//#include "TDetectorPulse.h"
+#include "RegisterModule.inc"
+#include "definitions.h"
+#include "SetupNavigator.h"
+//#include "debug_tools.h"
+
+using std::string;
+using std::map;
+using std::vector;
+using std::pair;
+
+extern SourceAnalPulseMap gAnalysedPulseMap;
+
+PlotTAP_Energy::PlotTAP_Energy(modules::options* opts) : 
+    BaseModule("PlotTAP_Energy",opts) {
+    }
+
+PlotTAP_Energy::~PlotTAP_Energy(){  
+}
+
+int PlotTAP_Energy::BeforeFirstEntry(TGlobalData *gData, const TSetupData *gSetup){
+    return 0;
+}
+
+int PlotTAP_Energy::ProcessEntry(TGlobalData *gData, const TSetupData* gSetup){
+
+    // Loop over each TAP list
+    for (SourceAnalPulseMap::const_iterator i_det = gAnalysedPulseMap.begin();
+            i_det != gAnalysedPulseMap.end();
+            i_det++) {
+
+        const std::string& detname = i_det->first.str();
+        std::string keyname = i_det->first.str() + GetName();
+
+        // Create the histogram if it's not been created yet
+        if ( fEnergyPlots.find(keyname) == fEnergyPlots.end() ) {
+
+            // hEnergy
+            std::string histname = "h" + detname + "_Energy";
+            std::stringstream histtitle;
+            histtitle<<"Energy of pulses from source " << i_det->first;
+            histtitle<<" for run "<<SetupNavigator::Instance()->GetRunNumber();
+            int n_bits = gSetup->GetNBits(gSetup->GetBankName(i_det->first.Channel().str()));
+            double max_adc_value = std::pow(2, n_bits);
+            TH1F* hEnergy = new TH1F(histname.c_str(), histtitle.str().c_str(), max_adc_value,0,max_adc_value);
+            hEnergy->GetXaxis()->SetTitle("Energy (KeV)");
+            hEnergy->GetYaxis()->SetTitle("Arbitrary Units");
+            fEnergyPlots[keyname] = hEnergy;
+        }
+
+        const AnalysedPulseList *pulses = &i_det->second;
+        //if(Debug() && pulses->empty()) DEBUG_PREFIX<<" no pulses to fill for "<<i_det->first<<std::endl;
+
+        for (AnalysedPulseList::const_iterator pulseIter = pulses->begin(); pulseIter != pulses->end(); ++pulseIter) {
+            double Energy = (*pulseIter)->GetEnergy();
+            fEnergyPlots[keyname]->Fill(Energy);
+
+        } // end loop through pulses
+
+    } // end loop through detectors
+    return 0;
+}
+
+ALCAP_REGISTER_MODULE(PlotTAP_Energy)

--- a/analyzer/rootana/src/plotters/PlotTAP_Energy.cpp
+++ b/analyzer/rootana/src/plotters/PlotTAP_Energy.cpp
@@ -53,8 +53,14 @@ int PlotTAP_Energy::ProcessEntry(TGlobalData *gData, const TSetupData* gSetup){
             histtitle<<"Energy of pulses from source " << i_det->first;
             histtitle<<" for run "<<SetupNavigator::Instance()->GetRunNumber();
             int n_bits = gSetup->GetNBits(gSetup->GetBankName(i_det->first.Channel().str()));
-            double max_adc_value = std::pow(2, n_bits);
-            TH1F* hEnergy = new TH1F(histname.c_str(), histtitle.str().c_str(), max_adc_value,0,max_adc_value);
+            const double max_adc_value = std::pow(2, n_bits);
+            double gain  = 1;
+            double offset= 0;
+            try{
+               gain  = SetupNavigator::Instance()->GetAdcToEnergyGain(    i_det->first.Channel());
+               offset= SetupNavigator::Instance()->GetAdcToEnergyConstant(i_det->first.Channel());
+            }catch( Except::InvalidDetector& e){};
+            TH1F* hEnergy = new TH1F(histname.c_str(), histtitle.str().c_str(), max_adc_value,0,gain*max_adc_value + offset);
             hEnergy->GetXaxis()->SetTitle("Energy (KeV)");
             hEnergy->GetYaxis()->SetTitle("Arbitrary Units");
             fEnergyPlots[keyname] = hEnergy;

--- a/analyzer/rootana/src/plotters/PlotTAP_Energy.h
+++ b/analyzer/rootana/src/plotters/PlotTAP_Energy.h
@@ -1,0 +1,23 @@
+#ifndef PlotTAP_energy_h__
+#define PlotTAP_energy_h__
+
+#include "BaseModule.h"
+#include "TGlobalData.h"
+#include "TSetupData.h"
+#include "ModulesOptions.h"
+
+class PlotTAP_Energy : public BaseModule{
+ public:
+  PlotTAP_Energy(modules::options* opts);
+  ~PlotTAP_Energy();
+
+ private:
+  virtual int BeforeFirstEntry(TGlobalData *gData, const TSetupData *gSetup);
+  virtual int AfterLastEntry(TGlobalData* gData,const TSetupData* setup){return 0;};
+  virtual int ProcessEntry(TGlobalData *gData, const TSetupData *gSetup);
+
+  std::map<std::string, TH1F*> fEnergyPlots;
+};
+
+#endif
+

--- a/analyzer/rootana/src/plotters/PlotTDP_TDiff.cpp
+++ b/analyzer/rootana/src/plotters/PlotTDP_TDiff.cpp
@@ -15,7 +15,8 @@ using std::endl;
 extern SourceDetPulseMap gDetectorPulseMap;
 
 PlotTDP_TDiff::PlotTDP_TDiff(modules::options* opts):
-   BaseModule("PlotTDP_TDiff",opts){
+   BaseModule("PlotTDP_TDiff",opts),
+  fTimeLow(opts->GetDouble("time_low",-1.e5)), fTimeHigh(opts->GetDouble("time_high",1.e5)){
 
   // Do something with opts here.  Has the user specified any
   // particular configuration that you want to know?
@@ -48,11 +49,7 @@ int PlotTDP_TDiff::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
 
   std::string histogram_name = modules::parser::ToCppValid("h" + fSourceA.str() + "_" + fSourceB.str() + "_TDiff");
   std::string histogram_title = "Time Difference between TDP source " + fSourceA.str() + "_" + fSourceB.str();
-  int x_max = 1000000;
-  int x_min = -1000000;
-  int bin_width = 100;
-  int n_bins = (x_max - x_min) / bin_width;
-  fTDiffPlot = new TH1F(histogram_name.c_str(), histogram_title.c_str(), n_bins, x_min, x_max);
+  fTDiffPlot = new TH1F(histogram_name.c_str(), histogram_title.c_str(), 600, fTimeLow, fTimeLow);
 
   std::string axis_title = "t_{" + detname_a + "} - t_{" + detname_b + "} [ns]";
   fTDiffPlot->GetXaxis()->SetTitle(axis_title.c_str());
@@ -114,4 +111,4 @@ int PlotTDP_TDiff::AfterLastEntry(TGlobalData* gData,const TSetupData *setup){
 // The first argument is compulsory and gives the name of this module
 // All subsequent arguments will be used as names for arguments given directly 
 // within the modules file.  See the github wiki for more.
-ALCAP_REGISTER_MODULE(PlotTDP_TDiff,source_a,source_b);
+ALCAP_REGISTER_MODULE(PlotTDP_TDiff,source_a,source_b, time_low, time_high);

--- a/analyzer/rootana/src/plotters/PlotTDP_TDiff.h
+++ b/analyzer/rootana/src/plotters/PlotTDP_TDiff.h
@@ -60,6 +60,8 @@ class PlotTDP_TDiff : public BaseModule {
   /// The pulse lists for the detector pulses that we want
   DetectorPulseList fDetPulsesA, fDetPulsesB;
 
+double fTimeLow, fTimeHigh;  
+
   /// \brief
   /// The histogram we fill
   TH1F* fTDiffPlot;

--- a/analyzer/rootana/src/plotters/PlotTME_activeSiRmuStops.cpp
+++ b/analyzer/rootana/src/plotters/PlotTME_activeSiRmuStops.cpp
@@ -7,6 +7,7 @@
 #include "TMuonEvent.h"
 #include "debug_tools.h"
 #include "EventNavigator.h"
+#include "ActiveSiRMuStopAlgo.h"
 
 #include <TH1F.h>
 #include <TH2F.h>
@@ -28,12 +29,13 @@ PlotTME_activeSiRmuStops::PlotTME_activeSiRmuStops(modules::options* opts):
    fMuScMin(opts->GetDouble("muSc_min",0)),
    fSiR2Max(opts->GetDouble("SiR2_max",1e9)),
    fSiR2Min(opts->GetDouble("SiR2_min",0)),
-   fHasStoppedMuon(NULL)
+   fHasStoppedMuon(new TMEAlgorithm::ActiveSiRStop(IDs::source(),fMuScMin,fMuScMax,fSiR2Min,fSiR2Max))
 { 
 DEBUG_VALUE(fMuSc, fSiR2,fChannel);
 }
 
 PlotTME_activeSiRmuStops::~PlotTME_activeSiRmuStops(){
+  if(fHasStoppedMuon) delete fHasStoppedMuon;
 }
 
 int PlotTME_activeSiRmuStops::BeforeFirstEntry(TGlobalData* gData,const TSetupData *setup){
@@ -141,6 +143,7 @@ void PlotTME_activeSiRmuStops::FillHistograms(const TMuonEvent* tme, const IDs::
   const int N_sir2=tme->NumPulses(sir2_source);
 
   // Scan for a muon hit in the SiR2
+  fHasStoppedMuon->SetSiR2Source(sir2_source);
   bool a_stop=(*fHasStoppedMuon)(tme,fChannel);
   if(a_stop) {
     ++fNStopsThisEvent;

--- a/analyzer/rootana/src/plotters/PlotTME_activeSiRmuStops.cpp
+++ b/analyzer/rootana/src/plotters/PlotTME_activeSiRmuStops.cpp
@@ -27,8 +27,9 @@ PlotTME_activeSiRmuStops::PlotTME_activeSiRmuStops(modules::options* opts):
    fMuScMax(opts->GetDouble("muSc_max",1e9)),
    fMuScMin(opts->GetDouble("muSc_min",0)),
    fSiR2Max(opts->GetDouble("SiR2_max",1e9)),
-   fSiR2Min(opts->GetDouble("SiR2_min",0))
-{
+   fSiR2Min(opts->GetDouble("SiR2_min",0)),
+   fHasStoppedMuon(NULL)
+{ 
 DEBUG_VALUE(fMuSc, fSiR2,fChannel);
 }
 
@@ -140,19 +141,10 @@ void PlotTME_activeSiRmuStops::FillHistograms(const TMuonEvent* tme, const IDs::
   const int N_sir2=tme->NumPulses(sir2_source);
 
   // Scan for a muon hit in the SiR2
-  bool a_stop=false;
-  if(muSc_amp>fMuScMin && muSc_amp< fMuScMax){
-    for(int i=0; i< N_sir2; ++i){
-      const double sir2_amp=tme->GetPulse(sir2_source,i)->GetAmplitude(fChannel);
-      if(sir2_amp > fSiR2Min && sir2_amp < fSiR2Max){
-         a_stop=true;
-         break;
-      }
-    }
-    if(a_stop) {
-      ++fNStopsThisEvent;
-      if(!tme->HasMuonPileup()) ++fNStopsThisEvent_PP;
-    }
+  bool a_stop=(*fHasStoppedMuon)(tme,fChannel);
+  if(a_stop) {
+    ++fNStopsThisEvent;
+    if(!tme->HasMuonPileup()) ++fNStopsThisEvent_PP;
   }
 
   // Fill all plots for SiR2

--- a/analyzer/rootana/src/plotters/PlotTME_activeSiRmuStops.h
+++ b/analyzer/rootana/src/plotters/PlotTME_activeSiRmuStops.h
@@ -4,6 +4,7 @@
 #include "TDetectorPulse.h"
 #include "BaseModule.h"
 #include "definitions.h"
+#include "ActiveSiRMuStopAlgo.h"
 class TGlobalData;
 class TSetupData;
 namespace modules {class options;}
@@ -68,6 +69,8 @@ class PlotTME_activeSiRmuStops : public BaseModule {
         TDetectorPulse::ParentChannel_t fChannel;
 
         double fMuScMax, fMuScMin, fSiR2Max, fSiR2Min;
+        
+        TMEAlgorithm::ActiveSiRStop* fHasStoppedMuon;
 
         TH1F *fTDiff_PP, *fTDiff, *fTDiffMuons, *fTDiffMuons_PP, *fStopsPerEvent, *fStopsPerEvent_PP, *fStops, *fStops_PP;
         TH2F *fAmplitudes, *fAmplitudes_PP, *fTDiffVsAmpSiR2, *fTDiffVsAmpSiR2_PP, *fTDiffVsAmpSiR2_MuStop, *fTDiffVsAmpSiR2_MuStop_PP;


### PR DESCRIPTION
I'm opening this pull request so I can start a new feature to go back to the template waveform analysis stuff.

I'll try to summarize the changes that could effect others since they're in previously existing or common code:
- To iterate over all pulses on a channel in a TME, the `BeginPulses` and `EndPulses` methods now return default iterators rather than throwing an exception, since it's quite possible a particular channel saw no pulses in a TME, without there being a problem in the calling code or the actual setup.
- A new class called `TSiliconEvent` has been added.  This is the result of the pairing and combining of hits in the Silicon detectors.  Each Silicon event is stored within the muon event that had the hits contained.  A module called `MakeSiliconEvents` was added as well to do the work.  Perhaps that should be merged with `MakeMuonEvents` as an option to run with.  If we don't want this approach on develop then I can remove this class from TMuonEvent.
- Added an optional argument to get a `IDs::source` as a string that is directly c++ valid.  Pass in true to the `str()` method and the returned string will have all bad punctuation characters replaced with underscores.
- The SetupNavigator's `GetCourseTimeOffset` method now removes everything but the first configuration options from the config string before looking in the calibration DB.  This is slightly more robust than the previous method which allowed only a single CFT value to be given, but is still very very hacky and should definitely be improved in the future.

I think that's the bulk of it.  I don't want this taking too much of my time, so I'm going to leave this request up until tomorrow before I merge, unless I hear otherwise.
